### PR TITLE
Allow new ticket without required contact fields

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1918,18 +1918,25 @@ class Ticket {
         global $ost, $cfg, $thisclient, $_FILES;
 
         // Don't enforce form validation for email
-        $field_filter = function($f) use ($origin) {
-            // Ultimately, only offer validation errors for web for
-            // non-internal fields. For email, no validation can be
-            // performed. For other origins, validate as usual
-            switch (strtolower($origin)) {
-            case 'email':
-                return false;
-            case 'web':
-                return !$f->get('private');
-            default:
-                return true;
-            }
+        $field_filter = function($type) use ($origin) {
+            return function($f) use ($origin, $type) {
+                // Ultimately, only offer validation errors for web for
+                // non-internal fields. For email, no validation can be
+                // performed. For other origins, validate as usual
+                switch (strtolower($origin)) {
+                case 'email':
+                    return false;
+                case 'staff':
+                    // Required 'Contact Information' fields aren't required
+                    // when staff open tickets
+                    return $type != 'user'
+                        || in_array($f->get('name'), array('name','email'));
+                case 'web':
+                    return !$f->get('private');
+                default:
+                    return true;
+                }
+            };
         };
 
         //Check for 403
@@ -1967,7 +1974,7 @@ class Ticket {
                 $field->value = $field->parse($vars[$fname]);
         }
 
-        if (!$form->isValid($field_filter))
+        if (!$form->isValid($field_filter('ticket')))
             $errors += $form->errors();
 
         // Unpack dynamic variables into $vars for filter application
@@ -2045,7 +2052,7 @@ class Ticket {
             // account created or detected
             if (!$user) {
                 $user_form = UserForm::getUserForm()->getForm($vars);
-                if (!$user_form->isValid($field_filter)
+                if (!$user_form->isValid($field_filter('user'))
                         || !($user=User::fromForm($user_form->getClean())))
                     $errors['user'] = 'Incomplete client information';
             }


### PR DESCRIPTION
If a staff member creates a new ticket and cancels the user-lookup / create-new-user dialog, and the contact information form has a required field other than the name and email address fields, the ticket cannot be created because the required fields for new clients are not shown and can therefore not have a required value.

This patch allows new clients to be created without the required fields when the ticket is created by staff members.
