### PR TITLE
pjax: Fix confusing POST resubmit

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -663,6 +663,8 @@ $(document).on('pjax:complete', function() {
         $(this).remove();
     });
     $('#overlay').stop(false, true).hide().removeAttr('style');
+    // Drop previous POST data (if any)
+    window.location.href = window.location.href;
 });
 
 $(document).on('pjax:end', function() {


### PR DESCRIPTION
If an agent submits a page via a POST (like updating settings in the admin panel or creating a ticket) and navigates away via PJAX, if the browser refresh button were clicked sometime later, the browser would prompt the user to resubmit the POST data.

This patch avoids the issue by setting the browser's current URL to itself, which magically clears the POST data.

The proper fix for the issue would be with [Post/Redirect/Get](http://en.wikipedia.org/wiki/Post/Redirect/Get) method, which would redirect the browser to a page it could GET after a successful POST. Therefore a subsequent GET would reload the GET request, not the POST. However, that would be too much of an edit for now.

References:
http://stackoverflow.com/a/6077822/1025836
http://en.wikipedia.org/wiki/Post/Redirect/Get
