### PR TITLE
oops: Enable adding collaborators from email

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -638,6 +638,7 @@ Class ThreadEntry {
             'ip' =>     '',
             'reply_to' => $this,
             'recipients' => $mailinfo['recipients'],
+            'to-email-id' => $mailinfo['to-email-id'],
         );
         $errors = array();
 


### PR DESCRIPTION
I'm thinking more and more that `$vars` in this context should start out as a copy of `$mailinfo`
