### PR TITLE
pwreset: Fixup password reset system

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -322,8 +322,6 @@ abstract class StaffAuthenticationBackend  extends AuthenticationBackend {
 
         Signal::send('auth.login.succeeded', $staff);
 
-        $staff->cancelResetTokens();
-
         return true;
     }
 

--- a/scp/pwreset.php
+++ b/scp/pwreset.php
@@ -53,8 +53,7 @@ if($_POST) {
             $errors = array();
             if ($staff = StaffAuthenticationBackend::processSignOn($errors)) {
                 $info = array('page' => 'index.php');
-                header('Location: '.$info['page']);
-                exit();
+                Http::redirect($info['page']);
             }
             elseif (isset($errors['msg'])) {
                 $msg = $errors['msg'];


### PR DESCRIPTION
Turns out that the new authentication system incorrectly cancels the reset tokens when it processes logins rather than after the user successfully resets his/her password
