### PR TITLE
Fixes missing lookup var in ticket lock renews

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -256,7 +256,7 @@ class TicketsAjaxAPI extends AjaxController {
     function acquireLock($tid) {
         global $cfg,$thisstaff;
 
-        if(!$tid or !is_numeric($tid) or !$thisstaff or !$cfg or !$cfg->getLockTime())
+        if(!$tid || !is_numeric($tid) || !$thisstaff || !$cfg || !$cfg->getLockTime())
             return 0;
 
         if(!($ticket = Ticket::lookup($tid)) || !$ticket->checkStaffAccess($thisstaff))
@@ -283,10 +283,10 @@ class TicketsAjaxAPI extends AjaxController {
     function renewLock($tid, $id) {
         global $thisstaff;
 
-        if(!$id or !is_numeric($id) or !$thisstaff)
+        if(!$tid || !is_numeric($tid) || !$id || !is_numeric($id) || !$thisstaff)
             return $this->json_encode(array('id'=>0, 'retry'=>true));
 
-        $lock= TicketLock::lookup($id);
+        $lock= TicketLock::lookup($id, $tid);
         if(!$lock || !$lock->getStaffId() || $lock->isExpired()) //Said lock doesn't exist or is is expired
             return self::acquireLock($tid); //acquire the lock
 
@@ -302,7 +302,7 @@ class TicketsAjaxAPI extends AjaxController {
     function releaseLock($tid, $id=0) {
         global $thisstaff;
 
-        if($id && is_numeric($id)){ //Lock Id provided!
+        if($tid && is_numeric($tid) && is_numeric($id)){ //Lock Id provided!
 
             $lock = TicketLock::lookup($id, $tid);
             //Already gone?


### PR DESCRIPTION
Was receiving stack traces "Missing argument 2 for TicketLock::lookup()"
Which, according to Ticket::lookup should be $id,$tid.. 

The change works for 1.7 as well.

Modified a few other checks, as we can't exactly check for a 0 default value with a boolean.. but we do need the TicketID to find the correct lock.

This extends from https://github.com/osTicket/osTicket-1.8/pull/335 

Guess I didn't notice the functionality was missing as it might not have worked for a while.
