### PR TITLE
forms: If an answer has no saved value, use the field

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1008,10 +1008,12 @@ class DynamicFormEntryAnswer extends VerySimpleModel {
     }
 
     function getValue() {
-        if (!$this->_value && isset($this->value))
-            $this->_value = $this->getField()->to_php(
-                $this->get('value'), $this->get('value_id'));
-        return $this->_value;
+        $value = $this->getField()->to_php(
+            $this->get('value'), $this->get('value_id'));
+        if (!$value && $this->getEntry()->getSource()) {
+            return $this->getEntry()->getField(
+                $this->getField()->get('name'))->getClean();
+        }
     }
 
     function getIdValue() {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2367,6 +2367,7 @@ class Ticket {
 
         // Create and verify the dynamic form entry for the new ticket
         $form = TicketForm::getNewInstance();
+        $form->setSource($vars);
         // If submitting via email, ensure we have a subject and such
         foreach ($form->getFields() as $field) {
             $fname = $field->get('name');


### PR DESCRIPTION
When processing the value of a DynamicFormEntryAnswer, if there is no database-backed, value, then use the value of the associated field.

Fixes #1326
Fixes #1348
