### PR TITLE
Fix dialog boxes on backward pjax navigation

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -441,7 +441,7 @@ var scp_prep = function() {
 };
 
 $(document).ready(scp_prep);
-$(document).on('pjax:complete', scp_prep);
+$(document).on('pjax:end', scp_prep);
 $(document).on('submit', 'form', function() {
     // Reformat dates
     $('.dp', $(this)).each(function(i, e) {


### PR DESCRIPTION
`pjax:complete` is only called after an AJAX page load. If a user navigates forward or backward and the page loads from local cache, then `pjax:complete` is not fired. `pjax:end`, however, is always fired.

Fixes #916
