### PR TITLE
Allows creation of new tickets "asStaff" though the API

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -102,8 +102,7 @@ class TicketApiController extends ApiController {
             $ticket = $this->processEmail();
         } else {
 			# Parse request body
-			//mail("scott@nexus-iservices.com","ticket intermediate format",print_r($this->getRequest($format),true));
-            $ticket = $this->createTicket($this->getRequest($format));
+			$ticket = $this->createTicket($this->getRequest($format));
         }
 
         if(!$ticket)


### PR DESCRIPTION
adds new "asStaff" value to JSON object, and if set, initializes the $thisstaff and $cfg objects before calling Ticket::open ... resulting in the ticket being created by the defined Staff.

If "asStaff" not present, ticket is created by the user, as per normal.
