### PR TITLE
forms: Support non-US locale on client portal

### DIFF
--- a/js/osticket.js
+++ b/js/osticket.js
@@ -214,3 +214,16 @@ showImagesInline = function(urls, thread_id) {
         }
     });
 }
+
+$(document).on('submit', 'form', function() {
+    // Reformat dates
+    $('.dp', $(this)).each(function(i, e) {
+        var $e = $(e),
+            d = $e.datepicker('getDate');
+        if (!d) return;
+        var day = ('0'+d.getDate()).substr(-2),
+            month = ('0'+(d.getMonth()+1)).substr(-2),
+            year = d.getFullYear();
+        $e.val(year+'-'+month+'-'+day);
+    });
+});


### PR DESCRIPTION
The staff portal has a feature where the date fields are converted to YYYY-MM-DD prior to form submission. However, this code was not ported to the client portal. Therefore, for non-US date formats (d/m/Y for instance) would not be processed properly by the server and would be nulled prior to validation.
