### PR TITLE
auth: Ensure session token is cleared on logout

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -314,6 +314,7 @@ abstract class StaffAuthenticationBackend  extends AuthenticationBackend {
         global $ost;
 
         $_SESSION['_auth']['staff'] = array();
+        unset($_SESSION[':token']['staff']);
         $ost->logDebug('Staff logout',
                 sprintf("%s logged out [%s]",
                     $staff->getUserName(),
@@ -430,6 +431,7 @@ abstract class UserAuthenticationBackend  extends AuthenticationBackend {
         global $ost;
 
         $_SESSION['_auth']['user'] = array();
+        unset($_SESSION[':token']['client']);
         $ost->logDebug('User logout',
                 sprintf("%s logged out [%s]",
                     $user->getUserName(), $_SERVER['REMOTE_ADDR']));

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -88,14 +88,14 @@ class osTicketSession {
                 list($this->data)=db_fetch_row($res);
             $this->id = $id;
         }
-        $this->data_hash = md5($this->data);
+        $this->data_hash = md5($id.$this->data);
         return $this->data;
     }
 
     function write($id, $data){
         global $thisstaff;
 
-        if (md5($data) == $this->data_hash)
+        if (md5($id.$data) == $this->data_hash)
             return;
 
         $ttl = ($this && get_class($this) == 'osTicketSession')

--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -114,9 +114,11 @@ class UserSession {
 class ClientSession extends EndUser {
 
     var $session;
+    var $token;
 
     function __construct($user) {
         parent::__construct($user);
+        $this->token = &$_SESSION[':token']['client'];
         // XXX: Change the key to user-id
         $this->session= new UserSession($user->getUserName());
     }
@@ -127,15 +129,15 @@ class ClientSession extends EndUser {
         if(!$this->getId() || $this->session->getSessionId()!=session_id())
             return false;
 
-        return $this->session->isvalidSession($_SESSION['_client']['token'],$cfg->getClientTimeout(),false)?true:false;
+        return $this->session->isvalidSession($this->token,$cfg->getClientTimeout(),false)?true:false;
     }
 
     function refreshSession(){
-        $time = $this->session->getLastUpdate($_SESSION['_client']['token']);
+        $time = $this->session->getLastUpdate($this->token);
         // Deadband session token updates to once / 30-seconds
         if (time() - $time < 30)
             return;
-        $_SESSION['_client']['token']=$this->getSessionToken();
+        $this->token = $this->getSessionToken();
         //TODO: separate expire time from hash??
     }
 
@@ -156,9 +158,11 @@ class ClientSession extends EndUser {
 class StaffSession extends Staff {
 
     var $session;
+    var $token;
 
     function __construct($var) {
         parent::__construct($var);
+        $this->token = &$_SESSION[':token']['staff'];
         $this->session= new UserSession($this->getId());
     }
 
@@ -168,16 +172,16 @@ class StaffSession extends Staff {
         if(!$this->getId() || $this->session->getSessionId()!=session_id())
             return false;
 
-        return $this->session->isvalidSession($_SESSION['_staff']['token'],$cfg->getStaffTimeout(),$cfg->enableStaffIPBinding())?true:false;
+        return $this->session->isvalidSession($this->token,$cfg->getStaffTimeout(),$cfg->enableStaffIPBinding())?true:false;
     }
 
     function refreshSession(){
-        $time = $this->session->getLastUpdate($_SESSION['_staff']['token']);
+        $time = $this->session->getLastUpdate($this->token);
         // Deadband session token updates to once / 30-seconds
         if (time() - $time < 30)
             return;
 
-        $_SESSION['_staff']['token']=$this->getSessionToken();
+        $this->token=$this->getSessionToken();
     }
 
     function getSession() {


### PR DESCRIPTION
### Outstanding
- [ ] Session tokens seem to get stuck (like from session timeout). They need to be cleaned up when no longer valid
