### PR TITLE
Emit a backtrace on db_error logs

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -264,6 +264,10 @@ class osTicket {
         if($alert && !$this->getConfig()->alertONSQLError())
             $alert =false;
 
+        $e = new Exception();
+        $bt = str_replace(ROOT_DIR, '(root)/', $e->getTraceAsString());
+        $error .= "\n\n---- Backtrace ----\n".$bt;
+
         return $this->log(LOG_ERR, $title, $error, $alert);
     }
 

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -235,8 +235,15 @@ function db_field_type($res, $col=0) {
 }
 
 function db_prepare($stmt) {
-    global $__db;
-    return $__db->prepare($stmt);
+    global $ost, $__db;
+
+    $res = $__db->prepare($stmt);
+    if (!$res && $ost) {
+        // Include a backtrace in the error email
+        $msg='['.$stmt."]\n\n".db_error();
+        $ost->logDBError('DB Error #'.db_errno(), $msg);
+    }
+    return $res;
 }
 
 function db_connect_error() {


### PR DESCRIPTION
This will help by giving the context of PHP execution along with the DB error. That way developers can know why the database query was executed along with why the statement failed.

This also closes a regression where database errors are not logged from ORM queries
