### PR TITLE
Show close date on closed tickets queue

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -855,7 +855,7 @@ class Ticket {
     //set status to open on a closed ticket.
     function reopen($isanswered=0) {
 
-        $sql='UPDATE '.TICKET_TABLE.' SET updated=NOW(), reopened=NOW() '
+        $sql='UPDATE '.TICKET_TABLE.' SET closed=NULL, updated=NOW(), reopened=NOW() '
             .' ,status='.db_input('open')
             .' ,isanswered='.db_input($isanswered)
             .' WHERE ticket_id='.db_input($this->getId());

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -229,7 +229,7 @@ $pageNav->setURL('tickets.php',$qstr.'&sort='.urlencode($_REQUEST['sort']).'&ord
 
 //ADD attachment,priorities, lock and other crap
 $qselect.=' ,IF(ticket.duedate IS NULL,IF(sla.id IS NULL, NULL, DATE_ADD(ticket.created, INTERVAL sla.grace_period HOUR)), ticket.duedate) as duedate '
-         .' ,CAST(GREATEST(IFNULL(ticket.lastmessage, 0), IFNULL(ticket.reopened, 0), ticket.created) as datetime) as effective_date '
+         .' ,CAST(GREATEST(IFNULL(ticket.lastmessage, 0), IFNULL(ticket.closed, 0), IFNULL(ticket.reopened, 0), ticket.created) as datetime) as effective_date '
          .' ,CONCAT_WS(" ", staff.firstname, staff.lastname) as staff, team.name as team '
          .' ,IF(staff.staff_id IS NULL,team.name,CONCAT_WS(" ", staff.lastname, staff.firstname)) as assigned '
          .' ,IF(ptopic.topic_pid IS NULL, topic.topic, CONCAT_WS(" / ", ptopic.topic, topic.topic)) as helptopic '


### PR DESCRIPTION
Consider close date when determining ticket's last activity date/time. The net effect is closed tickets queue gets sorted by closed date.
