### PR TITLE
forms: oops: Properly validate forms for agents

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -129,7 +129,7 @@ class UsersAjaxAPI extends AjaxController {
             Http::response(404, 'Unknown user');
 
         $errors = array();
-        if($user->updateInfo($_POST, $errors))
+        if ($user->updateInfo($_POST, $errors, true) && !$errors)
              Http::response(201, $user->to_json());
 
         $forms = $user->getForms();

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -732,23 +732,24 @@ class DynamicFormEntry extends VerySimpleModel {
         if (!is_array($this->_errors)) {
             $this->_errors = array();
             $this->getClean();
-            foreach ($this->getFields() as $field)
+            foreach ($this->getFields() as $field) {
                 if ($field->errors() && (!$filter || $filter($field)))
                     $this->_errors[$field->get('id')] = $field->errors();
+            }
         }
         return !$this->_errors;
     }
 
     function isValidForClient() {
         $filter = function($f) {
-            return !$f->isRequiredForUsers();
+            return $f->isVisibleToUsers();
         };
         return $this->isValid($filter);
     }
 
     function isValidForStaff() {
         $filter = function($f) {
-            return !$f->isRequiredForStaff();
+            return $f->isVisibleToStaff();
         };
         return $this->isValid($filter);
     }

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -678,6 +678,9 @@ class TextboxField extends FormField {
                             && false !== @preg_match($wrapped, ' ')) {
                         return $wrapped;
                     }
+                    if ($value == '//iu')
+                        return '';
+
                     return $value;
                 },
                 'validators' => function($self, $v) {

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -493,13 +493,15 @@ class User extends UserModel {
         return User::importCsv($stream, $extra);
     }
 
-    function updateInfo($vars, &$errors) {
+    function updateInfo($vars, &$errors, $staff=false) {
 
         $valid = true;
         $forms = $this->getDynamicData();
         foreach ($forms as $cd) {
             $cd->setSource($vars);
-            if (!$cd->isValidForClient())
+            if ($staff && !$cd->isValidForStaff())
+                $valid = false;
+            elseif (!$cd->isValidForClient())
                 $valid = false;
             elseif ($cd->get('type') == 'U'
                         && ($form= $cd->getForm())


### PR DESCRIPTION
This patch fixes a small glitch where validation might be bypassed for fields for agents. Previously there was a glitch where required fields would have their validation errors ignored.
