### PR TITLE
auth: Always show agent login link

### DIFF
--- a/include/client/login.inc.php
+++ b/include/client/login.inc.php
@@ -51,13 +51,14 @@ if (count($ext_bks)) {
 }
 if ($cfg && $cfg->isClientRegistrationEnabled()) {
     if (count($ext_bks)) echo '<hr style="width:70%"/>'; ?>
+    <div style="margin-bottom: 5px">
     Not yet registered? <a href="account.php?do=create">Create an account</a>
-    <br/>
-    <div style="margin-top: 5px;">
+    </div>
+<?php } ?>
+    <div>
     <b>I'm an agent</b> —
     <a href="<?php echo ROOT_PATH; ?>scp">sign in here</a>
     </div>
-<?php } ?>
     </div>
 </div>
 </form>


### PR DESCRIPTION
Previously, if the enduser registration mode were set to something other than `public`, the agent sign-in link would not be shown. Now, the agent sign-in link is always shown on the enduser sign-in page.
