### PR TITLE
faq: Fix last modified time not to be midnight

### DIFF
--- a/include/staff/faq-category.inc.php
+++ b/include/staff/faq-category.inc.php
@@ -11,7 +11,7 @@ if(!defined('OSTSTAFFINC') || !$category || !$thisstaff) die('Access Denied');
 <div>
     <strong><?php echo $category->getName() ?></strong>
     <span>(<?php echo $category->isPublic()?'Public':'Internal'; ?>)</span>
-    <time>Last updated <?php echo Format::db_daydatetime($category->getUpdateDate()); ?></time>
+    <time>Last updated <?php echo Format::db_date($category->getUpdateDate()); ?></time>
 </div>
 <div class="cat-desc">
 <?php echo Format::display($category->getDescription()); ?>

--- a/include/staff/faq-view.inc.php
+++ b/include/staff/faq-view.inc.php
@@ -33,7 +33,7 @@ if($thisstaff->canManageFAQ()) {
     <?php echo ($topics=$faq->getHelpTopics())?implode(', ',$topics):' '; ?>
     </div>
 </p>
-<div class="faded">&nbsp;Last updated <?php echo Format::db_daydatetime($category->getUpdateDate()); ?></div>
+<div class="faded">&nbsp;Last updated <?php echo Format::db_daydatetime($faq->getUpdateDate()); ?></div>
 <hr>
 <?php
 if($thisstaff->canManageFAQ()) {


### PR DESCRIPTION
It was also the last-modified date of the category -- not the actual FAQ article itself

Fixes #136
