### PR TITLE
emails: Allow selection of default prio and dept

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -292,10 +292,6 @@ class Email {
                 $errors['mail_fetchfreq']='Fetch interval required';
             if(!$vars['mail_fetchmax'] || !is_numeric($vars['mail_fetchmax']))
                 $errors['mail_fetchmax']='Maximum emails required';
-            if(!$vars['dept_id'] || !is_numeric($vars['dept_id']))
-                $errors['dept_id']='You must select a Dept.';
-            if(!$vars['priority_id'])
-                $errors['priority_id']='You must select a priority';
 
             if(!isset($vars['postfetch']))
                 $errors['postfetch']='Indicate what to do with fetched emails';

--- a/include/staff/emails.inc.php
+++ b/include/staff/emails.inc.php
@@ -69,6 +69,9 @@ else
         $total=0;
         $ids=($errors && is_array($_POST['ids']))?$_POST['ids']:null;
         if($res && db_num_rows($res)):
+            $defaultDeptId = $cfg->getDefaultDeptId();
+            $defaultDept = $cfg->getDefaultDept();
+            $defaultPriority = $cfg->getDefaultPriority();
             $defaultId=$cfg->getDefaultEmailId();
             while ($row = db_fetch_array($res)) {
                 $sel=false;
@@ -76,8 +79,15 @@ else
                     $sel=true;
                 $default=($row['email_id']==$defaultId);
                 $email=$row['email'];
-                if($row['name'])
+                if ($row['name'])
                     $email=$row['name'].' <'.$row['email'].'>';
+                if (!$row['dept_id']) {
+                    $row['dept_id'] = $defaultDeptId;
+                    $row['department'] = $defaultDept->getName();
+                }
+                if (!$row['priority']) {
+                    $row['priority'] = $defaultPriority->getDesc();
+                }
                 ?>
             <tr id="<?php echo $row['email_id']; ?>">
                 <td width=7px>


### PR DESCRIPTION
When the system default department and priority selections were enabled to be set for an email address, the validation check was left behind to ensure non-default values were set on save
