### PR TITLE
Use seemingly-random form input names

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -801,14 +801,15 @@ class SelectionWidget extends ChoicesWidget {
         ?>
         <span style="display:inline-block">
         <input type="text" size="30" name="<?php echo $this->name; ?>"
-            value="<?php echo $name; ?>" autocomplete="off" />
+            id="<?php echo $this->name; ?>" value="<?php echo $name; ?>"
+            autocomplete="off" />
         <script type="text/javascript">
         $(function() {
-            $('input[name=<?php echo $this->name; ?>]').typeahead({
+            $('input#<?php echo $this->name; ?>').typeahead({
                 source: <?php echo JsonDataEncoder::encode($source); ?>,
                 property: 'info',
                 onselect: function(item) {
-                    $('input[name="<?php echo $this->name; ?>"]').val(item['value'])
+                    $('input#<?php echo $this->name; ?>').val(item['value'])
                 }
             });
         });

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -302,7 +302,8 @@ class FormField {
 
     function getFormName() {
         if (is_numeric($this->get('id')))
-            return '-field-id-'.$this->get('id');
+            return substr(md5(
+                session_id() . '-field-id-'.$this->get('id')), -16);
         else
             return $this->get('id');
     }


### PR DESCRIPTION
Which will help fight off spammers. This should be coupled with logic that will add some enticing fields, like 'email' and 'name' to invite bot input. Then, on the form processing side, a spam submission can be detected and handled differently from human submissions. This should lessen reliance on CAPTCHA only as spam detection.
