### PR TITLE
thread: Detect inline and separate attachments

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1055,7 +1055,8 @@ Class ThreadEntry {
         //Emailed or API attachments
         if (isset($vars['attachments']) && $vars['attachments']) {
             foreach ($vars['attachments'] as &$a)
-                if (isset($a['cid']) && strpos($body, 'cid:'.$a['cid']) !== false)
+                if (isset($a['cid']) && $a['cid']
+                        && strpos($body, 'cid:'.$a['cid']) !== false)
                     $a['inline'] = true;
             unset($a);
 


### PR DESCRIPTION
If an email contains both inline and separate attachments, the previous logic would detect all the attachments as inline.

Separate attachments have the `cid` set to `false`. This will pass the `isset` test, which would cause the logic to search through the body for a string of `cid:`, which would very likely be found if there was another inline image somewhere in the body of the email.
