### PR TITLE
Only attempt email link sign-on if tokens exist

### DIFF
--- a/view.php
+++ b/view.php
@@ -19,7 +19,9 @@ require_once('client.inc.php');
 // Try autologin the user
 // Authenticated user can be of type ticket owner or collaborator
 $errors = array();
-$user =  UserAuthenticationBackend::processSignOn($errors);
+if (isset($_GET['auth']) || isset($_GET['t']))
+    $user =  UserAuthenticationBackend::processSignOn($errors);
+
 if ($user && $user->getTicketId())
     Http::redirect('tickets.php?id='.$user->getTicketId());
 


### PR DESCRIPTION
If the `view.php` page is requested and an auth token is not present in the URL, do not attempt to sign the user on since it will always fail and will result in a false "Failed login attempt" warning to the system log.
