### PR TITLE
InnoDB tables for search indexing where possible

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -403,14 +403,30 @@ class MysqlSearchBackend extends SearchBackend {
     }
 
     static function createSearchTable() {
-        $sql = 'CREATE TABLE IF NOT EXISTS '.TABLE_PREFIX.'_search (
+        // Use InnoDB with Galera, MyISAM with v5.5, and the database
+        // default otherwise
+        $sql = "select count(*) from information_schema.tables where
+            table_schema='information_schema' and table_name =
+            'INNODB_FT_CONFIG'";
+        $mysql56 = db_result(db_query($sql));
+
+        $sql = "show status like 'wsrep_local_state'";
+        $galera = db_result(db_query($sql));
+
+        if ($galera && !$mysql56)
+            throw new Exception('Galera cannot be used with MyISAM tables');
+        $engine = $galera ? 'InnodB' : ($mysql56 ? '' : 'MyISAM');
+        if ($engine)
+            $engine = 'ENGINE='.$engine;
+
+        $sql = 'CREATE TABLE IF NOT EXISTS '.TABLE_PREFIX."_search (
             `object_type` varchar(8) not null,
             `object_id` int(11) unsigned not null,
             `title` text collate utf8_general_ci,
             `content` text collate utf8_general_ci,
             primary key `object` (`object_type`, `object_id`),
             fulltext key `search` (`title`, `content`)
-        ) ENGINE=MyISAM CHARSET=utf8';
+        ) $engine CHARSET=utf8";
         return db_query($sql);
     }
 


### PR DESCRIPTION
Especially on Galera clusters, search indexing with MyISAM tables will cause unstable clusters and loss of data. For standalone servers using MySQL 5.6 or MariaDB 10.0, the database default table storage engine can be used, since either support fulltext indexing.
