### PR TITLE
Allow regular staff members to show assigned open tickets on open queue

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -396,8 +396,7 @@ class Staff extends AuthenticatedUser {
     }
 
     function showAssignedTickets() {
-        return ($this->ht['show_assigned_tickets']
-                && ($this->isAdmin() || $this->isManager()));
+        return ($this->ht['show_assigned_tickets']);
     }
 
     function getTeams() {

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -193,9 +193,6 @@ $info['id']=$staff->getId();
                 &nbsp;<span class="error">&nbsp;<?php echo $errors['default_paper_size']; ?></span>
             </td>
         </tr>
-        <?php
-        //Show an option to show assigned tickets to admins & managers.
-        if($staff->isAdmin() || $staff->isManager()){ ?>
         <tr>
             <td>Show Assigned Tickets:</td>
             <td>
@@ -203,7 +200,6 @@ $info['id']=$staff->getId();
                 <em>Show assigned tickets on open queue.</em>
             </td>
         </tr>
-        <?php } ?>
         <tr>
             <th colspan="2">
                 <em><strong>Password</strong>: To reset your password, provide your current password and a new password below.&nbsp;<span class="error">&nbsp;<?php echo $errors['passwd']; ?></span></em>


### PR DESCRIPTION
Previously only admins and department managers could show assigned tickets on open queue -even- when the feature is disabled globally. This pull request extends the same privilege to all agents.
