### PR TITLE
Revisit template management page

### DIFF
--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -119,7 +119,7 @@ class Internationalization {
         // Email templates
         // TODO: Lookup tpl_id
         $tpl = EmailTemplateGroup::lookup(1);
-        foreach ($tpl->all_names as $name=>$info) {
+        foreach ($tpl::$all_names as $name=>$info) {
             if (($tp = $this->getTemplate("templates/email/$name.yaml"))
                     && ($t = $tp->getData())) {
                 $t['tpl_id'] = $tpl->getId();

--- a/include/class.template.php
+++ b/include/class.template.php
@@ -21,44 +21,62 @@ class EmailTemplateGroup {
     var $id;
     var $ht;
     var $_templates;
-    var $all_names=array(
+    static $all_groups = array(
+        'sys' => 'System Management Templates',
+        'ticket.user' => 'End-User Ticket Templates',
+        'ticket.staff' => 'Staff Ticket Templates',
+    );
+    static $all_names=array(
         'ticket.autoresp'=>array(
+            'group'=>'ticket.user',
             'name'=>'New Ticket Auto-response',
             'desc'=>'Autoresponse sent to user, if enabled, on new ticket.'),
         'ticket.autoreply'=>array(
+            'group'=>'ticket.user',
             'name'=>'New Ticket Auto-reply',
             'desc'=>'Canned Auto-reply sent to user on new ticket, based on filter matches. Overwrites "normal" auto-response.'),
         'message.autoresp'=>array(
+            'group'=>'ticket.user',
             'name'=>'New Message Auto-response',
             'desc'=>'Confirmation sent to user when a new message is appended to an existing ticket.'),
         'ticket.notice'=>array(
+            'group'=>'ticket.user',
             'name'=>'New Ticket Notice',
             'desc'=>'Notice sent to user, if enabled, on new ticket created by staff on their behalf (e.g phone calls).'),
         'ticket.overlimit'=>array(
+            'group'=>'ticket.user',
             'name'=>'Over Limit Notice',
             'desc'=>'A one-time notice sent, if enabled, when user has reached the maximum allowed open tickets.'),
         'ticket.reply'=>array(
+            'group'=>'ticket.user',
             'name'=>'Response/Reply Template',
             'desc'=>'Template used on ticket response/reply'),
         'ticket.alert'=>array(
+            'group'=>'ticket.staff',
             'name'=>'New Ticket Alert',
             'desc'=>'Alert sent to staff, if enabled, on new ticket.'),
         'message.alert'=>array(
+            'group'=>'ticket.staff',
             'name'=>'New Message Alert',
             'desc'=>'Alert sent to staff, if enabled, when user replies to an existing ticket.'),
         'note.alert'=>array(
+            'group'=>'ticket.staff',
             'name'=>'Internal Note Alert',
             'desc'=>'Alert sent to selected staff, if enabled, on new internal note.'),
         'assigned.alert'=>array(
+            'group'=>'ticket.staff',
             'name'=>'Ticket Assignment Alert',
             'desc'=>'Alert sent to staff on ticket assignment.'),
         'transfer.alert'=>array(
+            'group'=>'ticket.staff',
             'name'=>'Ticket Transfer Alert',
             'desc'=>'Alert sent to staff on ticket transfer.'),
         'ticket.overdue'=>array(
+            'group'=>'ticket.staff',
             'name'=>'Overdue Ticket Alert',
             'desc'=>'Alert sent to staff on stale or overdue tickets.'),
         'staff.pwreset' => array(
+            'group'=>'sys',
             'name' => 'Staff Password Reset',
             'desc' => 'Notice sent to staff with the password reset link.',
             'default' => 'templates/staff.pwreset.txt'),
@@ -141,7 +159,7 @@ class EmailTemplateGroup {
     }
 
     function getTemplateDescription($name) {
-        return $this->all_names[$name];
+        return static::$all_names[$name];
     }
 
     function getMsgTemplate($name) {
@@ -171,7 +189,7 @@ class EmailTemplateGroup {
     }
 
     function getUndefinedTemplateNames() {
-        $list = $this->all_names;
+        $list = static::$all_names;
         foreach ($this->getTemplates() as $cn=>$tpl)
             unset($list[$cn]);
         return $list;
@@ -408,6 +426,10 @@ class EmailTemplate {
     }
     function getCodeName() {
         return $this->ht['code_name'];
+    }
+
+    function getLastUpdated() {
+        return $this->ht['updated'];
     }
 
     function getTplId() {

--- a/include/staff/template.inc.php
+++ b/include/staff/template.inc.php
@@ -66,40 +66,41 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
             </td>
         </tr>
         <?php
-        if($template){ ?>
-        <tr>
-            <th colspan="2">
-                <em><strong>Template Messages</strong>: Click on the message to edit.&nbsp;
-                    <span class="error">*&nbsp;<?php echo $errors['rules']; ?></span></em>
-            </th>
-        </tr>
-        <?php
-         foreach($template->getTemplates() as $tpl){
-             $info = $tpl->getDescription();
+        if($template){
+            $current_group = false;
+            $impl = $template->getTemplates();
+            $_tpls = $template::$all_names;
+            $_groups = $template::$all_groups;
+            uasort($_tpls, function($a,$b) {
+                return strcmp($a['group'].$a['name'], $b['group'].$b['name']);
+            });
+         foreach($_tpls as $cn=>$info){
              if (!$info['name'])
                  continue;
-            echo sprintf('<tr><td colspan=2>&nbsp;<strong><a href="templates.php?id=%d&a=manage">%s</a></strong>&nbsp-&nbsp<em>%s</em></td></tr>',
-                    $tpl->getId(),Format::htmlchars($info['name']),
-                    Format::htmlchars($info['desc']));
-         }
-         if (($undef = $template->getUndefinedTemplateNames())) { ?>
+             if (!$current_group || $current_group != $info['group']) {
+                $current_group = $info['group']; ?>
         <tr>
             <th colspan="2">
-                <em><strong>Unimplemented Template Messages</strong>: Click
-                on the message to implement</em>
+            <em><strong><?php echo isset($_groups[$current_group])
+            ? $_groups[$current_group] : $current_group; ?></strong>
+            :: Click on the title to edit.&nbsp;</em>
             </th>
         </tr>
-        <?php
-            foreach($template->getUndefinedTemplateNames() as $cn=>$info){
+<?php } # end if ($current_group)
+            if (isset($impl[$cn])) {
+                echo sprintf('<tr><td colspan="2">&nbsp;<strong><a href="templates.php?id=%d&a=manage">%s</a></strong>, <span class="faded">Updated %s</span><br/>&nbsp;%s</td></tr>',
+                $impl[$cn]->getId(), Format::htmlchars($info['name']),
+                Format::db_datetime($impl[$cn]->getLastUpdated()),
+                Format::htmlchars($info['desc']));
+            } else {
                 echo sprintf('<tr><td colspan=2>&nbsp;<strong><a
                     href="templates.php?tpl_id=%d&a=implement&code_name=%s"
-                    style="color:red;text-decoration:underline"
-                    >%s</a></strong>&nbsp-&nbsp<em>%s</em></td></tr>',
-                    $template->getId(),$cn,Format::htmlchars($info['name']),
-                    Format::htmlchars($info['desc']));
+                    >%s</a></strong><br/>&nbsp%s</td></tr>',
+                    $template->getid(),$cn,format::htmlchars($info['name']),
+                    format::htmlchars($info['desc']));
             }
-        }
-        }else{ ?>
+         } # endfor
+        } else { ?>
         <tr>
             <td width="180" class="required">
                 Template To Clone:

--- a/include/staff/tpl.inc.php
+++ b/include/staff/tpl.inc.php
@@ -10,7 +10,8 @@ if (is_a($template, EmailTemplateGroup)) {
     $selected = $_REQUEST['code_name'];
     $action = 'implement';
     $extras = array('code_name'=>$selected, 'tpl_id'=>$tpl_id);
-    $msgtemplates=$template->all_names;
+    $msgtemplates=$template::$all_names;
+    $desc = $msgtemplates[$selected];
     // Attempt to lookup the default data if it is defined
     $default = @$template->getMsgTemplate($selected);
     if ($default) {
@@ -22,11 +23,12 @@ if (is_a($template, EmailTemplateGroup)) {
     $id = $template->getId();
     $tpl_id = $template->getTplId();
     $name = $template->getGroup()->getName();
+    $desc = $template->getDescription();
     $group = $template->getGroup();
     $selected = $template->getCodeName();
     $action = 'updatetpl';
     $extras = array();
-    $msgtemplates=$template->getGroup()->all_names;
+    $msgtemplates=$group::$all_names;
     $info=array_merge(array('subject'=>$template->getSubject(), 'body'=>$template->getBodyWithImages()),$info);
 }
 $tpl=$msgtemplates[$selected];
@@ -34,24 +36,37 @@ $tpl=$msgtemplates[$selected];
 ?>
 <h2>Email Template Message - <span><?php echo $name; ?></span></h2>
 <div style="padding-top:10px;padding-bottom:5px;">
-    <form method="get" action="templates.php">
+    <form method="get" action="templates.php?">
     <input type="hidden" name="a" value="manage">
+    <input type="hidden" name="tpl_id" value="<?php echo $tpl_id; ?>">
     Message Template:
     <select id="tpl_options" name="id" style="width:300px;">
         <option value="">&mdash; Select Setting Group &mdash;</option>
         <?php
-        foreach($group->getTemplates() as $cn=>$t) {
-            $nfo=$t->getDescription();
+        $impl = $group->getTemplates();
+        $current_group = false;
+        $_tpls = $group::$all_names;
+        $_groups = $group::$all_groups;
+        uasort($_tpls, function($a,$b) {
+            return strcmp($a['group'].$a['name'], $b['group'].$b['name']);
+        });
+        foreach($_tpls as $cn=>$nfo) {
             if (!$nfo['name'])
                 continue;
+            if (!$current_group || $current_group != $nfo['group']) {
+                if ($current_group)
+                    echo "</optgroup>";
+                $current_group = $nfo['group']; ?>
+                <optgroup label="<?php echo isset($_groups[$current_group])
+                    ? $_groups[$current_group] : $current_group; ?>">
+            <?php }
             $sel=($selected==$cn)?'selected="selected"':'';
             echo sprintf('<option value="%s" %s>%s</option>',
-                    $t->getId(),$sel,$nfo['name']);
+                isset($impl[$cn]) ? $impl[$cn]->getId() : $cn,
+                $sel,$nfo['name']);
         }
-        if ($id == 0) { ?>
-            <option selected="selected" value="<?php echo $id; ?>"><?php
-            echo $msgtemplates[$selected]['name']; ?></option>
-        <?php }
+        if ($current_group)
+            echo "</optgroup>";
         ?>
     </select>
     <input type="submit" value="Go">
@@ -71,7 +86,7 @@ $tpl=$msgtemplates[$selected];
    <thead>
      <tr>
         <th colspan="2">
-            <h4><?php echo Format::htmlchars($tpl['desc']); ?></h4>
+            <h4><?php echo Format::htmlchars($desc['desc']); ?></h4>
             <em>Subject and body required.  <a class="tip" href="ticket_variables.txt">Supported Variables</a>.</em>
         </th>
      </tr>

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -148,7 +148,12 @@ $(document).ready(function(){
      });
 
     $('select#tpl_options').change(function() {
-        $(this).closest('form').submit();
+        var $this = $(this), form = $this.closest('form');
+        if ($this.val() % 1 !== 0) {
+            $('[name="a"]', form).val('implement');
+            $this.attr('name', 'code_name');
+        }
+        form.submit();
      });
 
     $(".clearrule").live('click',function() {


### PR DESCRIPTION
Arrange templates in a group by their respective use in the system:
- System Management Templates
- Staff Ticket Templates (Alerts and Notices)
- End-User Ticket Templates (Autoresponder)

This provides an interface to sort the templates and make them easier to find and provides a nice place for new templates to be added without making it increasingly more difficult to locate templates in the list.

This patch also fixes the missing templates in the drop-down list when editing an implemented template.
