### PR TITLE
Only add emailed collaborators if we have a positive match

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -38,7 +38,7 @@ class TicketApiController extends ApiController {
 
         if(!strcasecmp($format, 'email')) {
             $supported = array_merge($supported, array('header', 'mid',
-                'emailId', 'ticketId', 'reply-to', 'reply-to-name',
+                'emailId', 'to-email-id', 'ticketId', 'reply-to', 'reply-to-name',
                 'in-reply-to', 'references', 'thread-type',
                 'recipients' => array('*' => array('name', 'email', 'source'))
                 ));

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -604,8 +604,9 @@ class MailFetcher {
 
         $vars = $mailinfo;
         $vars['name'] = $mailinfo['name'];
-        $vars['subject'] = $mailinfo['subject'] ? $mailinfo['subject'] : '[No Subject]';
-        $vars['emailId'] = $mailinfo['emailId'] ? $mailinfo['emailId'] : $this->getEmailId();
+        $vars['subject'] = $mailinfo['subject'] ?: '[No Subject]';
+        $vars['emailId'] = $mailinfo['emailId'] ?: $this->getEmailId();
+        $vars['to-email-id'] = $mailinfo['emailId'] ?: 0;
 
         if ($this->isBounceNotice($mid)) {
             // Fetch the original References and assign to 'references'

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -596,6 +596,7 @@ class EmailDataParser {
         $data['header'] = $parser->getHeader();
         $data['mid'] = $parser->getMessageId();
         $data['priorityId'] = $parser->getPriority();
+        $data['to-email-id'] = $data['emailId'];
 
         if (($replyto = $parser->getReplyTo())) {
             $replyto = $replyto[0];

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1525,7 +1525,7 @@ class Ticket {
         //Add email recipients as collaborators...
         if ($vars['recipients']
                 //Only add if we have a matched local address
-                && $vars['emailId']) {
+                && $vars['to-email-id']) {
             //New collaborators added by other collaborators are disable --
             // requires staff approval.
             $info = array(


### PR DESCRIPTION
This is necessary to eliminate possible loop when an email is sent to a virtual/aliased address. Not all mail servers add delivered-to header!
