### PR TITLE
orm: Fix issues surrounding MySQL commands OoS

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -220,8 +220,7 @@ class UserForm extends DynamicForm {
 
     static function getUserForm() {
         if (!isset(static::$form)) {
-            $o = static::objects();
-            static::$form = $o[0];
+            static::$form = static::objects()->one();
         }
         return static::$form;
     }
@@ -233,8 +232,8 @@ class UserForm extends DynamicForm {
     }
 
     static function getNewInstance() {
-        $o = static::objects();
-        static::$instance = $o[0]->instanciate();
+        $o = static::objects()->one();
+        static::$instance = $o->instanciate();
         return static::$instance;
     }
 }
@@ -263,8 +262,8 @@ class TicketForm extends DynamicForm {
     }
 
     static function getNewInstance() {
-        $o = static::objects();
-        static::$instance = $o[0]->instanciate();
+        $o = static::objects()->one();
+        static::$instance = $o->instanciate();
         return static::$instance;
     }
 
@@ -1094,6 +1093,8 @@ class SelectionField extends FormField {
     }
 
     function to_php($value, $id=false) {
+        if ($value === null && $id === null)
+            return null;
         if ($id && is_int($id))
             $item = DynamicListItem::lookup($id);
         # Attempt item lookup by name too


### PR DESCRIPTION
Several places in the code initialize a list of objects from the database and only fetch one item. In certain instances (which seem almost like a race condition), MySQL will feel like there are more records available in the database and will complain with "Commands out of sync, you can't run the command now".

This patch addresses the issue by utilizing the ::one() method of the QuerySet where only one record is expected. The ::one() method is further designed to fetch all one results (which satisfies the MySQL client library) and return the first item.
