### PR TITLE
storage: Avoid using `strlen` to count bytes

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -394,8 +394,9 @@ class AttachmentFile {
                 $file['size'] = $size;
             // Prefer mb_strlen, because mbstring.func_overload will
             // automatically prefer it if configured.
-            elseif (function_exists('mb_strlen'))
+            elseif (extension_loaded('mbstring'))
                 $file['size'] = mb_strlen($file['data'], '8bit');
+            // bootstrap.php include a compat version of mb_strlen
             else
                 $file['size'] = strlen($file['data']);
 

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -462,6 +462,7 @@ class MailFetcher {
                         array(
                             'name'  => $this->mime_decode($filename),
                             'type'  => $this->getMimeType($part),
+                            'size' => $part->bytes ?: null,
                             'encoding' => $part->encoding,
                             'index' => ($index?$index:1),
                             'cid'   => $content_id,

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -396,6 +396,13 @@ class Mail_Parse {
             else
                 $file['data'] = $part->body;
 
+            // Capture filesize in order to support de-duplication
+            if (extension_loaded('mbstring'))
+                $file['size'] = mb_strlen($file['data'], '8bit');
+            // bootstrap.php include a compat version of mb_strlen
+            else
+                $file['size'] = strlen($file['data']);
+
             if(!$this->decode_bodies && $part->headers['content-transfer-encoding'])
                 $file['encoding'] = $part->headers['content-transfer-encoding'];
 


### PR DESCRIPTION
For PHP installations that have `mbstring.func_overload` enabled (set to a value including `2`), the `strlen` function will be overloaded to use the `mb_strlen` equivalent. Problematically, the internal encoding of `UTF-8` will be applied to all file content, which will count UTF-8 characters rather than bytes. This will cause the data to be saved correctly; however, the `size` recorded in the %file table will be recorded incorrectly.

This patch allows the backend to report the size of the contents saved with the request and provides a failsafe mechanism which will use the mbstring equivalent if available, and the mbstring version is coded to use the `8bit` as the encoding which will prevent reading characters.

References:
https://github.com/osTicket/osTicket-1.8/issues/552
