### PR TITLE
auth: Fixup remote user lookup with spaces in DN

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -127,8 +127,9 @@ class UsersAjaxAPI extends AjaxController {
 
         $user_info = $backend->lookup($id);
         $form = UserForm::getUserForm()->getForm($user_info);
+        $info = array('title' => 'Import Remote User');
         if (!$user_info)
-            $info = array('error' => 'Unable to find user in directory');
+            $info['error'] = 'Unable to find user in directory';
 
         include(STAFFINC_DIR . 'templates/user-lookup.tmpl.php');
     }

--- a/include/staff/templates/user-lookup.tmpl.php
+++ b/include/staff/templates/user-lookup.tmpl.php
@@ -80,7 +80,7 @@ $(function() {
         },
         onselect: function (obj) {
             $('#the-lookup-form').load(
-                '<?php echo $info['onselect']? $info['onselect']: "ajax.php/users/select/"; ?>'+obj.id
+                '<?php echo $info['onselect']? $info['onselect']: "ajax.php/users/select/"; ?>'+encodeURIComponent(obj.id)
             );
         },
         property: "/bin/true"


### PR DESCRIPTION
If there is a space (_or any other invalid URI character_) in the DN, it should be properly encoded when being sent in a URL back to the server
