### PR TITLE
Relax detection of images for strip detection

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1282,7 +1282,7 @@ class ThreadBody /* extends SplString */ {
 
         // Capture a list of inline images
         $images_before = $images_after = array();
-        preg_match_all('/src="cid:([\w_-]+)(?:@|")/', $this->body, $images_before,
+        preg_match_all('/src=("|\'|\b)cid:(\S+)\1/', $this->body, $images_before,
             PREG_PATTERN_ORDER);
 
         // Strip the quoted part of the body
@@ -1291,10 +1291,10 @@ class ThreadBody /* extends SplString */ {
 
             // Capture a list of dropped inline images
             if ($images_before) {
-                preg_match_all('/src="cid:([\w_-]+)(?:@|")/', $this->body,
+                preg_match_all('/src=("|\'|\b)cid:(\S+)\1/', $this->body,
                     $images_after, PREG_PATTERN_ORDER);
-                $this->stripped_images = array_diff($images_before[1],
-                    $images_after[1]);
+                $this->stripped_images = array_diff($images_before[2],
+                    $images_after[2]);
             }
         }
     }


### PR DESCRIPTION
It is perfectectly fine to have an image cited in an HTML body similar to:

``` html
<img width=909 height=302 src=cid:image002.jpg@01CF5426.BF5A72A0 alt=image>
```

Which may or may not have quoted `@src` attribute, and may very well have an at sign (@) somewhere in the attribute text. The previous regular expression would not match such a `@src` attribute.
