### PR TITLE
Correctly process email tickets for existing users

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2284,7 +2284,7 @@ class Ticket {
         $number = Ticket::genRandTicketNumber();
         $sql='INSERT INTO '.TICKET_TABLE.' SET created=NOW() '
             .' ,lastmessage= NOW()'
-            .' ,user_id='.db_input($user->id)
+            .' ,user_id='.db_input($user->getId())
             .' ,`number`='.db_input($number)
             .' ,dept_id='.db_input($deptId)
             .' ,topic_id='.db_input($topicId)


### PR DESCRIPTION
If a ticket is created via email for an existing user, under some circumstances, no user will be associated with the new ticket.

Maybe fixes #526
