### PR TITLE
Continue drafts after a reset

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -83,6 +83,7 @@ RedactorPlugins.draft = {
                 self.opts.imageUploadErrorCallback = self.displayError;
             }
         });
+        this.opts.original_autosave = this.opts.autosave;
         this.opts.autosave = 'ajax.php/draft/'+data.draft_id;
     },
 
@@ -95,17 +96,18 @@ RedactorPlugins.draft = {
     },
 
     deleteDraft: function() {
+        if (!this.draft_id)
+            // Nothing to delete
+            return;
         var self = this;
         $.ajax('ajax.php/draft/'+this.draft_id, {
             type: 'delete',
             async: false,
             success: function() {
-                self.opts.autosave = '';
-                self.opts.imageUpload = '';
                 self.draft_id = undefined;
-                clearInterval(self.autosaveInterval);
                 self.hideDraftSaved();
                 self.set('');
+                self.opts.autosave = self.opts.original_autosave;
             }
         });
     },


### PR DESCRIPTION
Previously, deleting a draft either from a form [reset] button or from the trashcan would delete the draft and cancel the draft system for the remainder of the page's lifetime. This patch deletes the current draft and resets the Redactor's content, but then it starts a new draft cycle so drafts can be continued. It also prevents posting to an undefined URL if the draft_id has not yet been setup.

Fixes #90
