### PR TITLE
Fix UI bug where user change warning always showed

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -897,9 +897,10 @@ $tcount+= $ticket->getNumNotes();
         Are you sure want to <b>unassign</b> ticket from <b><?php echo $ticket->getAssigned(); ?></b>?
     </p>
     <p class="confirm-action" style="display:none;" id="changeuser-confirm">
-        <p id="msg_warning">
-        <b><?php echo Format::htmlchars($ticket->getName()); ?></b> &lt;<?php echo $ticket->getEmail(); ?>&gt; will no longer have access to the ticket.
-        </p>
+        <span id="msg_warning" style="display:block;vertical-align:top">
+        <b><?php echo Format::htmlchars($ticket->getName()); ?></b> &lt;<?php echo $ticket->getEmail(); ?>&gt;
+        <br> will no longer have access to the ticket.
+        </span>
         Are you sure want to <b>change</b> ticket owner to <b><span id="newuser">this guy</span></b>?
     </p>
     <p class="confirm-action" style="display:none;" id="delete-confirm">


### PR DESCRIPTION
HTML does not allow nested `<p>` tags. Therefore the user warning was not correctly hidden with the rest of the user change confirmation message.
