### PR TITLE
forms: Allow user name and email to be blocked

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1976,6 +1976,13 @@ class Ticket {
         foreach ($form->getFields() as $f)
             $vars['field.'.$f->get('id')] = $f->toString($f->getClean());
 
+        // Unpack the basic user information
+        $interesting = array('name', 'email');
+        $user_form = UserForm::getUserForm()->getForm($vars);
+        foreach ($user_form->getFields() as $f)
+            if (in_array($f->get('name'), $interesting))
+                $vars[$f->get('name')] = $f->toString($f->getClean());
+
         //Init ticket filters...
         $ticket_filter = new TicketFilter($origin, $vars);
         // Make sure email contents should not be rejected


### PR DESCRIPTION
Fixes a regression in 1.8 where user names and emails submitted via the web interface would not properly be detected by the filter system for rejection.

References:
http://osticket.com/forum/discussion/75456/v1-8-ticket-filter-for-banning-domain-doesn-t-work
