### PR TITLE
Careful transcoding attachments with a charset

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -370,7 +370,8 @@ class Mail_Parse {
                     'type'  => strtolower($part->ctype_primary.'/'.$part->ctype_secondary),
                     );
 
-            if ($part->ctype_parameters['charset'])
+            if ($part->ctype_parameters['charset']
+                    && 0 === strcasecmp($part->ctype_primary, 'text'))
                 $file['data'] = $this->mime_encode($part->body,
                     $part->ctype_parameters['charset']);
             else


### PR DESCRIPTION
If a non-text attachment specifies a charset in the content-type header, don't transcode the content before saving it to the database. This can corrupt attachments which have a header like the following:

`Content-Type: application/pdf; charset=UTF-8`

Since a PDF contains binary data, coercing it to UTF-8 encoding will drop characters not valid in UTF-8 and will corrupt the attachment data.
