### PR TITLE
file: Fix saving backend char

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -295,7 +295,7 @@ class AttachmentFile {
         return false;
     }
 
-    function save(&$file, $ft=false) {
+    function save(&$file, $ft='T') {
 
         if (isset($file['data'])) {
             // Allow a callback function to delay or avoid reading or

--- a/include/upgrader/streams/core/15b30765-dd0022fb.task.php
+++ b/include/upgrader/streams/core/15b30765-dd0022fb.task.php
@@ -108,7 +108,7 @@ class AttachmentMigrater extends MigrationTask {
         }
         # TODO: Add extension-based mime-type lookup
 
-        if (!($fileId = AttachmentFile::save($info))) {
+        if (!($fileId = AttachmentFile::save($info, false))) {
             return $this->skip($info['attachId'],
                 sprintf('%s: Unable to migrate attachment', $info['path']));
         }


### PR DESCRIPTION
Because the file type normally defaults to the system default (for fetched emails at least), the backend char was not saved, because the file type char was left at the system default. Therefore, if a file is saved to a backend other than the default (in the database), the data will likely be saved to the backend, but the file metadata will reflect the incorrect backend.

The only reason the file type char was not defaulted in the `AttachmentFile::save()` method was for the migration process from osTicet 1.6 to osTicket 1.7. This is mitigated by passing `false` specifically from the migration task.

Since otherwise the file type char is now set, the backend char is now saved with the file metadata.
