### PR TITLE
Allow for duplicate tickets

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -303,6 +303,10 @@ class Dept {
         return $num;
     }
 
+    function __toString() {
+        return $this->getName();
+    }
+
     /*----Static functions-------*/
 	function getIdByName($name) {
         $id=0;

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -685,14 +685,14 @@ class MailFetcher {
             }
         }
 
-        $seen = false;
-        if (($thread = ThreadEntry::lookupByEmailHeaders($vars, $seen))
+        $vars['seen'] = false;
+        if (($thread = ThreadEntry::lookupByEmailHeaders($vars))
                 && ($message = $thread->postEmail($vars))) {
             if (!$message instanceof ThreadEntry)
                 // Email has been processed previously
                 return $message;
             $ticket = $message->getTicket();
-        } elseif ($seen) {
+        } elseif ($vars['seen']) {
             // Already processed, but for some reason (like rejection), no
             // thread item was created. Ignore the email
             return true;

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -288,35 +288,50 @@ class MailFetcher {
         // Put together a list of recipients
         $tolist = array();
 
-        //Add delivered-to address to list.
+        // Add delivered-to address to list first.
         if (stripos($header['header'], 'delivered-to:') !==false
                 && ($dt = Mail_Parse::findHeaderEntry($header['header'],
                      'delivered-to', true))) {
             if (($delivered_to = Mail_Parse::parseAddressList($dt)))
-                $tolist['delivered-to'] = $delivered_to;
+                $tolist['delivered-to'] = array_reverse($delivered_to);
         }
 
-        if($headerinfo->to)
+        if ($headerinfo->bcc)
+            $tolist['bcc'] = $headerinfo->bcc;
+
+        if ($headerinfo->to)
             $tolist['to'] = $headerinfo->to;
-        if($headerinfo->cc)
+        if ($headerinfo->cc)
             $tolist['cc'] = $headerinfo->cc;
 
         $header['recipients'] = array();
-        foreach($tolist as $source => $list) {
-            foreach($list as $addr) {
+        $fetchedEmailId = $this->getEmailId();
+        $systemEmails = array();
+        foreach ($tolist as $source => $list) {
+            foreach ($list as $addr) {
                 if (!($emailId=Email::getIdByEmail(strtolower($addr->mailbox).'@'.$addr->host))) {
                     //Skip virtual Delivered-To addresses
-                    if ($source == 'delivered-to') continue;
+                    if (in_array($source, array('delivered-to', 'bcc'))) continue;
 
                     $header['recipients'][] = array(
                             'source' => "Email ($source)",
                             'name' => $this->mime_decode(@$addr->personal),
                             'email' => strtolower($addr->mailbox).'@'.$addr->host);
-                } elseif(!$header['emailId']) {
-                    $header['emailId'] = $emailId;
+                } elseif (!$header['emailId']) {
+                    if ($source == 'delivered-to')
+                        $header['emailId'] = $emailId;
+                    elseif ($emailId == $fetchedEmailId)
+                        $header['emailId'] = $emailId;
                 }
+
+                $systemEmails[] = $emailId;
             }
         }
+
+        // Use the first system email if target is not set.
+        if (!$header['emailId'] && $systemEmails)
+            $header['emailId'] = $systemEmails[0];
+
 
         //See if any of the recipients is a delivered to address
         if ($tolist['delivered-to']) {
@@ -325,15 +340,6 @@ class MailFetcher {
                     if (strcasecmp($r['email'], $addr->mailbox.'@'.$addr->host) === 0)
                         $header['recipients'][$i]['source'] = 'delivered-to';
                 }
-            }
-        }
-
-        //BCCed?
-        if(!$header['emailId']) {
-            if ($headerinfo->bcc) {
-                foreach($headerinfo->bcc as $addr)
-                    if (($header['emailId'] = Email::getIdByEmail(strtolower($addr->mailbox).'@'.$addr->host)))
-                        break;
             }
         }
 

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -287,10 +287,6 @@ class MailFetcher {
 
         // Put together a list of recipients
         $tolist = array();
-        if($headerinfo->to)
-            $tolist['to'] = $headerinfo->to;
-        if($headerinfo->cc)
-            $tolist['cc'] = $headerinfo->cc;
 
         //Add delivered-to address to list.
         if (stripos($header['header'], 'delivered-to:') !==false
@@ -299,6 +295,11 @@ class MailFetcher {
             if (($delivered_to = Mail_Parse::parseAddressList($dt)))
                 $tolist['delivered-to'] = $delivered_to;
         }
+
+        if($headerinfo->to)
+            $tolist['to'] = $headerinfo->to;
+        if($headerinfo->cc)
+            $tolist['cc'] = $headerinfo->cc;
 
         $header['recipients'] = array();
         foreach($tolist as $source => $list) {

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -550,14 +550,14 @@ class EmailDataParser {
          */
 
         $tolist = array();
+        if (($dt = $parser->getDeliveredToAddressList()))
+            $tolist['delivered-to'] = $dt;
+
         if (($to = $parser->getToAddressList()))
             $tolist['to'] = $to;
 
         if (($cc = $parser->getCcAddressList()))
             $tolist['cc'] = $cc;
-
-        if (($dt = $parser->getDeliveredToAddressList()))
-            $tolist['delivered-to'] = $dt;
 
         foreach ($tolist as $source => $list) {
             foreach($list as $addr) {

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -542,16 +542,19 @@ class EmailDataParser {
                 $data['name'] = $data['email'];
         }
 
-        /* Scan through the list of addressees (via To, Cc, and Delivered-To headers), and identify
+        /* Scan through the list of addressees (via To, Cc, Bcc and Delivered-To headers), and identify
          * how the mail arrived at the system. One of the mails should be in the system email list.
-         * The recipient list (without the Delivered-To addressees) will be made available to the
+         * The recipient list (without the Delivered-To and BCC addressees) will be made available to the
          * ticket filtering system. However, addresses in the Delivered-To header should never be
          * considered for the collaborator list.
          */
 
         $tolist = array();
         if (($dt = $parser->getDeliveredToAddressList()))
-            $tolist['delivered-to'] = $dt;
+            $tolist['delivered-to'] = array_reverse($dt);
+
+        if (($bcc = $parser->getBccAddressList()))
+            $tolist['bcc'] = $bcc;
 
         if (($to = $parser->getToAddressList()))
             $tolist['to'] = $to;
@@ -563,7 +566,7 @@ class EmailDataParser {
             foreach($list as $addr) {
                 if (!($emailId=Email::getIdByEmail(strtolower($addr->mailbox).'@'.$addr->host))) {
                     //Skip virtual Delivered-To addresses
-                    if ($source == 'delivered-to') continue;
+                    if (in_array($source, array('delivered-to', 'bcc'))) continue;
 
                     $data['recipients'][] = array(
                         'source' => "Email ($source)",
@@ -590,17 +593,6 @@ class EmailDataParser {
             }
         }
 
-
-        //maybe we got BCC'ed??
-        if(!$data['emailId']) {
-            $emailId =  0;
-            if($bcc = $parser->getBccAddressList()) {
-                foreach ($bcc as $addr)
-                    if(($emailId=Email::getIdByEmail($addr->mailbox.'@'.$addr->host)))
-                        break;
-            }
-            $data['emailId'] = $emailId;
-        }
 
         if ($parser->isBounceNotice()) {
             // Fetch the original References and assign to 'references'

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -836,7 +836,7 @@ Class ThreadEntry {
                     // Ticket still exists
                     && ($ticket = $entry->getTicket())
                     // Duplicate email sent to 2 different  queues (email addresses)
-                    && ($ticket->getEmailId() != $mailinfo['emailId'])
+                    && ($ticket->getEmailChannelId() != $mailinfo['emailId'])
                     ) {
                 // Same email got sent to 2 different system emails we're
                 // fetching. Pretending as if we haven't seen the message b4
@@ -857,8 +857,8 @@ Class ThreadEntry {
                 $e = Email::lookup($mailinfo['emailId']);
                 $ticket->logNote(
                         'Duplicate Email',
-                        sprintf('Same email delivered to %s address',
-                            $e ? $e->getEmail() : 'another system'),
+                        'This email was also delivered to ' .
+                            ($e ? sprintf('the <%s> mailbox', $e->getEmail()) : 'another mailbox'),
                         'SYSTEM',
                         false);
             }

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -831,7 +831,7 @@ Class ThreadEntry {
             $entry = ThreadEntry::lookup($id);
 
             if ($entry // We found a thread entry
-                    //Lax matching - allow duplicates
+                    // Lax matching - allow duplicates
                     && !$strict
                     // Ticket still exists
                     && ($ticket = $entry->getTicket())
@@ -839,9 +839,28 @@ Class ThreadEntry {
                     && ($ticket->getEmailId() != $mailinfo['emailId'])
                     ) {
                 // Same email got sent to 2 different system emails we're
-                // fetching. Pretending as if we haven't seen the message
+                // fetching. Pretending as if we haven't seen the message b4
                 $entry = null;
                 $mailinfo['seen'] = false;
+
+                // Note for about to be created ticket
+                $mailinfo['note'] = array(
+                        'title' => 'Duplicate Ticket',
+                        'body' => new TextThreadBody(
+                            sprintf('Duplicate ticket #%s already exists in %s department',
+                                $ticket->getNumber(),
+                                $ticket->getDept())),
+                        'poster' => 'SYSTEM',
+                        'alert' => false);
+
+                // Log a note to existing ticket
+                $e = Email::lookup($mailinfo['emailId']);
+                $ticket->logNote(
+                        'Duplicate Email',
+                        sprintf('Same email delivered to %s address',
+                            $e ? $e->getEmail() : 'another system'),
+                        'SYSTEM',
+                        false);
             }
 
             return $entry;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2401,6 +2401,15 @@ class Ticket {
                 $ticket->assignToTeam($vars['teamId'], 'Auto Assignment');
         }
 
+        // Log a note (if any)
+        if (($note=$vars['note'])
+                // Make sure the note of interest is an array to distinguish
+                // it from internal note from staff created tickets
+                && is_array($note)) {
+            $ticket->logNote($note['title'], $note['body'], $note['poster'],
+                    $note['alert']);
+        }
+
         /**********   double check auto-response  ************/
         //Override auto responder if the FROM email is one of the internal emails...loop control.
         if($autorespond && (Email::getIdByEmail($ticket->getEmail())))

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -334,6 +334,10 @@ class Ticket {
         return $this->ht['ip_address'];
     }
 
+    function getEmailChannelId() {
+        return $this->ht['email_id'];
+    }
+
     function getHashtable() {
         return $this->ht;
     }


### PR DESCRIPTION
osTicket uses message-id to detect previously "seen" emails in order to prevent duplicate tickets from being created from a single email. This is necessary to avoid duplicate tickets when fetched emails are left in the INBOX.

The proposal will allows for less strict matching which can allow for duplicate tickets when an email is sent to multiple email queues.

__Use Case Scenario__:
 * We have multiple departments with strict access control on tickets
  e.g members of Billing department do not have access to tickets in Legal department
 * Joe sends an email to billing@company.com and legal@company.com (CC)
 * If a ticket gets created in Legal first (unpredictable - depends on which inbox gets processed first)
  - Billing department will be left in the dark
  - No way for legal to know that the same email was also addressed to Billing and vise versa

====
- [ ] Add setting to enable/disable the strict mode.
- [x] Log internal notes on duplicate tickets (?)