### PR TITLE
Hide attachment links for inline images

### DIFF
--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -118,13 +118,14 @@ if($ticket->getThreadCount() && ($thread=$ticket->getClientThread())) {
                     && ($tentry=$ticket->getThreadEntry($entry['id']))
                     && ($urls = $tentry->getAttachmentUrls())
                     && ($links=$tentry->getAttachmentsLinks())) { ?>
+                <tr><td class="info"><?php echo $links; ?></td></tr>
+<?php       }
+            if ($urls) { ?>
                 <script type="text/javascript">
                     $(function() { showImagesInline(<?php echo
                         JsonDataEncoder::encode($urls); ?>); });
                 </script>
-                <tr><td class="info"><?php echo $links; ?></td></tr>
-            <?php
-            } ?>
+<?php       } ?>
         </table>
     <?php
     }

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -368,18 +368,20 @@ $tcount+= $ticket->getNumNotes();
                 echo Format::viewableImages(Format::display($entry['body'])); ?></div></td></tr>
             <?php
             if($entry['attachments']
-                    && ($tentry=$ticket->getThreadEntry($entry['id']))
+                    && ($tentry = $ticket->getThreadEntry($entry['id']))
                     && ($urls = $tentry->getAttachmentUrls())
-                    && ($links=$tentry->getAttachmentsLinks())) {?>
+                    && ($links = $tentry->getAttachmentsLinks())) {?>
             <tr>
-                <td class="info" colspan="4"><?php echo $links; ?></td>
+                <td class="info" colspan="4"><?php echo $tentry->getAttachmentsLinks(); ?></td>
+            </tr> <?php
+            }
+            if ($urls) { ?>
                 <script type="text/javascript">
                     $(function() { showImagesInline(<?php echo
                         JsonDataEncoder::encode($urls); ?>); });
                 </script>
-            </tr>
-            <?php
-            }?>
+<?php
+            } ?>
         </table>
         <?php
         if($entry['thread_type']=='M')


### PR DESCRIPTION
This patch allows detection of inline images and hides the download links for those images in the thread view. Starting from 1.8.0, images have a hover link for download, so there's no need for an extra one.
