### PR TITLE
Await draft deletion before refreshing the page

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -98,6 +98,7 @@ RedactorPlugins.draft = {
         var self = this;
         $.ajax('ajax.php/draft/'+this.draft_id, {
             type: 'delete',
+            async: false,
             success: function() {
                 self.opts.autosave = '';
                 self.opts.imageUpload = '';


### PR DESCRIPTION
If the [reset] button refreshes the page, ensure the draft deletion is
completed before the refresh is performed or the draft deletion will be
canceled.
