### PR TITLE
Drop the cdata table on field type change

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -303,7 +303,8 @@ Signal::connect('model.updated',
     array('TicketForm', 'dropDynamicDataView'),
     'DynamicFormField',
     // TODO: Lookup the dynamic form to verify {type == 'T'}
-    function($o, $d) { return isset($d['dirty']) && isset($d['dirty']['name']); });
+    function($o, $d) { return isset($d['dirty'])
+        && (isset($d['dirty']['name']) || isset($d['dirty']['type'])); });
 
 require_once(INCLUDE_DIR . "class.json.php");
 


### PR DESCRIPTION
If a field on the ticket details form changes type, recreate the cdata table
