### PR TITLE
forms: Add default selection to SelectionField

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -977,7 +977,7 @@ class SelectionField extends FormField {
 
     function getListId() {
         list(,$list_id) = explode('-', $this->get('type'));
-        return $list_id;
+        return $list_id ?: $this->get('list_id');
     }
 
     function getList() {
@@ -1093,6 +1093,11 @@ class SelectionField extends FormField {
                 'hint'=>__('Leading text shown before a value is selected'),
                 'configuration'=>array('size'=>40, 'length'=>40),
             )),
+            'default' => new SelectionField(array(
+                'id'=>4, 'label'=>__('Default'), 'required'=>false, 'default'=>'',
+                'list_id'=>$this->getListId(),
+                'configuration' => array('prompt'=>__('Select a Default')),
+            )),
         );
     }
 
@@ -1163,12 +1168,20 @@ class TypeaheadSelectionWidget extends ChoicesWidget {
             return parent::render($how);
 
         $name = $this->getEnteredValue();
+        $config = $this->field->getConfiguration();
         if (is_array($this->value)) {
             $name = $name ?: current($this->value);
             $value = key($this->value);
         }
+        else {
+            // Pull configured default (if configured)
+            $def_key = $this->field->get('default');
+            if (!$def_key && $config['default'])
+                $def_key = $config['default'];
+            if (is_array($def_key))
+                $name = current($def_key);
+        }
 
-        $config = $this->field->getConfiguration();
         $source = array();
         foreach ($this->field->getList()->getItems() as $i)
             $source[] = array(

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -608,7 +608,7 @@ class FormField {
         if (!$this->_cform) {
             $type = static::getFieldType($this->get('type'));
             $clazz = $type[1];
-            $T = new $clazz();
+            $T = new $clazz(array('type'=>$this->get('type')));
             $config = $this->getConfiguration();
             $this->_cform = new Form($T->getConfigurationOptions(), $source);
             if (!$source) {
@@ -1814,12 +1814,14 @@ class ChoicesWidget extends Widget {
             $def_key = $this->field->get('default');
             if (!$def_key && $config['default'])
                 $def_key = $config['default'];
+            if (is_array($def_key))
+                $def_key = key($def_key);
             $have_def = isset($choices[$def_key]);
             $def_val = $have_def ? $choices[$def_key] : $prompt;
         }
 
         $values = $this->value;
-        if (!is_array($values)) {
+        if (!is_array($values) && $values) {
             $values = array($values => $this->field->getChoice($values));
         }
 


### PR DESCRIPTION
This allows administrators to select a default value for selection fields deriving from Custom Lists. This has been implemented on the ChoiceField, but was forgotten on the SelectionField
