### PR TITLE
Display external images and original links on thanks

### DIFF
--- a/open.php
+++ b/open.php
@@ -69,8 +69,8 @@ if($ticket
             (($topic = $ticket->getTopic()) && ($page = $topic->getPage()))
             || ($page = $cfg->getThankYouPage())
         )) {
-    //Thank the user and promise speedy resolution!
-    echo Format::display($ticket->replaceVars($page->getBody()));
+    // Thank the user and promise speedy resolution!
+    echo Format::viewableImages($ticket->replaceVars($page->getBody()));
 }
 else {
     require(CLIENTINC_DIR.'open.inc.php');


### PR DESCRIPTION
Previously, external images were mucked up and links were routed through l.php, which requires a client sign in. If a client were not signed in when creating a ticket. The links would not work correctly.

Fixes #994
