### PR TITLE
orgs: Allow inline edit, change, and creation

### DIFF
--- a/include/staff/templates/org.tmpl.php
+++ b/include/staff/templates/org.tmpl.php
@@ -14,9 +14,10 @@ if ($info['error']) {
 <div id="org-profile" style="display:<?php echo $forms ? 'none' : 'block'; ?>;margin:5px;">
     <i class="icon-group icon-4x pull-left icon-border"></i>
     <?php
-    if ($account) { ?>
+    if ($user) { ?>
     <a class="action-button pull-right user-action" style="overflow:inherit"
-        href="#users/<?php echo $account->getUserId(); ?>/org/<?php echo $org->getId(); ?>" ><i class="icon-user"></i> Change Organization</a>
+        href="#users/<?php echo $user->getId(); ?>/org/<?php echo $org->getId(); ?>" ><i class="icon-user"></i> Change</a>
+    <a class="action-button pull-right" href="orgs.php?id=<?php echo $org->getId(); ?>"><i class="icon-share"></i> Manage</a>
     <?php
     } ?>
     <div><b><a href="#" id="editorg"><i class="icon-edit"></i>&nbsp;<?php

--- a/include/staff/user-view.inc.php
+++ b/include/staff/user-view.inc.php
@@ -84,8 +84,8 @@ $org = $user->getOrganization();
                         <span id="user-<?php echo $user->getId(); ?>-org">
                         <?php
                             if ($org)
-                                echo sprintf('<a href="orgs.php?id=%d">%s</a>',
-                                        $org->getId(), $org->getName());
+                                echo sprintf('<a href="#users/%d/org" class="user-action">%s</a>',
+                                        $user->getId(), $org->getName());
                             else
                                 echo sprintf('<a href="#users/%d/org"
                                         class="user-action">Add Organization</a>',


### PR DESCRIPTION
On the user profile page, the link to view the organization now triggers a popup dialog which allows for changing and editing the organization directly from the user profile page. An additional [Manage] button is added to the dialog to allow redirect access to the organization page.
