### PR TITLE
Recommend better permissions

### DIFF
--- a/setup/inc/install-done.inc.php
+++ b/setup/inc/install-done.inc.php
@@ -10,7 +10,7 @@ $url=URL;
         <h2>Config file permission:</h2>
         Change permission of ost-config.php to remove write access as shown below.
         <ul>
-            <li><b>CLI</b>:<br><i>chmod 0664  include/ost-config.php</i></li>
+            <li><b>CLI</b>:<br><i>chmod 0440  include/ost-config.php</i></li>
             <li><b>FTP</b>:<br>Using WS_FTP this would be right hand clicking on the file, selecting chmod, and then remove write access</li>
             <li><b>Cpanel</b>:<br>Click on the file, select change permission, and then remove write access.</li>
         </ul>


### PR DESCRIPTION
664 is not so great.

The "66" will allow the web server (or whoever owns the files) to write those files. The "4" is much worse as it allows anyone to read that configuration file which contains the database username and password.

Dangerous stuffs!

0440 should only allow the owner of the file (which must be the user php is running under) to read the file, and the zero should keep those passwords safe.
