### PR TITLE
Add ability to audit failed logins attempts

### DIFF
--- a/scp/login.php
+++ b/scp/login.php
@@ -37,7 +37,7 @@ if($_POST) {
 }
 // Consider single sign-on authentication backends
 else if (!$thisstaff || !($thisstaff->getId() || $thisstaff->isValid())) {
-    if (($user = StaffAuthenticationBackend::processSignOn($errors))
+    if (($user = StaffAuthenticationBackend::processSignOn($errors, false))
             && ($user instanceof StaffSession))
        @header("Location: $dest");
 }


### PR DESCRIPTION
Separate authentication strike (excessive login attempts) count from timeout enforcement.

Addresses issue #549
