### PR TITLE
forms: Kinda fix clobbering for custom ticket data

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -110,7 +110,8 @@ class Ticket {
             foreach (DynamicFormEntry::forTicket($this->getId(), true) as $form)
                 foreach ($form->getAnswers() as $answer)
                     if ($tag = mb_strtolower($answer->getField()->get('name')))
-                        $this->_answers[$tag] = $answer;
+                        if (!isset($this->_answers[$tag]))
+                            $this->_answers[$tag] = $answer;
         }
     }
 


### PR DESCRIPTION
If a ticket has multiple forms, and more than one specifies a particular field variable, such as `priority`, the system may crash when rending the ticket-view page. Previously, the last form processed to define a particular field name was used. This patch changes the behavior to use the first.
