### PR TITLE
orm: Fix MySQL occasional "Commands OOS" error

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -986,8 +986,6 @@ class MysqlExecutor {
     function _prepare() {
         $this->execute();
         $this->_setup_output();
-        if (!$this->stmt->store_result())
-            throw new OrmException('Unable to process query: '.$this->stmt->error);
     }
 
     function execute() {
@@ -996,7 +994,7 @@ class MysqlExecutor {
                 .' '.$this->sql);
         if (count($this->params))
             $this->_bind($this->params);
-        if (!$this->stmt->execute()) {
+        if (!$this->stmt->execute() || ! $this->stmt->store_result()) {
             throw new OrmException('Unable to execute query: ' . $this->stmt->error);
         }
         return true;


### PR DESCRIPTION
Under certain intermittent circumstances (usually a significant number of ORM queries), the ORM will trigger a MySQL error:

```
Commands out of sync; you can't run this command now
```

Usually this MySQL error is related to buffered versus unbuffered queries. However, the ORM already uses buffered queries (MySQL calls it "store_result"). In this case, it appears there is some sort of race between fetching the result metadata before configuring the statement for buffering. (By "race" I mean that the error is not reliably triggered).

This patch seems to fix the issue by configuring buffering before fetching result metadata — necessary to configure the fetching (output) phase of the statement.
