### PR TITLE
fix: User remote lookup on add new user

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -215,8 +215,9 @@ class UsersAjaxAPI extends AjaxController {
 
         $info['title'] = 'Add New User';
 
+        $info['lookup'] = 'remote';
         if (!AuthenticationBackend::getSearchDirectories())
-            $info['lookup'] = 'local';
+            $info['lookup'] = false;
 
         if ($_POST) {
             $form = UserForm::getUserForm()->getForm($_POST);


### PR DESCRIPTION
Don't show user search box, when adding a new user, if the system don't have remote directories installed
