### PR TITLE
Remove assignment warning

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -540,8 +540,6 @@ if($cfg->showAnsweredTickets()) {
 }
 
 if($stats['assigned']) {
-    if(!$ost->getWarning() && $stats['assigned']>10)
-        $ost->setWarning($stats['assigned'].' tickets assigned to you! Do something about it!');
 
     $nav->addSubMenu(array('desc'=>'My Tickets ('.number_format($stats['assigned']).')',
                            'title'=>'Assigned Tickets',


### PR DESCRIPTION
The warning was meant to be humorous but apparently the world has no sense of humor.
