### PR TITLE
forms: Fix validation errors for field `name` matches

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2368,11 +2368,14 @@ class Ticket {
         // Create and verify the dynamic form entry for the new ticket
         $form = TicketForm::getNewInstance();
         $form->setSource($vars);
-        // If submitting via email, ensure we have a subject and such
-        foreach ($form->getFields() as $field) {
-            $fname = $field->get('name');
-            if ($fname && isset($vars[$fname]) && !$field->value)
-                $field->value = $field->parse($vars[$fname]);
+
+        // If submitting via email or api, ensure we have a subject and such
+        if (!in_array(strtolower($origin), array('web', 'staff'))) {
+            foreach ($form->getFields() as $field) {
+                $fname = $field->get('name');
+                if ($fname && isset($vars[$fname]) && !$field->value)
+                    $field->value = $field->parse($vars[$fname]);
+            }
         }
 
         if (!$form->isValid($field_filter('ticket')))


### PR DESCRIPTION
For fields with `name`s which are the same as other fields on the new ticket form (such as `time` used with the new ticket by staff form), ensure that data from the fields outside the main ticket form ("Ticket Details") is not mingled with fields inside the form.

Since this is only a problem for web requests, and specifically new ticket by staff requests, this patch only applies the field name to data matching for non-web requests.
