### PR TITLE
Rollback to autocommit, except for sequence  iteration

### DIFF
--- a/include/class.sequence.php
+++ b/include/class.sequence.php
@@ -151,6 +151,9 @@ class Sequence extends VerySimpleModel {
      * and assured to be session-wise atomic before the value is returned.
      */
     function __next($digits=false) {
+        // Ensure this block is executed in a single transaction
+        db_autocommit(false);
+
         // Lock the database object -- this is important to handle concurrent
         // requests for new numbers
         static::objects()->filter(array('id'=>$this->id))->lock()->one();
@@ -160,6 +163,8 @@ class Sequence extends VerySimpleModel {
         $this->next += $this->increment;
         $this->updated = SqlFunction::NOW();
         $this->save();
+
+        db_autocommit(true);
 
         return $next;
     }

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -76,23 +76,18 @@ function db_connect($host, $user, $passwd, $options = array()) {
 
     @db_set_variable('sql_mode', '');
 
-    // Start a new transaction -- for performance. Transactions are always
-    // committed at shutdown (below)
-    $__db->autocommit(false);
-
-    // Auto commit the transaction at shutdown and re-enable statement-level
-    // autocommit
-    register_shutdown_function(function() {
-        global $__db, $err;
-        if (!$__db->commit())
-            $err = 'Unable to save changes to database';
-        $__db->autocommit(true);
-    });
+    $__db->autocommit(true);
 
     // Use connection timing to seed the random number generator
     Misc::__rand_seed((microtime(true) - $start) * 1000000);
 
     return $__db;
+}
+
+function db_autocommit($enable=true) {
+    global $__db;
+
+    return $__db->autocommit($enable);
 }
 
 function db_close() {


### PR DESCRIPTION
Keeping the transaction active for the entire request increases the likelihood of a deadlock on Galera clusters.
