### PR TITLE
Fix empty mails causing an error on every fetch.

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -534,6 +534,8 @@ class MailFetcher {
                 $body = new HtmlThreadBody($html);
             elseif ($text=$this->getPart($mid, 'text/plain', $this->charset))
                 $body = new TextThreadBody($text);
+            else
+                $body = new TextThreadBody('');
         }
         elseif ($text=$this->getPart($mid, 'text/plain', $this->charset))
             $body = new TextThreadBody($text);


### PR DESCRIPTION
Fix issue where fetched mail with no content could cause each fetch to fail with an error and, because the email wasn't deleted from the mailbox, the error would continue until the email was manualy deleted
