### PR TITLE
Ensure unique form entries are made with each ticket

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -179,11 +179,14 @@ class TicketForm extends DynamicForm {
     }
 
     static function getInstance() {
-        if (!isset(static::$instance)) {
-            $o = static::objects();
-            static::$instance = $o[0]->instanciate();
-        }
+        if (!isset(static::$instance))
+            static::$instance = static::getNewInstance();
         return static::$instance;
+    }
+
+    static function getNewInstance() {
+        $o = static::objects();
+        return $o[0]->instanciate();
     }
 }
 // Add fields from the standard ticket form to the ticket filterable fields
@@ -698,7 +701,7 @@ class DynamicList extends VerySimpleModel {
         return $selections;
     }
 }
-FormField::addFieldTypes('Custom Lists', array(DynamicList, 'getSelections'));
+FormField::addFieldTypes('Custom Lists', array('DynamicList', 'getSelections'));
 
 /**
  * Represents a single item in a dynamic list

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1928,7 +1928,7 @@ class Ticket {
         }
 
         // Create and verify the dynamic form entry for the new ticket
-        $form = TicketForm::getInstance();
+        $form = TicketForm::getNewInstance();
         // If submitting via email, ensure we have a subject and such
         foreach ($form->getFields() as $field) {
             $fname = $field->get('name');


### PR DESCRIPTION
Fixes a case where multiple tickets are created in one request (such as a cron job triggering multiple email fetches). The `TicketForm::getInstance()` called in `Ticket::create()` used a singleton pattern to retrieve a cached instance of the `TicketForm`. In the case of ticket creation, each ticket needs a new `TicketForm` entry instance.
