### PR TITLE
redactor: No more link shortening

### DIFF
--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -48,5 +48,20 @@ class ConfigAjaxAPI extends AjaxController {
 
         return $config;
     }
+
+    function templateLinks() {
+        $links = $this->json_encode(array(
+            array('name'=>'Select ...', 'url'=> false),
+            array('name'=>'Agent Ticket Link', 'url'=> '%{ticket.staff_link}'),
+            array('name'=>'Agent Login Page', 'url'=> '%{url}/scp'),
+            array('name'=>'End-User Ticket Link', 'url'=> '%{recipient.ticket_link}'),
+            array('name'=>'End-User Login Page', 'url'=> '%{url}/login.php'),
+        ));
+
+        Http::cacheable(md5($links), filemtime(__file__));
+        header('Content-Type: application/json; charset=UTF-8');
+
+        return $links;
+    }
 }
 ?>

--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -241,7 +241,9 @@ $(function() {
                 'linebreaks': true,
                 'tabFocus': false,
                 'toolbarFixedBox': true,
-                'focusCallback': function() { this.$box.addClass('no-pjax'); }
+                'focusCallback': function() { this.$box.addClass('no-pjax'); },
+                'linkSize': 100000,
+                'predefinedLinks': 'ajax.php/config/links'
             }, options||{});
         if (el.data('redactor')) return;
         var reset = $('input[type=reset]', el.closest('form'));

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -48,7 +48,8 @@ $dispatcher = patterns('',
         url_post('^(?P<id>\d+)(?:/(?P<lang>\w+))?$', 'updateContent')
     )),
     url('^/config/', patterns('ajax.config.php:ConfigAjaxAPI',
-        url_get('^scp', 'scp')
+        url_get('^scp', 'scp'),
+        url_get('^links', 'templateLinks')
     )),
     url('^/form/', patterns('ajax.forms.php:DynamicFormsAjaxAPI',
         url_get('^help-topic/(?P<id>\d+)$', 'getFormsForHelpTopic'),


### PR DESCRIPTION
Also add a drop-down list of common links include ticket links and login pages for both agents and end users.
