### PR TITLE
templates: %{ticket.phone} shows the entire number

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -297,16 +297,6 @@ class Ticket {
         return '';
     }
 
-    function getPhone() {
-        list($phone, $ext) = $this->getPhoneNumber();
-        return $phone;
-    }
-
-    function getPhoneExt() {
-        list($phone, $ext) = $this->getPhoneNumber();
-        return $ext;
-    }
-
     function getPhoneNumber() {
         return (string)$this->getOwner()->getPhoneNumber();
     }
@@ -1056,6 +1046,7 @@ class Ticket {
             return call_user_func(array($this, 'get'.ucfirst($tag)));
 
         switch(strtolower($tag)) {
+            case 'phone':
             case 'phone_number':
                 return $this->getPhoneNumber();
                 break;


### PR DESCRIPTION
Previously, due to a bug in Ticket::getPhone(), the first digit of the formatted phone number was displayed only. This patch will allow display of the entire formatted phone number.

Fixes osTicket/osTicket-1.8#248
