### PR TITLE
Retire canned response append checkbox on ticket reply.

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -515,8 +515,6 @@ $tcount+= $ticket->getNumNotes();
                             }
                             ?>
                         </select>
-                        &nbsp;&nbsp;&nbsp;
-                        <label><input type='checkbox' value='1' name="append" id="append" checked="checked"> Append</label>
                         <br>
                     <?php
                     }
@@ -539,7 +537,7 @@ $tcount+= $ticket->getNumNotes();
                         placeholder="Start writing your response here. Use canned responses from the drop-down above"
                         data-draft-object-id="<?php echo $ticket->getId(); ?>"
                         rows="9" wrap="soft"
-                        class="richtext ifhtml draft"><?php
+                        class="richtext ifhtml draft draft-delete"><?php
                         echo $info['response']; ?></textarea>
                 </td>
             </tr>
@@ -647,7 +645,7 @@ $tcount+= $ticket->getNumNotes();
                         placeholder="Note details"
                         rows="9" wrap="soft" data-draft-namespace="ticket.note"
                         data-draft-object-id="<?php echo $ticket->getId(); ?>"
-                        class="richtext ifhtml draft"><?php echo $info['note'];
+                        class="richtext ifhtml draft draft-delete"><?php echo $info['note'];
                         ?></textarea>
                         <span class="error"><?php echo $errors['note']; ?></span>
                         <br>

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -213,18 +213,11 @@ var scp_prep = function() {
                     var box = $('#response',fObj),
                         redactor = box.data('redactor');
                     if(canned.response) {
-                        if($('#append',fObj).is(':checked') &&  $('#response',fObj).val()) {
-                            if (redactor)
-                                redactor.insertHtml(canned.response);
-                            else
-                                box.val(box.val() + canned.response);
-                        }
-                        else {
-                            if (redactor)
-                                redactor.set(canned.response);
-                            else
-                                box.val(canned.response);
-                        }
+                        if (redactor)
+                            redactor.insertHtml(canned.response);
+                        else
+                            box.val(box.val() + canned.response);
+
                         if (redactor)
                             redactor.observeStart();
                     }


### PR DESCRIPTION
The default mode going forward will be to insert when Rich Text support is enabled and append otherwise. To clear the draft the user can simply click reset or delete draft icon on the bar.

For consistency, enable delete draft option on reply & internal note boxes.
