### PR TITLE
forms: Require `title` for all custom forms

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -216,9 +216,11 @@ class Bootstrap {
             define('LATIN1_UC_CHARS', 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝ');
             define('LATIN1_LC_CHARS', 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüý');
             function mb_strtoupper($str) {
+                if (is_array($str)) $str = $str[0];
                 return strtoupper(strtr($str, LATIN1_LC_CHARS, LATIN1_UC_CHARS));
             }
             function mb_strtolower($str) {
+                if (is_array($str)) $str = $str[0];
                 return strtolower(strtr($str, LATIN1_UC_CHARS, LATIN1_LC_CHARS));
             }
             define('MB_CASE_LOWER', 1);

--- a/include/staff/dynamic-form.inc.php
+++ b/include/staff/dynamic-form.inc.php
@@ -37,6 +37,8 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
             <td><input type="text" name="title" size="40" value="<?php
                 echo $info['title']; ?>"/>
                 <i class="help-tip icon-question-sign" href="#form_title"></i>
+                <font class="error"><?php
+                    if ($errors['title']) echo '<br/>'; echo $errors['title']; ?></font>
             </td>
         </tr>
         <tr>

--- a/scp/forms.php
+++ b/scp/forms.php
@@ -8,12 +8,15 @@ if($_REQUEST['id'] && !($form=DynamicForm::lookup($_REQUEST['id'])))
 
 if($_POST) {
     $fields = array('title', 'notes', 'instructions');
-    $required = array('subject');
+    $required = array('title');
     $max_sort = 0;
     switch(strtolower($_POST['do'])) {
         case 'update':
             foreach ($fields as $f)
-                if (isset($_POST[$f]))
+                if (in_array($f, $required) && !$_POST[$f])
+                    $errors[$f] = sprintf('%s is required',
+                        mb_convert_case($f, MB_CASE_TITLE));
+                elseif (isset($_POST[$f]))
                     $form->set($f, $_POST[$f]);
             $form->save(true);
             $names = array();
@@ -107,6 +110,8 @@ if($_POST) {
     }
     if ($errors)
         $errors['err'] = 'Unable to commit form. Check validation errors';
+    else
+        $msg = 'Custom form successfully updated';
 }
 
 $page='dynamic-forms.inc.php';


### PR DESCRIPTION
Otherwise, you can't click on the custom form in the table view in order to manage it.

Fixes osTicket/osTicket-1.8#276
