### PR TITLE
Fix attachment mishap in outgoing emails

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -78,11 +78,14 @@ class Mailer {
     }
 
     function addAttachment($attachment) {
-        $this->attachments[] = $attachment;
+        // XXX: This looks too assuming; however, the attachment processor
+        // in the ::send() method seems hard coded to expect this format
+        $this->attachments[$attachment['file_id']] = $attachment;
     }
 
     function addAttachments($attachments) {
-        $this->attachments = array_merge($this->attachments, $attachments);
+        foreach ($attachments as $a)
+            $this->addAttachment($a);
     }
 
     function send($to, $subject, $message, $options=null) {
@@ -180,8 +183,6 @@ class Mailer {
                     $mime->addAttachment($file->getData(),
                         $file->getType(), $file->getName(),false);
                 }
-                elseif($attachment['file'] &&  file_exists($attachment['file']) && is_readable($attachment['file']))
-                    $mime->addAttachment($attachment['file'],$attachment['type'],$attachment['name']);
             }
         }
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1515,8 +1515,6 @@ class Ticket {
             if($cfg->stripQuotedReply() && ($tag=$cfg->getReplySeparator()))
                 $msg['body'] = "<p style=\"display:none\">$tag<p>".$msg['body'];
 
-            //Set attachments if emailing.
-            $attachments = $cfg->emailAttachments()?$response->getAttachments():array();
             $options = array(
                 'inreplyto' => $response->getEmailMessageId(),
                 'references' => $response->getEmailReferences());


### PR DESCRIPTION
The detection of inline images in the mail processor causes inline images to be removed from the attachment list, if listed there. However, the attachments in the attachment list were not keyed by the attachment-id, so there was no proper way to detect and remove the attachments from the list.

This patch properly keys the attachment list by the attachment file_id
