### PR TITLE
email: Always include a message-id token

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -176,10 +176,12 @@ class Mailer {
         $mid_token = (isset($options['thread']))
             ? $options['thread']->asMessageId($to) : '';
         if (!(isset($options['text']) && $options['text'])) {
-            if ($cfg && $cfg->stripQuotedReply() && ($tag=$cfg->getReplySeparator())
+            $tag = '';
+            if ($cfg && $cfg->stripQuotedReply()
                     && (!isset($options['reply-tag']) || $options['reply-tag']))
-                $message = "<div style=\"display:none\"
-                    data-mid=\"$mid_token\">$tag<br/><br/></div>$message";
+                $tag = $cfg->getReplySeparator() . '<br/><br/>';
+            $message = "<div style=\"display:none\"
+                data-mid=\"$mid_token\">$tag</div>$message";
             $txtbody = rtrim(Format::html2text($message, 90, false))
                 . ($mid_token ? "\nRef-Mid: $mid_token\n" : '');
             $mime->setTXTBody($txtbody);

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -245,7 +245,7 @@ class osTicket {
             $email=$this->getConfig()->getDefaultEmail(); //will take the default email.
 
         if($email) {
-            $email->sendAlert($to, $subject, $message, null, array('text'=>true));
+            $email->sendAlert($to, $subject, $message, null, array('text'=>true, 'reply-tag'=>false));
         } else {//no luck - try the system mail.
             Mailer::sendmail($to, $subject, $message, sprintf('"osTicket Alerts"<%s>',$to));
         }


### PR DESCRIPTION
Previously, if the quoted response mechanism was disabled, then outgoing mail would also not include the message-id token. This breaks the correlation of email to ticket-thread. Now, the message-id token is always embedded in HTML emails even if the quoted-response removal system is disabled.

(Turns out that the message-id token was always included in text bodies.)

_This patch also omits the reply-tag on system log alerts_
