### PR TITLE
Fix attachments not working on ticket open

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -491,7 +491,8 @@ if($_POST && !$errors):
                 } else {
                     $vars = $_POST;
                     $vars['uid'] = $user? $user->getId() : 0;
-
+                    if($_FILES['attachments'])
+                	 	$vars['files'] = AttachmentFile::format($_FILES['attachments']);
                     if(($ticket=Ticket::open($vars, $errors))) {
                         $msg='Ticket created successfully';
                         $_REQUEST['a']=null;


### PR DESCRIPTION
When opening a ticket, and attaching a file, currently the code does not look for or process attachments.

My proposed code will find any attachments, process them, and add them upon opening the ticket.