### PR TITLE
Fixup image hover

### DIFF
--- a/js/osticket.js
+++ b/js/osticket.js
@@ -119,16 +119,23 @@ showImagesInline = function(urls, thread_id) {
             e = $(el);
         if (info) {
             // Add a hover effect with the filename
-            var caption = $('<div class="image-hover">')
+            var timeout, caption = $('<div class="image-hover">');
+            e.wrap(caption).parent()
                 .hover(
-                    function() { $(this).find('.caption').slideDown(250); },
-                    function() { $(this).find('.caption').slideUp(250); }
+                    function() {
+                        var self = this;
+                        timeout = setTimeout(
+                            function() { $(self).find('.caption').slideDown(250); },
+                            500);
+                    },
+                    function() {
+                        clearTimeout(timeout);
+                        $(this).find('.caption').slideUp(250);
+                    }
                 ).append($('<div class="caption">')
                     .append('<span class="filename">'+info.filename+'</span>')
                     .append('<a href="'+info.download_url+'" class="action-button"><i class="icon-download-alt"></i> Download</a>')
-                )
-            caption.appendTo(e.parent())
-            e.appendTo(caption);
+                );
         }
     });
 

--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -428,7 +428,8 @@ showImagesInline = function(urls, thread_id) {
             e = $(el);
         if (info) {
             // Add a hover effect with the filename
-            var timeout, caption = $('<div class="image-hover">')
+            var timeout, caption = $('<div class="image-hover">');
+            e.wrap(caption).parent()
                 .hover(
                     function() {
                         var self = this;
@@ -443,9 +444,7 @@ showImagesInline = function(urls, thread_id) {
                 ).append($('<div class="caption">')
                     .append('<span class="filename">'+info.filename+'</span>')
                     .append('<a href="'+info.download_url+'" class="action-button"><i class="icon-download-alt"></i> Download</a>')
-                )
-            caption.appendTo(e.parent())
-            e.appendTo(caption);
+                );
         }
     });
 }


### PR DESCRIPTION
Since the ticket thread is nested in a div now (required for inline videos to be displayed correctly), the image hover caused the images to be shown at the end of the thread entry body rather that its original location.
