### PR TITLE
Hide close/hide dialog when esc key is pressed fixes issue #441

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -371,6 +371,13 @@ $(document).ready(function(){
         return false;
     });
 
+    $(document).keydown(function(e) {        
+        if (e.keyCode == 27) {
+            $('div.dialog').hide();
+            $('#overlay').hide();
+        }  
+    });
+
     /* advanced search */
     $('.dialog#advanced-search').css({
         top  : ($(window).height() / 6),


### PR DESCRIPTION
This catches the 'esc' key and closes any div.dialog popups currently visible on screen. Fixes issue #441
