### PR TITLE
pages: Fix incorrect lookup of inline images

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -180,9 +180,7 @@ class FAQ {
 
         // Inline images (attached to the draft)
         $this->attachments->deleteInlines();
-        if (isset($vars['draft_id']) && $vars['draft_id'])
-            if ($draft = Draft::lookup($vars['draft_id']))
-                $this->attachments->upload($draft->getAttachmentIds(), true);
+        $this->attachments->upload(Draft::getAttachmentIds($vars['answer']));
 
         $this->reload();
 

--- a/scp/pages.php
+++ b/scp/pages.php
@@ -27,11 +27,9 @@ if($_POST) {
                 $_REQUEST['a'] = null;
                 $msg='Page added successfully';
                 // Attach inline attachments from the editor
-                if (isset($_POST['draft_id'])
-                        && ($draft = Draft::lookup($_POST['draft_id']))
-                        && ($page = Page::lookup($pageId)))
+                if ($page = Page::lookup($pageId))
                     $page->attachments->upload(
-                        $draft->getAttachmentIds($_POST['response']), true);
+                        Draft::getAttachmentIds($_POST['body']), true);
                 Draft::deleteForNamespace('page');
             } elseif(!$errors['err'])
                 $errors['err'] = 'Unable to add page. Try again!';
@@ -43,12 +41,10 @@ if($_POST) {
                 $msg='Page updated successfully';
                 $_REQUEST['a']=null; //Go back to view
                 // Attach inline attachments from the editor
-                if (isset($_POST['draft_id'])
-                        && ($draft = Draft::lookup($_POST['draft_id']))) {
-                    $page->attachments->deleteInlines();
-                    $page->attachments->upload(
-                        $draft->getAttachmentIds($_POST['response']),
-                        true);
+                $page->attachments->deleteInlines();
+                $page->attachments->upload(
+                    Draft::getAttachmentIds($_POST['body']),
+                    true);
                 }
                 Draft::deleteForNamespace('page.'.$page->getId());
             } elseif(!$errors['err'])


### PR DESCRIPTION
In some cases, a POST might be sent to the server and there be no draft. In such a case, neither the draft nor the body of the page can be inspected for images. Even worse, in some cases the previous images might be unlinked from the article without being relinked. Therefore, the images will no longer be linked to the page and will likely be purged from the system.
