### PR TITLE
Support viewing tickets without a departments

### DIFF
--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -31,7 +31,7 @@ if(!$dept || !$dept->isPublic())
                 </tr>
                 <tr>
                     <th>Department:</th>
-                    <td><?php echo Format::htmlchars($dept->getName()); ?></td>
+                    <td><?php echo Format::htmlchars($dept instanceof Dept ? $dept->getName() : ''); ?></td>
                 </tr>
                 <tr>
                     <th>Create Date:</th>


### PR DESCRIPTION
This can happen when associated department is private and the system has no default department (which is possible with v1.6 upgrades)
