### PR TITLE
html: Be careful not to strip too much

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -199,7 +199,7 @@ class Format {
     function safe_html($html) {
         // Remove HEAD and STYLE sections
         $html = preg_replace(
-            array(':<(head|style|script).+</\1>:is',   # <head> and <style> sections
+            array(':<(head|style|script).+?</\1>:is', # <head> and <style> sections
                   ':<!\[[^]<]+\]>:',            # <![if !mso]> and friends
                   ':<!DOCTYPE[^>]+>:',          # <!DOCTYPE ... >
                   ':<\?[^>]+>:',                # <?xml version="1.0" ... >


### PR DESCRIPTION
If there is content between to `<style>` elements, the content was previously stripped by Format::safe_html function. This patch adjusts the regex to strip tags such as `<head>`, `<script>` and `<style>` so that if content is found between two of them, it will be preserved.

Fixes #674
