### PR TITLE
Fixing ticket search when dates are in the future

### DIFF
--- a/scp/js/dashboard.inc.js
+++ b/scp/js/dashboard.inc.js
@@ -249,7 +249,7 @@
 
                 // ------------------------> Export <-----------------------
                 $('<a>').attr({'href':'ajax.php/report/overview/table/export?group='
-                        +group+'&start='+start+'&stop='+stop}).append('Export')
+                        +group+'&start='+start+'&stop='+stop, 'class':'no-pjax'}).append('Export')
                     .appendTo($('<li>')
                     .appendTo(p));
 


### PR DESCRIPTION
force ticket search result to null when input dates (startTime & endTime) are in the future or startTime > endTime
