### PR TITLE
Inline images in email without a 'cid:' indicator

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1048,7 +1048,7 @@ Class ThreadEntry {
                 // content-id will be discarded, only the unique hash-code
                 // will be available to retrieve the image later
                 if ($a['cid'] && $a['key']) {
-                    $body = preg_replace('/src=("|\'|\b)cid:'.$a['cid'].'\1/i',
+                    $body = preg_replace('/src=("|\'|\b)(?:cid:)?'.$a['cid'].'\1/i',
                         'src="cid:'.$a['key'].'"', $body);
                 }
             }


### PR DESCRIPTION
It is the defacto standard to reference an inline image in an email by referencing the Content-ID header of the referenced attachment in the `@src` attribute of the image. For instance, `<imc src="cid:image001.png">` where the `cid:` scheme of the attribute indicates that the referenced image URL is a separate content of the email. The image attached to the email would have an accompanying header like: `Content-Id: <image001.png>`. However, some mail systems, including a certain fax to email service, do not correctly indicate the location of the image with the content-id URL. Instead, the referenced image tag would be `<img src="image001.png">`

This patch addresses the issue by searching the message body for all references to attached content-id's in all `@src` attributes with or without the content-id URL scheme indicator. Previously, such images would not be displayed inline in the ticket thread.

References:
https://tools.ietf.org/html/rfc2392
