### PR TITLE
Fix possible serious errors in dynamic form fields

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -211,10 +211,11 @@ class TicketsAjaxAPI extends AjaxController {
         foreach (TicketForm::getInstance()->getFields() as $f) {
             if (isset($req[$f->getFormName()])
                     && ($val = $req[$f->getFormName()])) {
-                $name = $f->get('name') ? $f->get('name') : 'field_'.$f->get('id');
-                $cwhere = "cdata.`$name` LIKE '%".db_real_escape($val)."%'";
+                $name = $f->get('name') ? db_real_escape($f->get('name'))
+                    : 'field_'.$f->get('id');
+                $cwhere = "cdata.\"$name\" LIKE '%".db_real_escape($val)."%'";
                 if ($f->getImpl()->hasIdValue() && is_numeric($val))
-                    $cwhere .= " OR cdata.`{$name}_id` = ".db_input($val);
+                    $cwhere .= " OR cdata.\"{$name}_id\" = ".db_input($val);
                 $where .= ' AND ('.$cwhere.')';
                 $cdata_search = true;
             }

--- a/include/staff/dynamic-form.inc.php
+++ b/include/staff/dynamic-form.inc.php
@@ -123,7 +123,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
         <tr>
             <td><i class="icon-sort"></i></td>
             <td><input type="text" size="32" name="label-<?php echo $id; ?>"
-                value="<?php echo $f->get('label'); ?>"/>
+                value="<?php echo Format::htmlchars($f->get('label')); ?>"/>
                 <font class="error"><?php
                     if ($ferrors['label']) echo '<br/>'; echo $ferrors['label']; ?>
             </td>
@@ -161,7 +161,8 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
             </td>
             <td>
                 <input type="text" size="20" name="name-<?php echo $id; ?>"
-                    value="<?php echo $f->get('name'); ?>" <?php echo $force_name ?>/>
+                    value="<?php echo Format::htmlchars($f->get('name'));
+                    ?>" <?php echo $force_name ?>/>
                 <font class="error"><?php
                     if ($ferrors['name']) echo '<br/>'; echo $ferrors['name'];
                 ?></font>

--- a/scp/forms.php
+++ b/scp/forms.php
@@ -43,6 +43,8 @@ if($_POST) {
                 }
                 if (in_array($field->get('name'), $names))
                     $field->addError('Field variable name is not unique', 'name');
+                if (preg_match('/[.{}\'"`; ]/u', $field->get('name')))
+                    $field->addError('Invalid character in variable name. Please use letters and numbers only.', 'name');
                 if ($field->get('name'))
                     $names[] = $field->get('name');
                 if ($field->isValid())


### PR DESCRIPTION
Fix dropping of materialized view when variable name is changed

Prevent possible sql injection error in field name used in the materialized view.

Prevent possible xss error in the display of the field label and variable name in the admin panel.
