### PR TITLE
pjax: Fix placement of footer

### DIFF
--- a/include/staff/footer.inc.php
+++ b/include/staff/footer.inc.php
@@ -1,5 +1,6 @@
+</div>
+</div>
 <?php if (!isset($_SERVER['HTTP_X_PJAX'])) { ?>
-    </div>
     <div id="footer">
         Copyright &copy; 2006-<?php echo date('Y'); ?>&nbsp;<?php echo (string) $ost->company ?: 'osTicket.com'; ?>&nbsp;All Rights Reserved.
     </div>
@@ -12,7 +13,6 @@ if(is_object($thisstaff) && $thisstaff->isStaff()) { ?>
     </div>
 <?php
 } ?>
-</div>
 </div>
 <div id="overlay"></div>
 <div id="loading">


### PR DESCRIPTION
Footer should not be in `#pjax_container`, because the footer is not rendered for non PJAX requests.

Fixes #1353
