### PR TITLE
Users can visit more than one ticket via link

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -599,15 +599,8 @@ abstract class UserAuthenticationBackend  extends AuthenticationBackend {
                 throw new AccessDenied('Account is administratively locked');
         }
 
-        //Tag the authkey.
-        $authkey = $bk::$id.':'.$authkey;
-
-        //Set the session goodies
-        $authsession = &$_SESSION['_auth']['user'];
-
-        $authsession = array(); //clear.
-        $authsession['id'] = $user->getId();
-        $authsession['key'] = $authkey;
+        // Tag the user and associated ticket in the SESSION
+        $this->setAuthKey($user, $bk, $authkey);
 
         //The backend used decides the format of the auth key.
         // XXX: encrypt to hide the bk??
@@ -629,6 +622,20 @@ abstract class UserAuthenticationBackend  extends AuthenticationBackend {
             $acct->cancelResetTokens();
 
         return true;
+    }
+
+    function setAuthKey($user, $bk, $key=false) {
+        $authkey = $key ?: $bk->getAuthKey($user);
+
+        //Tag the authkey.
+        $authkey = $bk::$id.':'.$authkey;
+
+        //Set the session goodies
+        $authsession = &$_SESSION['_auth']['user'];
+
+        $authsession = array(); //clear.
+        $authsession['id'] = $user->getId();
+        $authsession['key'] = $authkey;
     }
 
     function authenticate($username, $password) {

--- a/view.php
+++ b/view.php
@@ -23,6 +23,11 @@ if ($_GET['auth']
         && ($u = TicketUser::lookupByToken($_GET['auth']))
         && ($u->getUserId() == $thisclient->getId())
 ) {
+    // Switch auth keys ? (Otherwise the user can never use links for two
+    // different tickets)
+    if (($bk = $thisclient->getAuthBackend()) instanceof AuthTokenAuthentication) {
+        $bk->setAuthKey($u, $bk);
+    }
     Http::redirect('tickets.php?id='.$u->getTicketId());
 }
 // Try autologin the user


### PR DESCRIPTION
Previously, once a client was authenticated to the system with an email link, the user could utilize other email links to other tickets; however, the same ticket page would be presented to the user regardless of which link was utilized.

This patch allows the ticket in focus for the user to be changed after visiting the client portal with a different ticket link.
