### PR TITLE
Use up-to-date user/staff name instead of poster when displaying ticket thread

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -291,7 +291,7 @@ class Ticket2PDF extends mPDF
                 $this->WriteCell($w/2, 7, Format::db_datetime($entry['created']), 'LTB', 0, 'L', true);
                 $this->SetFont('Arial', '', 10);
                 $this->WriteCell($w, 7, Format::truncate($entry['title'], 50), 'TB', 0, 'L', true);
-                $this->WriteCell($w/2, 7, $entry['poster'], 'TBR', 1, 'L', true);
+                $this->WriteCell($w/2, 7, $entry['name'] ?: $entry['poster'], 'TBR', 1, 'L', true);
                 $this->SetFont('');
                 $text= $entry['body'];
                 if($entry['attachments']

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -113,9 +113,17 @@ class Thread {
         if(!$order || !in_array($order, array('DESC','ASC')))
             $order='ASC';
 
-        $sql='SELECT thread.* '
+        $sql='SELECT thread.*
+               , COALESCE(user.name,
+                    IF(staff.staff_id,
+                        CONCAT_WS(" ", staff.firstname, staff.lastname),
+                        NULL)) as name '
             .' ,count(DISTINCT attach.attach_id) as attachments '
             .' FROM '.TICKET_THREAD_TABLE.' thread '
+            .' LEFT JOIN '.USER_TABLE.' user
+                ON (thread.user_id=user.id) '
+            .' LEFT JOIN '.STAFF_TABLE.' staff
+                ON (thread.staff_id=staff.staff_id) '
             .' LEFT JOIN '.TICKET_ATTACHMENT_TABLE.' attach
                 ON (thread.ticket_id=attach.ticket_id
                         AND thread.id=attach.ref_id) '

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -351,7 +351,7 @@ $tcount+= $ticket->getNumNotes();
                         <span style="vertical-align:middle;" class="textra"></span>
                         <span style="vertical-align:middle;"
                             class="tmeta faded title"><?php
-                            echo Format::htmlchars($entry['poster']); ?></span>
+                            echo Format::htmlchars($entry['name'] ?: $entry['poster']); ?></span>
                     </span>
                 </div>
                 </th>


### PR DESCRIPTION
Join to staff/user tables to get current name when fetching thread entries.
Update poster with the current name on delete
