### PR TITLE
Update class.mailfetch.php

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -267,7 +267,7 @@ class MailFetcher {
         if(!($headerinfo=imap_headerinfo($this->mbox, $mid)) || !$headerinfo->from)
             return null;
 
-        $sender=$headerinfo->from[0];
+        $sender=(isset($headerinfo->reply_to[0]))? $headerinfo->reply_to[0] : $headerinfo->from[0];
         //Just what we need...
         $header=array('name'  =>@$sender->personal,
                       'email'  => trim(strtolower($sender->mailbox).'@'.$sender->host),


### PR DESCRIPTION
Make mailfetch class to honor "reply_to", to answer emails, when it exists in the email header and use "from" only when "reply_to" is not there.
This change makes the osTicket compatible with Facebook notifications, for example.
