### PR TITLE
forms: Fix interpretation of custom list data

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1127,7 +1127,9 @@ class SelectionField extends FormField {
         if (!is_array($value)) {
             $choices = $this->getChoices();
             if (isset($choices[$value]))
-                $value = $choices[$value];
+                $value = array($value => $choices[$value]);
+            elseif ($id && isset($choices[$id]))
+                $value = array($id => $choices[$id]);
         }
         // Don't set the ID here as multiselect prevents using exactly one
         // ID value. Instead, stick with the JSON value only.


### PR DESCRIPTION
Prior to osTicket v1.9.4, drop down lists only allowed for a single entry. After upgrading to 1.9.4 the database data for drop downs changed to allow for multiple entries. However, the old data format was not properly handled by the `SelectionField::to_php()` method which handled interpreting and upgrading the database data.
