### PR TITLE
bug: Decode mailbox when parsing an email address

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -73,9 +73,10 @@ class Format {
                 $str.= Format::encode($part->text, $part->charset, $encoding);
 
             $text = $str;
-        } elseif(function_exists('iconv_mime_decode')) {
+        } elseif($text[0] == '=' && function_exists('iconv_mime_decode')) {
             $text = iconv_mime_decode($text, 0, $encoding);
-        } elseif(!strcasecmp($encoding, 'utf-8') && function_exists('imap_utf8')) {
+        } elseif(!strcasecmp($encoding, 'utf-8')
+                && function_exists('imap_utf8')) {
             $text = imap_utf8($text);
         }
 

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -513,12 +513,18 @@ class Mail_Parse {
 
         $parsed = Mail_RFC822::parseAddressList($address, null, null,false);
 
-        if(PEAR::isError($parsed))
+        if (PEAR::isError($parsed))
             return array();
 
+        // Decode name and mailbox
         foreach ($parsed as $p) {
             $p->personal = Format::mimedecode($p->personal, $this->charset);
+            // Some mail clients may send ISO-8859-1 strings without proper encoding.
+            // Also, handle the more sane case where the mailbox is properly encoded
+            // against RFC2047
+            $p->mailbox = Format::mimedecode($p->mailbox, $this->charset);
         }
+
         return $parsed;
     }
 


### PR DESCRIPTION
This addresses cases where a mailbox might contain non-ascii characters and the charset is not specified.
