### PR TITLE
forms: Better failsafe for __toString

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -729,7 +729,8 @@ class DynamicFormEntryAnswer extends VerySimpleModel {
     }
 
     function __toString() {
-        return $this->toString();
+        $v = $this->toString();
+        return is_string($v) ? $v : (string) $this->getValue();
     }
 }
 


### PR DESCRIPTION
This mostly helps when fields change types. If the type of the field currently cannot convert previous data to a string (like if a short-answer field was changed to choices), the textual representation of the PHP value of the field data is given.

Fixes #652
