### PR TITLE
lists: Don't crash rendering a selection

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1227,8 +1227,8 @@ class SelectionField extends FormField {
             foreach ($this->getList()->getItems() as $i)
                 $this->_choices[$i->get('id')] = $i->get('value');
             if ($this->value && !isset($this->_choices[$this->value])) {
-                $v = DynamicListItem::lookup($this->value);
-                $this->_choices[$v->get('id')] = $v->get('value').' (Disabled)';
+                if ($v = DynamicListItem::lookup($this->value))
+                    $this->_choices[$v->get('id')] = $v->get('value').' (Disabled)';
             }
         }
         return $this->_choices;


### PR DESCRIPTION
This patch fixes an issue where a fatal error would be triggered if the current value of a selection field on a custom form was a custom list item that has since been deleted.
