### PR TITLE
search: Improve typeahead search results

### DIFF
--- a/include/staff/templates/user-lookup.tmpl.php
+++ b/include/staff/templates/user-lookup.tmpl.php
@@ -68,9 +68,11 @@ if ($info['error']) {
 </div>
 <script type="text/javascript">
 $(function() {
+    var last_req;
     $('#user-search').typeahead({
         source: function (typeahead, query) {
-            $.ajax({
+            if (last_req) last_req.abort();
+            last_req = $.ajax({
                 url: "ajax.php/users?q="+query,
                 dataType: 'json',
                 success: function (data) {

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -308,9 +308,11 @@ $(document).ready(function(){
     });
 
     /* Typeahead tickets lookup */
+    var last_req;
     $('#basic-ticket-search').typeahead({
         source: function (typeahead, query) {
-            $.ajax({
+            if (last_req) last_req.abort();
+            last_req = $.ajax({
                 url: "ajax.php/tickets/lookup?q="+query,
                 dataType: 'json',
                 success: function (data) {
@@ -329,7 +331,8 @@ $(document).ready(function(){
     $('.email.typeahead').typeahead({
         source: function (typeahead, query) {
             if(query.length > 2) {
-                $.ajax({
+                if (last_req) last_req.abort();
+                last_req = $.ajax({
                     url: "ajax.php/users?q="+query,
                     dataType: 'json',
                     success: function (data) {
@@ -348,7 +351,8 @@ $(document).ready(function(){
     $('.staff-username.typeahead').typeahead({
         source: function (typeahead, query) {
             if(query.length > 2) {
-                $.ajax({
+                if (last_req) last_req.abort();
+                last_req = $.ajax({
                     url: "ajax.php/users/staff?q="+query,
                     dataType: 'json',
                     success: function (data) {


### PR DESCRIPTION
Fixup search for users with hits in an searchable authentication backend:
- If there is a hit for the remote backend, include that in the search for
  local users by email address. If there is a hit locally for the same
  email address, then remove the remote hit from the search results.

Fixup typeahead results
- Abort previous search requests when the user enters more text into the
  search fields. This makes the search box feel more consistent, and
  avoids the case where the user finishes typing and valid search hits
  never appear
