### PR TITLE
users: Error message setting username to an email

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -957,15 +957,15 @@ class UserAccount extends UserAccountModel {
                 $errors['passwd2'] = __('Passwords do not match');
         }
 
+        // Make sure the username is not an email.
+        if ($vars['username'] && Validator::is_email($vars['username']))
+            $errors['username'] =
+                __('Users can always sign in with their email address');
+
         if ($errors) return false;
 
         $this->set('timezone_id', $vars['timezone_id']);
         $this->set('dst', isset($vars['dst']) ? 1 : 0);
-
-        // Make sure the username is not an email.
-        if ($vars['username'] && Validator::is_email($vars['username']))
-             $vars['username'] = '';
-
         $this->set('username', $vars['username']);
 
         if ($vars['passwd1']) {

--- a/include/staff/templates/user-account.tmpl.php
+++ b/include/staff/templates/user-account.tmpl.php
@@ -104,8 +104,13 @@ if ($info['error']) {
                     <?php echo __('Username'); ?>:
                 </td>
                 <td>
-                    <input type="text" size="35" name="username" value="<?php echo $info['username'] ?: $user->getEmail(); ?>">
-                    &nbsp;<span class="error">&nbsp;<?php echo $errors['username']; ?></span>
+                    <input type="text" size="35" name="username" value="<?php echo $info['username']; ?>">
+                    <i class="help-tip icon-question-sign" data-title="<?php
+                        echo __("Login via email"); ?>"
+                    data-content="<?php echo sprintf('%s: %s',
+                        __('Users can always sign in with their email address'),
+                        $user->getEmail()); ?>"></i>
+                    <div class="error">&nbsp;<?php echo $errors['username']; ?></div>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
Since users can already log in via their email address, offer a friendly error message when agents configure the user name to be an email address.

Fixes #1328
