### PR TITLE
email: Don't sanitize and munge ws for emails

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -161,8 +161,6 @@ class Mailer {
                     && (!isset($options['reply-tag']) || $options['reply-tag']))
                 $message = "<div style=\"display:none\"
                     data-mid=\"$mid_token\">$tag<br/><br/></div>$message";
-            // Make sure nothing unsafe has creeped into the message
-            $message = Format::safe_html($message); //XXX??
             $txtbody = rtrim(Format::html2text($message, 90, false))
                 . ($mid_token ? "\nRef-Mid: $mid_token\n" : '');
             $mime->setTXTBody($txtbody);


### PR DESCRIPTION
If the HTML ticket thread is disabled, outgoing emails will have a text thread body placed inside an HTML template. The template and message are then sanitized and converted to text. However, htmLawed will munge the white space in the message before converting to text.

This patch disables sanitizing. I think it's fair to assume that the template and the message by the client or agent have been properly sanitized prior to sending out the email.
