### PR TITLE
Timeout after max timeout while fetching emails

### DIFF
--- a/scp/autocron.php
+++ b/scp/autocron.php
@@ -26,6 +26,12 @@ header('Cache-Control: no-cache, must-revalidate');
 header('Content-Length: '.strlen($data));
 header('Connection: Close');
 print $data;
+// Flush the request buffer
+while(@ob_end_flush());
+flush();
+//Terminate the request
+if (function_exists('fastcgi_finish_request'))
+    fastcgi_finish_request();
 
 ob_start(); //Keep the image output clean. Hide our dirt.
 //TODO: Make cron DB based to allow for better time limits. Direct calls for now sucks big time.
@@ -37,7 +43,7 @@ if($sec>180 && $ost && !$ost->isUpgradePending()): //user can call cron once eve
 require_once(INCLUDE_DIR.'class.cron.php');
 
 $thisstaff = null; //Clear staff obj to avoid false credit internal notes & auto-assignment
-Cron::TicketMonitor(); //Age tickets: We're going to age tickets regardless of cron settings. 
+Cron::TicketMonitor(); //Age tickets: We're going to age tickets regardless of cron settings.
 if($cfg && $cfg->isAutoCronEnabled()) { //ONLY fetch tickets if autocron is enabled!
     Cron::MailFetcher();  //Fetch mail.
     $ost->logDebug('Auto Cron', 'Mail fetcher cron call ['.$caller.']');
@@ -45,6 +51,5 @@ if($cfg && $cfg->isAutoCronEnabled()) { //ONLY fetch tickets if autocron is enab
 
 $_SESSION['lastcroncall']=time();
 endif;
-$output = ob_get_contents();
 ob_end_clean();
 ?>


### PR DESCRIPTION
Processing fetching in ASC order of the last fetch time
Remove LIMIT of 10 emails per fetch
Flush the buffer and terminate the request cleanly on autocron
