### PR TITLE
Restrict access to closed tickets based on staff's access control.

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -106,10 +106,12 @@ class TicketsAjaxAPI extends AjaxController {
         $select = 'SELECT ticket.ticket_id';
         $from = ' FROM '.TICKET_TABLE.' ticket ';
         //Access control.
-        $where = ' WHERE ( ticket.staff_id='.db_input($thisstaff->getId());
+        $where = ' WHERE ( (ticket.staff_id='.db_input($thisstaff->getId())
+                    .' AND ticket.status="open" )';
 
         if(($teams=$thisstaff->getTeams()) && count(array_filter($teams)))
-            $where.=' OR ticket.team_id IN('.implode(',', db_input(array_filter($teams))).')';
+            $where.=' OR (ticket.team_id IN ('.implode(',', db_input(array_filter($teams)))
+                   .' ) AND ticket.status="open")';
 
         if(!$thisstaff->showAssignedOnly() && ($depts=$thisstaff->getDepts()))
             $where.=' OR ticket.dept_id IN ('.implode(',', db_input($depts)).')';

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1837,11 +1837,12 @@ class Ticket {
         if(!$staff || (!is_object($staff) && !($staff=Staff::lookup($staff))) || !$staff->isStaff())
             return null;
 
-        $where = array('ticket.staff_id='.db_input($staff->getId()));
+        $where = array('(ticket.staff_id='.db_input($staff->getId()) .' AND ticket.status="open")');
         $where2 = '';
 
         if(($teams=$staff->getTeams()))
-            $where[] = 'ticket.team_id IN('.implode(',', db_input(array_filter($teams))).')';
+            $where[] = ' ( ticket.team_id IN('.implode(',', db_input(array_filter($teams)))
+                        .') AND ticket.status="open")';
 
         if(!$staff->showAssignedOnly() && ($depts=$staff->getDepts())) //Staff with limited access just see Assigned tickets.
             $where[] = 'ticket.dept_id IN('.implode(',', db_input($depts)).') ';

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -61,13 +61,15 @@ $qwhere ='';
 
 $depts=$thisstaff->getDepts();
 $qwhere =' WHERE ( '
-        .'  ticket.staff_id='.db_input($thisstaff->getId());
+        .'  ( ticket.staff_id='.db_input($thisstaff->getId())
+        .' AND ticket.status="open")';
 
 if(!$thisstaff->showAssignedOnly())
     $qwhere.=' OR ticket.dept_id IN ('.($depts?implode(',', db_input($depts)):0).')';
 
 if(($teams=$thisstaff->getTeams()) && count(array_filter($teams)))
-    $qwhere.=' OR ticket.team_id IN('.implode(',', db_input(array_filter($teams))).') ';
+    $qwhere.=' OR (ticket.team_id IN ('.implode(',', db_input(array_filter($teams)))
+            .') AND ticket.status="open")';
 
 $qwhere .= ' )';
 


### PR DESCRIPTION
Background: osTicket allows access to assigned open tickets (both personal and team assignments) regardless of the staff's department and group. This is necessary to allow staff to work on tickets in an otherwise restricted department.

When a staff member closes a ticket, they're credited (ticket.staff_id is set to staff's id) for the purpose of showing who closed the ticket. osTicket mistakenly allowed continued access to closed tickets even when the staff doesn't have access to the ticket based on departmental access.
