### PR TITLE
thread: Always embed HTML in email templates

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -776,7 +776,7 @@ Class ThreadEntry {
     }
 
     function asVar() {
-        return (string) $this;
+        return (string) $this->getBody()->display('html');
     }
 
     function getVar($tag) {
@@ -1379,6 +1379,11 @@ class TextThreadBody extends ThreadBody {
         default:
             return '<pre>'.$this->body.'</pre>';
         }
+    }
+
+    function asVar() {
+        // Email template, assume HTML
+        return $this->display('html');
     }
 }
 class HtmlThreadBody extends ThreadBody {


### PR DESCRIPTION
With the advent of 1.9, the original, plain text email is saved in the thread table. If a system has the HTML ticket thread enabled (which is the default), if the plain text message is placed in the email template (which is always HTML), it will not be formatted as correct HTML and the whitespace will be collapsed.

This patch addresses the issue by always returning HTML from the asVar() method, which is used to embed the thread post into a email template.
