### PR TITLE
Partially revert 37b8d549d610c

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -41,7 +41,7 @@ class DynamicForm extends VerySimpleModel {
     var $_form;
     var $_fields;
     var $_has_data = false;
-    var $_dfields = array();
+    var $_dfields;
 
     function getFields($cache=true) {
         if (!isset($this->_fields) || !$cache) {


### PR DESCRIPTION
That patch introduced a bug where the list of dynamic fields for a form is always empty

Fixes #979
