### PR TITLE
Allow full HTML control for email template

### DIFF
--- a/include/class.template.php
+++ b/include/class.template.php
@@ -497,7 +497,7 @@ class EmailTemplate {
         if ($errors)
             return false;
 
-        $vars['body'] = Format::sanitize($vars['body'], false);
+		$vars['body'] = Format::sanitize($vars['body'], false, true);
 
         if ($id) {
             $sql='UPDATE '.EMAIL_TEMPLATE_TABLE.' SET updated=NOW() '

--- a/include/staff/tpl.inc.php
+++ b/include/staff/tpl.inc.php
@@ -105,7 +105,7 @@ $tpl=$msgtemplates[$selected];
                 </div>
                 <input type="hidden" name="draft_id" value=""/>
                 <textarea name="body" cols="21" rows="16" style="width:98%;" wrap="soft"
-                    class="richtext draft" data-draft-namespace="tpl.<?php echo $selected; ?>"
+                    class="richtext draft emailhtml" data-draft-namespace="tpl.<?php echo $selected; ?>"
                     data-draft-object-id="<?php echo $tpl_id; ?>"><?php echo $info['body']; ?></textarea>
             </td>
         </tr>

--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -225,6 +225,11 @@ $(function() {
                 'linebreaks': true,
                 'tabFocus': false
             };
+		if(el.hasClass('emailhtml')){
+            // For HTML in emails only deny SCRIPT and APPLET tags instead of the default list of tags:
+            // ["html", "head", "link", "body", "meta", "script", "style", "applet"]
+            options['deniedTags'] = ['script', 'applet'];
+        }
         if (el.data('redactor')) return;
         var reset = $('input[type=reset]', el.closest('form'));
         if (reset) {


### PR DESCRIPTION
These changes should help to fix #795 by reducing the level of sanitation applied to email templates.
