### PR TITLE
email: Setting default for priority and department

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -292,10 +292,6 @@ class Email {
                 $errors['mail_fetchfreq']='Fetch interval required';
             if(!$vars['mail_fetchmax'] || !is_numeric($vars['mail_fetchmax']))
                 $errors['mail_fetchmax']='Maximum emails required';
-            if(!$vars['dept_id'] || !is_numeric($vars['dept_id']))
-                $errors['dept_id']='You must select a Dept.';
-            if(!$vars['priority_id'])
-                $errors['priority_id']='You must select a priority';
 
             if(!isset($vars['postfetch']))
                 $errors['postfetch']='Indicate what to do with fetched emails';

--- a/include/staff/emails.inc.php
+++ b/include/staff/emails.inc.php
@@ -41,6 +41,10 @@ if($res && ($num=db_num_rows($res)))
 else
     $showing='No emails found!';
 
+$def_dept_id = $cfg->getDefaultDeptId();
+$def_dept_name = $cfg->getDefaultDept()->getName();
+$def_priority = $cfg->getDefaultPriority()->getDesc();
+
 ?>
 <div style="width:700px;padding-top:5px; float:left;">
  <h2>Email Addresses</h2>
@@ -81,12 +85,13 @@ else
                 ?>
             <tr id="<?php echo $row['email_id']; ?>">
                 <td width=7px>
-                  <input type="checkbox" class="ckb" name="ids[]" value="<?php echo $row['email_id']; ?>" 
+                  <input type="checkbox" class="ckb" name="ids[]" value="<?php echo $row['email_id']; ?>"
                             <?php echo $sel?'checked="checked"':''; ?>  <?php echo $default?'disabled="disabled"':''; ?>>
                 </td>
                 <td><a href="emails.php?id=<?php echo $row['email_id']; ?>"><?php echo Format::htmlchars($email); ?></a>&nbsp;</td>
-                <td><?php echo $row['priority']; ?></td>
-                <td><a href="departments.php?id=<?php echo $row['dept_id']; ?>"><?php echo $row['department']; ?></a></td>
+                <td><?php echo $row['priority'] ?: $def_priority; ?></td>
+                <td><a href="departments.php?id=<?php $row['dept_id'] ?: $def_dept_id; ?>"><?php
+                    echo $row['department'] ?: $def_dept_name; ?></a></td>
                 <td>&nbsp;<?php echo Format::db_date($row['created']); ?></td>
                 <td>&nbsp;<?php echo Format::db_datetime($row['updated']); ?></td>
             </tr>


### PR DESCRIPTION
Previously, osTicket introduced the ability to cascade defaults for the department and priority to the email mail boxes. However, the validation checks and display fall-backs were never added.
