### PR TITLE
Display of staff name backwards on ticket lock

### DIFF
--- a/include/class.lock.php
+++ b/include/class.lock.php
@@ -33,7 +33,7 @@ class TicketLock {
             $id=$this->ht['id'];
 
         $sql='SELECT l.*, TIME_TO_SEC(TIMEDIFF(expire,NOW())) as timeleft '
-            .' ,IF(s.staff_id IS NULL,"staff",CONCAT_WS(" ", s.lastname, s.firstname)) as staff '
+            .' ,IF(s.staff_id IS NULL,"staff",CONCAT_WS(" ", s.firstname, s.lastname)) as staff '
             .' FROM '.TICKET_LOCK_TABLE. ' l '
             .' LEFT JOIN '.STAFF_TABLE.' s ON(s.staff_id=l.staff_id) '
             .' WHERE lock_id='.db_input($id);


### PR DESCRIPTION
When displaying the ticket details if the ticket is locked the name of the staff member locking the ticket will be displayed as LastName FirstName instead of FirstName LastName like the other ticket details.

![image](https://cloud.githubusercontent.com/assets/3441198/4686589/9028d426-5647-11e4-9c54-74631c8b83d3.png)
