### PR TITLE
Fix keeping selection value in a selection field

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -708,6 +708,8 @@ class DynamicListItem extends VerySimpleModel {
 }
 
 class SelectionField extends FormField {
+    static $widget = 'SelectionWidget';
+
     function getListId() {
         list(,$list_id) = explode('-', $this->get('type'));
         return $list_id;
@@ -717,10 +719,6 @@ class SelectionField extends FormField {
         if (!$this->_list)
             $this->_list = DynamicList::lookup($this->getListId());
         return $this->_list;
-    }
-
-    function getWidget() {
-        return new SelectionWidget($this);
     }
 
     function parse($value) {


### PR DESCRIPTION
Previously, the value of the selection was lost in the request and, if the form field was marked as required, then a ticket could never be submitted.
