### PR TITLE
oops: Fixup deploy for 1.8.1 and onward

### DIFF
--- a/setup/cli/manage.php
+++ b/setup/cli/manage.php
@@ -46,8 +46,7 @@ class Manager extends Module {
                 if ($val == $action)
                     unset($argv[$idx]);
 
-            foreach (glob(dirname(__file__).'/modules/*.php') as $script)
-                include_once $script;
+            require_once dirname(__file__)."/modules/{$args['action']}.php";
             if (($module = Module::getInstance($action)))
                 return $module->_run($args['action']);
 

--- a/setup/cli/modules/file.php
+++ b/setup/cli/modules/file.php
@@ -48,6 +48,8 @@ class FileManager extends Module {
 
 
     function run($args, $options) {
+        if (!defined('OST_INSTALLED'))
+            $this->fail('Install your config file into `include/`');
         Bootstrap::connect();
         osTicket::start();
 


### PR DESCRIPTION
This patch requires the module name registered to be the same as the filename. Not too much of a stretch, but might break some CLI code.
### Outstanding
- [ ] Add a doc to the `setup/` folder on creating a CLI module
