### PR TITLE
Use config URL instead of THISPAGE

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -224,12 +224,11 @@ class osTicket {
     function alertAdmin($subject, $message, $log=false) {
 
         //Set admin's email address
-        if(!($to=$this->getConfig()->getAdminEmail()))
-            $to=ADMIN_EMAIL;
-
+        if (!($to = $this->getConfig()->getAdminEmail()))
+            $to = ADMIN_EMAIL;
 
         //append URL to the message
-        $message.="\n\n".THISPAGE;
+        $message.="\n\n".$this->getConfig()->getBaseUrl();
 
         //Try getting the alert email.
         $email=null;


### PR DESCRIPTION
THISPAGE is unreliable for CLI cron calls. It was historically used so the admin could figure out which file/page generated the error. But with backtrace support we no longer need it.
