### PR TITLE
forms: Fix corruption of company name on new ticket

### DIFF
--- a/include/class.company.php
+++ b/include/class.company.php
@@ -48,7 +48,7 @@ class Company {
     }
 
     function getInfo() {
-        return $this->getForm()->getClean();
+        return $this->getForm()->getSaved();
     }
 
     function getName() {

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -546,6 +546,16 @@ class DynamicFormEntry extends VerySimpleModel {
         return $this->_clean;
     }
 
+    function getSaved() {
+        $info = array();
+        foreach ($this->getAnswers() as $a) {
+            $field = $a->getField();
+            $info[$field->get('id')]
+                = $info[$field->get('name')] = $a->getValue();
+        }
+        return $info;
+    }
+
     function forTicket($ticket_id, $force=false) {
         static $entries = array();
         if (!isset($entries[$ticket_id]) || $force)


### PR DESCRIPTION
New ticket by staff would cause the %{company.name} variable to be incorrectly replaced as the user's name in email templates.
