### PR TITLE
Connect the redactor editor to the autolock

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -64,6 +64,11 @@ RedactorPlugins.draft = {
     setupDraftUpdate: function(data) {
         this.$box.parent().find('.draft-saved').show();
 
+        // Slight workaround. Signal the 'keyup' event normally signaled
+        // from typing in the <textarea>
+        if ($.autoLock && this.opts.draft_namespace == 'ticket.response')
+            $.autoLock.handleEvent();
+
         if (typeof data != 'object')
             data = $.parseJSON(data);
 

--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -200,6 +200,7 @@ var autoLock = {
             type: 'POST',
             url: 'ajax.php/tickets/'+autoLock.tid+'/lock/'+autoLock.lockId+'/release',
             data: 'delete',
+            async: false,
             cache: false,
             success: function(){
 
@@ -257,7 +258,8 @@ var autoLock = {
         clearTimeout(autoLock.timerId);
         autoLock.timerId=setTimeout(function () { autoLock.monitorEvents() },30000);
     }
-}
+};
+$.autoLock = autoLock;
 
 /*
    UI & form events


### PR DESCRIPTION
Previously the rich text editor introduced the loss of the collision avoidance feature.

This request connects the new rich text editor with the autoLock code used with the <textarea> previously. And, if the HTML ticket thread is disabled, the <textarea> and autoLock system will be used exactly as before.
