### PR TITLE
Change verbage displayed at templates.php to express 'sets'

### DIFF
--- a/include/staff/templates.inc.php
+++ b/include/staff/templates.inc.php
@@ -43,10 +43,10 @@ else
 ?>
 
 <div style="width:700px;padding-top:5px; float:left;">
- <h2>Email Templates</h2>
+ <h2>Email Template Sets</h2>
 </div>
 <div style="float:right;text-align:right;padding-top:5px;padding-right:5px;">
- <b><a href="templates.php?a=add" class="Icon newEmailTemplate">Add New Template</a></b></div>
+ <b><a href="templates.php?a=add" class="Icon newEmailTemplate">Add New Template Set</a></b></div>
 <div class="clear"></div>
 <form action="templates.php" method="POST" name="tpls">
  <?php csrf_token(); ?>


### PR DESCRIPTION
- Change the table header from `Email Templates` to
  `Email Template Sets`
- Change `Add New Template` to `Add New Template Set`

This removes any possible confusion for new users. Instead of
thinking that they have one template because it displays one
template set, the new verbage will clarify that the table
at templates.php is a list of their template sets.
