### PR TITLE
pipe: Decode address lists names after parsing emails

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -40,7 +40,7 @@ class Mail_Parse {
             $this->charset = $charset;
 
         $this->include_bodies = true;
-        $this->decode_headers = true;
+        $this->decode_headers = false;
         $this->decode_bodies = true;
 
         //Desired charset
@@ -233,7 +233,7 @@ class Mail_Parse {
     }
 
     function getSubject(){
-        return $this->struct->headers['subject'];
+        return Format::mimedecode($this->struct->headers['subject'], $this->charset);
     }
 
     function getReplyTo() {
@@ -486,6 +486,10 @@ class Mail_Parse {
 
         if(PEAR::isError($parsed))
             return array();
+
+        foreach ($parsed as $p) {
+            $p->personal = Format::mimedecode($p->personal, $this->charset);
+        }
         return $parsed;
     }
 


### PR DESCRIPTION
Otherwise, if a decoded email name has a comma in it, for instance

```
From: =?utf-8?B?RnJ5ZGVubHVuZCBIeW3DuGxsZXIsIEJldHRpbmE=?=
    <bettina.frydenlundhymoller@domain.com>
```

The address list will be parsed incorrectly since the comma has an ambiguous significance. Usually, the personal name would be quoted; however, since it is encoded, there is no need to quote it.
