### PR TITLE
Allow staff with numeric usernames to be authenticated

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -54,12 +54,15 @@ class Staff {
             $sql .= 'email='.db_input($var);
         elseif (is_string($var))
             $sql .= 'username='.db_input($var);
-        else
-            return null;
-
-        if(!($res=db_query($sql)) || !db_num_rows($res))
-            return NULL;
-
+            
+        if(!($res=db_query($sql)) || !db_num_rows($res)) {
+            $sql='SELECT staff.created as added, grp.*, staff.* '
+                .' FROM '.STAFF_TABLE.' staff '
+                .' LEFT JOIN '.GROUP_TABLE.' grp ON(grp.group_id=staff.group_id)
+                   WHERE username='.db_input($var);
+            if(!($res=db_query($sql)) || !db_num_rows($res))
+                return null;
+        }
 
         $this->ht=db_fetch_array($res);
         $this->id  = $this->ht['staff_id'];


### PR DESCRIPTION
If a staff's username contains only numbers, it may be misunderstood as internal ID. While this patch fixes #464 and allows users with numeric usernames to login, there may be a case where internal ID of one staff is username of other staff. TODO: Staff::load should accept another variable stating if var is internal ID or username or email.
