### PR TITLE
forms: Fix user creation if email is a drop-down

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -749,6 +749,9 @@ class DynamicListItem extends VerySimpleModel {
     function toString() {
         return $this->get('value');
     }
+    function __toString() {
+        return $this->toString();
+    }
 
     function delete() {
         # Don't really delete, just unset the list_id to un-associate it with

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -85,7 +85,7 @@ class User extends UserModel {
                 'created'=>new SqlFunction('NOW'),
                 'updated'=>new SqlFunction('NOW'),
                 'default_email'=>
-                    UserEmail::create(array('address'=>$data['email']))
+                    UserEmail::create(array('address'=>(string) $data['email']))
             ));
             $user->save(true);
             $user->emails->add($user->default_email);


### PR DESCRIPTION
Previously, it was assumed that the user email field would be a text field
