### PR TITLE
forms: Add concept of inline form fields

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -140,6 +140,7 @@ class FormField {
             'bool' => array('Checkbox', 'BooleanField'),
             'choices' => array('Choices', 'ChoiceField'),
             'break' => array('Section Break', 'SectionBreakField'),
+            'inline' => array('Inline Form', 'InlineFormField'),
         ),
     );
     static $more_types = array();
@@ -941,6 +942,113 @@ FormField::addFieldTypes('Built-in Lists', function() {
     );
 });
 
+class InlineFormData extends ArrayObject {
+    var $_form;
+
+    function __construct($form, array $data=array()) {
+        parent::__construct($data);
+        $this->_form = $form;
+    }
+
+    function getVar($tag) {
+        foreach ($this->_form->getFields() as $f) {
+            if ($f->get('name') == $tag)
+                return $this[$f->get('id')];
+        }
+    }
+}
+
+
+class InlineFormField extends FormField {
+    static $widget = 'InlineFormWidget';
+
+    var $_iform = null;
+
+    function validateEntry($value) {
+        if (!$this->getInlineForm()->isValid()) {
+            $this->_errors[] = 'Correct errors in the inline form';
+        }
+    }
+
+    function parse($value) {
+        // The InlineFieldWidget returns an array of cleaned data
+        return $value;
+    }
+
+    function to_database($value) {
+        return JsonDataEncoder::encode($value);
+    }
+
+    function to_php($value) {
+        $data = JsonDataParser::decode($value);
+        // The InlineFormData helps with the variable replacer API
+        return new InlineFormData($this->getInlineForm(), $data);
+    }
+
+    function display($data) {
+        $form = $this->getInlineForm();
+        ob_start(); ?>
+        <div><?php
+        foreach ($form->getFields() as $field) { ?>
+            <span style="display:inline-block;padding-right:5px;vertical-align:top">
+                <strong><?php echo Format::htmlchars($field->get('label')); ?></strong>
+                <div><?php
+                    $value = $data[$field->get('id')];
+                    echo $field->display($value); ?></div>
+            </span><?php
+        } ?>
+        </div><?php
+        return ob_get_clean();
+    }
+
+    function getInlineForm($data=false) {
+        if (!isset($this->_iform) || $data) {
+            $config = $this->getConfiguration();
+            $this->_iform = DynamicForm::lookup($config['form']);
+            if ($data)
+                $this->_iform = $this->_iform->getForm($data);
+        }
+        return $this->_iform;
+    }
+
+    function getConfigurationOptions() {
+        $forms = DynamicForm::objects()->filter(array('type'=>'G'));
+        $choices = array();
+        foreach ($forms as $f) {
+            $choices[$f->id] = $f->title;
+        }
+        return array(
+            'form' => new ChoiceField(array(
+                'id'=>2, 'label'=>'Inline Form', 'required'=>true,
+                'default'=>'', 'choices'=>$choices
+            )),
+        );
+    }
+}
+
+class InlineFormWidget extends Widget {
+    function render($mode=false) {
+        $form = $this->field->getInlineForm();
+        if (!$form)
+            return;
+        // Handle first-step edits -- load data from $this->value
+        if ($form instanceof DynamicForm && !$form->getSource())
+            $form = $form->getForm($this->value);
+        $inc = ($mode == 'client') ? CLIENTINC_DIR : STAFFINC_DIR;
+        include $inc . 'templates/inline-form.tmpl.php';
+    }
+
+    function getValue() {
+        $data = $this->field->getSource();
+        if (!$data)
+            return null;
+        $form = $this->field->getInlineForm($data);
+        if (!$form)
+            return null;
+        return $form->getClean();
+    }
+}
+
 class Widget {
 
     function __construct($field) {
@@ -963,6 +1071,8 @@ class Widget {
             return $data[$this->name];
         elseif (isset($data[$this->field->get('name')]))
             return $data[$this->field->get('name')];
+        elseif (isset($data[$this->field->get('id')]))
+            return $data[$this->field->get('id')];
         return null;
     }
 }

--- a/include/client/templates/inline-form.tmpl.php
+++ b/include/client/templates/inline-form.tmpl.php
@@ -1,0 +1,24 @@
+<div><?php
+foreach ($form->getFields() as $field) { ?>
+    <span style="display:inline-block;padding-right:5px;vertical-align:top">
+        <span class="<?php if ($field->get('required')) echo 'required'; ?>">
+            <?php echo Format::htmlchars($field->get('label')); ?></span>
+        <div><?php
+        $field->render(); ?>
+        <?php if ($field->get('required')) { ?>
+            <span class="error">*</span>
+        <?php
+        }
+        if ($field->get('hint') && !$field->isBlockLevel()) { ?>
+            <br/><em style="color:gray;display:inline-block"><?php
+                echo Format::htmlchars($field->get('hint')); ?></em>
+        <?php
+        }
+        foreach ($field->errors() as $e) { ?>
+            <br />
+            <span class="error"><?php echo Format::htmlchars($e); ?></span>
+        <?php } ?>
+        </div>
+    </span><?php
+} ?>
+</div>

--- a/include/staff/templates/inline-form.tmpl.php
+++ b/include/staff/templates/inline-form.tmpl.php
@@ -1,0 +1,24 @@
+<div><?php
+foreach ($form->getFields() as $field) { ?>
+    <span style="display:inline-block;padding-right:5px;vertical-align:top">
+        <span class="<?php if ($field->get('required')) echo 'required'; ?>">
+            <?php echo Format::htmlchars($field->get('label')); ?></span>
+        <div><?php
+        $field->render(); ?>
+        <?php if ($field->get('required')) { ?>
+            <span class="error">*</span>
+        <?php
+        }
+        if ($field->get('hint') && !$field->isBlockLevel()) { ?>
+            <br/><em style="color:gray;display:inline-block"><?php
+                echo Format::htmlchars($field->get('hint')); ?></em>
+        <?php
+        }
+        foreach ($field->errors() as $e) { ?>
+            <br />
+            <span class="error"><?php echo Format::htmlchars($e); ?></span>
+        <?php } ?>
+        </div>
+    </span><?php
+} ?>
+</div>


### PR DESCRIPTION
In-line forms are forms that are rendered as one field. The data of the inline form is also saved in the data for one field. Currently, the data is rendered to JSON and stashed in the database.

The data in the field is also accessible via the variable replacement system, so something line `%{ticket.field.subfield}` can be handled by the inline form field.
### Outstanding
- [ ] In-Code documentation of new classes
- [ ] PDF printing for inline fields
- [ ] Ensure behavior of internal fields for clients
- [ ] Add filtering capability for inline form fields
### Screenshot Tour
#### Form Edit

![screen shot 2014-05-26 at 09 07 48](https://cloud.githubusercontent.com/assets/672074/3083210/3656ab28-e4df-11e3-8696-0058e69bc139.png)
#### Field Configuration

![screen shot 2014-05-26 at 09 08 00](https://cloud.githubusercontent.com/assets/672074/3083209/31245934-e4df-11e3-8217-0d1bfec755b7.png)
#### Display for Agents

![screen shot 2014-05-26 at 09 06 37](https://cloud.githubusercontent.com/assets/672074/3083196/07159a4a-e4df-11e3-9f32-6306c6d93253.png)
#### Edit for Agents

![screen shot 2014-05-26 at 09 07 32](https://cloud.githubusercontent.com/assets/672074/3083211/3a842a4a-e4df-11e3-85e4-04019ec28ff2.png)
#### Display for Clients

![screen shot 2014-05-26 at 09 12 04](https://cloud.githubusercontent.com/assets/672074/3083249/f65e27e8-e4df-11e3-83da-2e71bbe9e933.png)
#### Edit for Clients

![screen shot 2014-05-26 at 09 13 07](https://cloud.githubusercontent.com/assets/672074/3083251/0170acbe-e4e0-11e3-93fa-fd1a32d5d42c.png)
