### PR TITLE
Handle email addresses used as names

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -159,6 +159,17 @@ class User extends UserModel {
                 $this->name = $parts[1].' '.$parts[0].' '.$parts[2];
                 break;
         }
+
+        // Handle email addresses -- use the box name
+        if (Validator::is_email($this->name)) {
+            list($box, $domain) = explode('@', $this->name, 2);
+            if (strpos($box, '.') !== false)
+                $this->name = str_replace('.', ' ', $box);
+            else
+                $this->name = $box;
+            $this->name = mb_convert_case($this->name, MB_CASE_TITLE);
+        }
+
         if (count($this->dirty))
             $this->set('updated', new SqlFunction('NOW'));
         return parent::save($refetch);


### PR DESCRIPTION
If an email arrives in the system without a "personal" field (name), the email address is used as the name. The email address, however, is not parsed well by the `PersonsName` constructor. This patch uses the mailbox of the email address as the name.

Also include a slight boost to the mbstring compatibility functions declared in the bootstrap::i18n_prep() function
