### PR TITLE
email: No bounces for system alerts

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -25,11 +25,12 @@ class Mailer {
 
     var $ht = array();
     var $attachments = array();
+    var $options = array();
 
     var $smtp = array();
     var $eol="\n";
 
-    function Mailer($email=null, $options=null) {
+    function Mailer($email=null, array $options=array()) {
         global $cfg;
 
         if(is_object($email) && $email->isSMTPEnabled() && ($info=$email->getSMTPInfo())) { //is SMTP enabled for the current email?
@@ -46,6 +47,7 @@ class Mailer {
 
         $this->email = $email;
         $this->attachments = array();
+        $this->options = $options;
     }
 
     function getEOL() {
@@ -114,7 +116,12 @@ class Mailer {
             'X-Mailer' =>'osTicket Mailer',
         );
 
-        if ($this->getEmail() instanceof Email)
+        // Add in the options passed to the constructor
+        $options = ($options ?: array()) + $this->options;
+
+        if (isset($options['nobounce']) && $options['nobounce'])
+            $headers['Return-Path'] = '<>';
+        elseif ($this->getEmail() instanceof Email)
             $headers['Return-Path'] = $this->getEmail()->getEmail();
 
         //Bulk.
@@ -285,7 +292,7 @@ class Mailer {
     //Emails using native php mail function - if DB connection doesn't exist.
     //Don't use this function if you can help it.
     function sendmail($to, $subject, $message, $from) {
-        $mailer = new Mailer();
+        $mailer = new Mailer(null, array('notice'=>true, 'nobounce'=>true));
         $mailer->setFromAddress($from);
         return $mailer->send($to, $subject, $message);
     }


### PR DESCRIPTION
Send an empty return-path envelope when sending out system alerts. If they should happen to bounce for any reason, they should not return to the system and create tickets.
