### PR TITLE
email: Add MAIL_EOL setting to ost-config.php file

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -155,6 +155,13 @@ class Mailer {
             }
         }
 
+        // Use Mail_mime default initially
+        $eol = null;
+
+        // MAIL_EOL setting can be defined in `ost-config.php`
+        if (defined('MAIL_EOL') && is_string(MAIL_EOL)) {
+            $eol = MAIL_EOL;
+        }
         // The Suhosin patch will muck up the line endings in some
         // cases
         //
@@ -162,12 +169,12 @@ class Mailer {
         // https://github.com/osTicket/osTicket-1.8/issues/202
         // http://pear.php.net/bugs/bug.php?id=12032
         // http://us2.php.net/manual/en/function.mail.php#97680
-        if ((extension_loaded('suhosin') || defined("SUHOSIN_PATCH"))
-                && !$this->getSMTPInfo())
-            $mime = new Mail_mime("\n");
-        else
-            // Use defaults
-            $mime = new Mail_mime();
+        elseif ((extension_loaded('suhosin') || defined("SUHOSIN_PATCH"))
+            && !$this->getSMTPInfo()
+        ) {
+            $eol = "\n";
+        }
+        $mime = new Mail_mime($eol);
 
         // If the message is not explicitly declared to be a text message,
         // then assume that it needs html processing to create a valid text

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -16,19 +16,6 @@
     $Id: $
 **********************************************************************/
 
-/**
- * If you have a strange HTTP server configuration and osTicket cannot
- * discover the URL path of where your osTicket is installed, define
- * ROOT_PATH here.
- *
- * The ROOT_PATH is the part of the URL used to access your osTicket
- * helpdesk before the '/scp' part and after the hostname. For instance, for
- * http://mycompany.com/support', the ROOT_PATH should be '/support/'
- *
- * ROOT_PATH *must* end with a forward-slash!
- */
-# define('ROOT_PATH', '/support/');
-
 #Disable direct access.
 if(!strcasecmp(basename($_SERVER['SCRIPT_NAME']),basename(__FILE__)) || !defined('INCLUDE_DIR'))
     die('kwaheri rafiki!');
@@ -48,13 +35,19 @@ define('SECRET_SALT','%CONFIG-SIRI');
 #Default admin email. Used only on db connection issues and related alerts.
 define('ADMIN_EMAIL','%ADMIN-EMAIL');
 
-#Mysql Login info
+# Database Options
+# ---------------------------------------------------
+# Mysql Login info
 define('DBTYPE','mysql');
 define('DBHOST','%CONFIG-DBHOST');
 define('DBNAME','%CONFIG-DBNAME');
 define('DBUSER','%CONFIG-DBUSER');
 define('DBPASS','%CONFIG-DBPASS');
 
+# Table prefix
+define('TABLE_PREFIX','%CONFIG-PREFIX');
+
+#
 # SSL Options
 # ---------------------------------------------------
 # SSL options for MySQL can be enabled by adding a certificate allowed by
@@ -75,7 +68,42 @@ define('DBPASS','%CONFIG-DBPASS');
 # define('DBSSLCERT','/path/to/client.crt');
 # define('DBSSLKEY','/path/to/client.key');
 
-#Table prefix
-define('TABLE_PREFIX','%CONFIG-PREFIX');
+#
+# Mail Options
+# ---------------------------------------------------
+# Option: MAIL_EOL (default: \r\n)
+#
+# Some mail setups do not handle emails with \r\n (CRLF) line endings for
+# headers and base64 and quoted-response encoded bodies. This is an error
+# and a violation of the internet mail RFCs. However, because this is also
+# outside the control of both osTicket development and many server
+# administrators, this option can be adjusted for your setup. Many folks who
+# experience blank or garbled email from osTicket can adjust this setting to
+# use "\n" (LF) instead of the CRLF default.
+#
+# References:
+# http://www.faqs.org/rfcs/rfc2822.html
+# https://github.com/osTicket/osTicket-1.8/issues/202
+# https://github.com/osTicket/osTicket-1.8/issues/700
+# https://github.com/osTicket/osTicket-1.8/issues/759
+# https://github.com/osTicket/osTicket-1.8/issues/1217
 
+# define(MAIL_EOL, "\n");
+
+#
+# HTTP Server Options
+# ---------------------------------------------------
+# Option: ROOT_PATH (default: <auto detect>, fallback: /)
+#
+# If you have a strange HTTP server configuration and osTicket cannot
+# discover the URL path of where your osTicket is installed, define
+# ROOT_PATH here.
+#
+# The ROOT_PATH is the part of the URL used to access your osTicket
+# helpdesk before the '/scp' part and after the hostname. For instance, for
+# http://mycompany.com/support', the ROOT_PATH should be '/support/'
+#
+# ROOT_PATH *must* end with a forward-slash!
+
+# define('ROOT_PATH', '/support/');
 ?>


### PR DESCRIPTION
This setting allows administrators to add (uncomment) a MAIL_EOL setting in the ost-config.php config file to define the line ending used for mail headers and encoded bodies in outbound mail (SMTP, for instance).

By default, CRLF is used by the SMTP email generator as per the RFC 822 standard. However, many administrators can benefit by setting LF (\n) as the line ending.
