### PR TITLE
auth: Forbid password reset for non-local users

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -137,6 +137,10 @@ class Staff extends AuthenticatedUser {
         return $this->check_passwd($password, false);
     }
 
+    function hasPassword() {
+        return (bool) $this->ht['passwd'];
+    }
+
     function forcePasswdRest() {
         return db_query('UPDATE '.STAFF_TABLE.' SET change_passwd=1 WHERE staff_id='.db_input($this->getId()));
     }
@@ -862,6 +866,8 @@ class Staff extends AuthenticatedUser {
             if(isset($vars['change_passwd']))
                 $sql.=' ,change_passwd=1';
         }
+        elseif (!isset($vars['change_passwd']))
+            $sql .= ' ,change_passwd=0';
 
         if($id) {
             $sql='UPDATE '.STAFF_TABLE.' '.$sql.' WHERE staff_id='.db_input($id);

--- a/scp/pwreset.php
+++ b/scp/pwreset.php
@@ -36,7 +36,10 @@ if($_POST) {
     switch ($_POST['do']) {
         case 'sendmail':
             if (($staff=Staff::lookup($_POST['userid']))) {
-                if (!$staff->sendResetEmail()) {
+                if (!$staff->hasPassword()) {
+                    $msg = 'Unable to reset password. Contact your administrator';
+                }
+                elseif (!$staff->sendResetEmail()) {
                     $tpl = 'pwreset.sent.php';
                 }
             }


### PR DESCRIPTION
Also allow an administrator to lift the force password change flag without
specifying a new password.
