### PR TITLE
Make ticket subject better visible

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -365,13 +365,13 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
     } ?>
 </table>
 <div class="clear"></div>
-<h2 style="padding:10px 0 5px 0; font-size:11pt;"><?php echo Format::htmlchars($ticket->getSubject()); ?></h2>
 <?php
 $tcount = $ticket->getThreadCount();
 $tcount+= $ticket->getNumNotes();
 ?>
 <ul id="threads">
     <li><a class="active" id="toggle_ticket_thread" href="#"><?php echo sprintf(__('Ticket Thread (%d)'), $tcount); ?></a></li>
+    <h2 style="padding:8px 0 5px 0; font-size:12pt;"><?php echo Format::htmlchars($ticket->getSubject()); ?></h2>
 </ul>
 <div id="ticket_thread">
     <?php


### PR DESCRIPTION
The idea for this pull request is based on the suggestion of mLipok from the forum:
http://osticket.com/forum/discussion/79243/ticket-subcject-did-not-catches-the-eye#latest

We also found that sometimes the ticket subject / issue summary could be better visible. So I played a bit around and now that is the result.

Moved the subject next to the ticket thread, increased font size from 11pt to 12pt and decreased padding from 10px to 8px. It's just a little cosmetic change, but I (and also my colleagues) think that it's better than before. If you like it, merge it, if not I will delete it.

BEFORE / CURRENT:
![image](https://cloud.githubusercontent.com/assets/2871833/4317026/b8619748-3f0e-11e4-821a-2c8de14e4c3f.png)

AFTER / PROPOSED:
![image](https://cloud.githubusercontent.com/assets/2871833/4317042/df5b4d3a-3f0e-11e4-929f-3285a607b3fa.png)
