### PR TITLE
html: Fix dropped text after inserted image

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -720,9 +720,9 @@ $tcount+= $ticket->getNumNotes();
                         }?>
                     </select>
                     &nbsp;<span class='error'>*&nbsp;<?php echo $errors['state']; ?></span>
+                    </div>
                 </td>
             </tr>
-            </div>
         </table>
 
        <p  style="padding-left:165px;">

--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -255,6 +255,13 @@ $(function() {
                     el.redactor('set', '', false, false);
             });
         }
+        $('input[type=submit]', el.closest('form')).on('click', function() {
+            // Some setups (IE v10 on Windows 7 at least) seem to have a bug
+            // where Redactor does not sync properly after adding an image.
+            // Therefore, the ::get() call will not include text added after
+            // the image was inserted.
+            el.redactor('sync');
+        });
         if (el.hasClass('draft')) {
             el.closest('form').append($('<input type="hidden" name="draft_id"/>'));
             options['plugins'].push('draft');


### PR DESCRIPTION
On some setups, IE v10 on Windows 7 at least, text added to the Redactor editor after an image is inserted (via the image popup dialog for instance), will not be retrieved via the ::get() method and so will not be submitted with the form submit button.

This patch introduces a workaround by manually calling ::sync() for the Redactor when the submit button is pressed — just before the form is submitted.
