### PR TITLE
Dashboard statistics should use 'period' as the date limiter

### DIFF
--- a/scp/js/dashboard.inc.js
+++ b/scp/js/dashboard.inc.js
@@ -140,7 +140,7 @@
             method:     'GET',
             dataType:   'json',
             url:        'ajax.php/report/overview/table',
-            data:       {group: group, start: start, stop: stop},
+            data:       {group: group, start: start, period: stop},
             success:    function(json) {
                 var q = $('<table>').attr({'class':'table table-condensed table-striped'}),
                     h = $('<tr>').appendTo($('<thead>').appendTo(q)),


### PR DESCRIPTION
The statistics module on the dashboard was using the incorrect query parameter `stop`. This meant that the module was loading all tickets from the report start date to the present day. This commit fixes this by using the `period` parameter instead.
