### PR TITLE
forms: Fix ticket submission if already logged in

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -27,6 +27,7 @@ class Client {
     var $_answers;
 
     var $ticket_id;
+    var $user_id;
     var $ticketID;
 
     var $ht;
@@ -42,7 +43,7 @@ class Client {
         if(!$id && !($id=$this->getId()))
             return false;
 
-        $sql='SELECT ticket.ticket_id, ticketID, email.address as email '
+        $sql='SELECT ticket.ticket_id, ticketID, email.address as email, user.id as user_id '
             .' FROM '.TICKET_TABLE.' ticket '
             .' LEFT JOIN '.USER_TABLE.' user ON user.id = ticket.user_id'
             .' LEFT JOIN '.USER_EMAIL_TABLE.' email ON user.id = email.user_id'
@@ -59,7 +60,8 @@ class Client {
         $this->ticket_id  = $this->ht['ticket_id'];
         $this->ticketID   = $this->ht['ticketID'];
 
-        $user = User::lookup(array('emails__address'=>$this->ht['email']));
+        $user = User::lookup($this->ht['user_id']);
+        $this->user_id    = $this->ht['user_id'];
         $this->fullname   = $user->getFullName();
 
         $this->username   = $this->ht['email'];
@@ -88,6 +90,10 @@ class Client {
 
     function getId() {
         return $this->id;
+    }
+
+    function getUserId() {
+        return $this->user_id;
     }
 
     function getEmail() {

--- a/open.php
+++ b/open.php
@@ -21,8 +21,7 @@ if($_POST):
     $vars = $_POST;
     $vars['deptId']=$vars['emailId']=0; //Just Making sure we don't accept crap...only topicId is expected.
     if($thisclient) {
-        $vars['name']=$thisclient->getName();
-        $vars['email']=$thisclient->getEmail();
+        $vars['uid'] = $thisclient->getUserId();
     } elseif($cfg->isCaptchaEnabled()) {
         if(!$_POST['captcha'])
             $errors['captcha']='Enter text shown on the image';


### PR DESCRIPTION
If a client is already logged into the client portal and attempts to submit a new ticket, the ticket will be rejected if the contact-information form has a required field other than `name` and `email`.

This patch fixes `class Client` so that the user-id is fetched from the database and made available via the `::getUserId()` method. This was already corrected in the `develop-next` branch for v1.8.1. The `uid` field is passed into `Ticket::create()` so the user form validation is bypassed.

This commit should be ignored when merged into the 1.8.1 codebase.
