### PR TITLE
filters: Unpack the user information before filter

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1970,11 +1970,17 @@ class Ticket {
             $vars['field.'.$f->get('id')] = $f->toString($f->getClean());
 
         // Unpack the basic user information
-        $interesting = array('name', 'email');
-        $user_form = UserForm::getUserForm()->getForm($vars);
-        foreach ($user_form->getFields() as $f)
-            if (in_array($f->get('name'), $interesting))
-                $vars[$f->get('name')] = $f->toString($f->getClean());
+        if ($vars['uid'] && ($user = User::lookup($vars['uid']))) {
+            $vars['email'] = $user->getEmail();
+            $vars['name'] = $user->getName();
+        }
+        else {
+            $interesting = array('name', 'email');
+            $user_form = UserForm::getUserForm()->getForm($vars);
+            foreach ($user_form->getFields() as $f)
+                if (in_array($f->get('name'), $interesting))
+                    $vars[$f->get('name')] = $f->toString($f->getClean());
+        }
 
         //Init ticket filters...
         $ticket_filter = new TicketFilter($origin, $vars);
@@ -2026,11 +2032,6 @@ class Ticket {
         }
 
         if (!$errors) {
-
-            if ($vars['uid'] && ($user = User::lookup($vars['uid']))) {
-                $vars['email'] = $user->getEmail();
-                $vars['name'] = $user->getName();
-            }
 
             # Perform ticket filter actions on the new ticket arguments
             if ($ticket_filter) $ticket_filter->apply($vars);


### PR DESCRIPTION
If a user is created / selected before opening a ticket (very likely the case in the SCP), the email address and name should be unpacked into the $vars dictionary prior to creating and processing ticket filters
