### PR TITLE
Use `reply-to` header as ticket's email

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -283,6 +283,7 @@ class MailFetcher {
         if ($replyto = $headerinfo->reply_to) {
             $header['reply-to'] = $replyto[0]->mailbox.'@'.$replyto[0]->host;
             $header['reply-to-name'] = $replyto[0]->personal;
+            $header['email']=$header['reply-to'];
         }
 
         // Put together a list of recipients


### PR DESCRIPTION
In case when client's mails are sended via web from corporate mail (robot@company.name)  to support team - it's important to isolate each user's ticket one from another.
