### PR TITLE
Replace assign-on-reopen with claim-on-response

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -147,6 +147,7 @@ class OsticketConfig extends Config {
         'allow_online_attachments' => true,
         'allow_online_attachments_onlogin' => false,
         'name_format' =>        'full', # First Last
+        'auto_claim_tickets'=>  true,
     );
 
     function OsticketConfig($section=null) {
@@ -651,8 +652,8 @@ class OsticketConfig extends Config {
         return ($this->get('overdue_alert_dept_members'));
     }
 
-    function autoAssignReopenedTickets() {
-        return ($this->get('auto_assign_reopened_tickets'));
+    function autoClaimTickets() {
+        return $this->get('auto_claim_tickets');
     }
 
     function showAssignedTickets() {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -734,10 +734,14 @@ class Ticket {
             .' ,isanswered='.db_input($isanswered)
             .' WHERE ticket_id='.db_input($this->getId());
 
-        //TODO: log reopen event here
+        if (!db_query($sql) || !db_affected_rows())
+            return false;
 
         $this->logEvent('reopened', 'closed');
-        return (db_query($sql) && db_affected_rows());
+        $this->ht['status'] = 'open';
+        $this->ht['isanswerd'] = $isanswered;
+
+        return true;
     }
 
     function onNewTicket($message, $autorespond=true, $alertstaff=true) {
@@ -872,7 +876,7 @@ class Ticket {
 
         //auto-assign to closing staff or last respondent
         if(!($staff=$this->getStaff()) || !$staff->isAvailable()) {
-            if($cfg->autoAssignReopenedTickets() && ($lastrep=$this->getLastRespondent()) && $lastrep->isAvailable()) {
+            if(($lastrep=$this->getLastRespondent()) && $lastrep->isAvailable()) {
                 $this->setStaffId($lastrep->getId()); //direct assignment;
             } else {
                 $this->setStaffId(0); //unassign - last respondent is not available.
@@ -1504,6 +1508,10 @@ class Ticket {
         //Set status - if checked.
         if(isset($vars['reply_ticket_status']) && $vars['reply_ticket_status'])
             $this->setStatus($vars['reply_ticket_status']);
+
+        if($thisstaff && $this->isOpen() && !$this->getStaffId()
+                && $cfg->autoClaimTickets())
+            $this->setStaffId($thisstaff->getId()); //direct assignment;
 
         $this->onResponse(); //do house cleaning..
         $this->reload();

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -71,7 +71,7 @@ core:
     assigned_alert_staff: 1
     assigned_alert_team_lead: 0
     assigned_alert_team_members: 0
-    auto_assign_reopened_tickets: 1
+    auto_claim_tickets: 1
     show_related_tickets: 1
     show_assigned_tickets: 1
     show_answered_tickets: 0

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -98,10 +98,12 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
-            <td>Reopened Tickets:</td>
+            <td>Claim Tickets:</td>
             <td>
-                <input type="checkbox" name="auto_assign_reopened_tickets" <?php echo $config['auto_assign_reopened_tickets']?'checked="checked"':''; ?>>
-                Auto-assign reopened tickets to the last available respondent.
+                <input type="checkbox" name="auto_claim_tickets" <?php echo $config['auto_claim_tickets']?'checked="checked"':''; ?>>
+                Auto-assign unassigned tickets on response
+                <!-- Help Tip:
+                     Reopened tickets are always assigned to the last respondent -->
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
If a ticket is currently unassigned and your respond to it, it's yours. If a ticket is closed and later reopened due to a new message, the last respondent will always be assigned if available at the time.
