### PR TITLE
fix: Restrict access to closed tickets

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -151,9 +151,24 @@ class Ticket {
         if(!is_object($staff) && !($staff=Staff::lookup($staff)))
             return false;
 
-        return ((!$staff->showAssignedOnly() && $staff->canAccessDept($this->getDeptId()))
-                 || ($this->getTeamId() && $staff->isTeamMember($this->getTeamId()))
-                 || $staff->getId()==$this->getStaffId());
+        // Staff has access to the department.
+        if (!$staff->showAssignedOnly()
+                && $staff->canAccessDept($this->getDeptId()))
+            return true;
+
+        // Only consider assignment if the ticket is open
+        if (!$this->isOpen())
+            return false;
+
+        // Check ticket access based on direct or team assignment
+        if ($staff->getId() == $this->getStaffId()
+                || ($this->getTeamId()
+                    && $staff->isTeamMember($this->getTeamId())
+        ))
+            return true;
+
+        // No access bro!
+        return false;
     }
 
     function checkUserAccess($user) {


### PR DESCRIPTION
When checking ticket access - only consider assignment IF the ticket is open. This is required since staff_id field is overloaded to show who closed the ticket.
