### PR TITLE
createTicket respects alert/autorespond negatives

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -118,9 +118,11 @@ class TicketApiController extends ApiController {
     function createTicket($data) {
 
         # Pull off some meta-data
-        $alert          = array_key_exists('alert',       $data) ? $data['alert']       : true;
-        $autorespond    = array_key_exists('autorespond', $data) ? $data['autorespond'] : true;
-        $data['source'] = array_key_exists('source',      $data) ? $data['source']      : 'API';
+        $alert       = (bool) (isset($data['alert'])       ? $data['alert']       : true);
+        $autorespond = (bool) (isset($data['autorespond']) ? $data['autorespond'] : true);
+
+        # Assign default value to source if not defined, or defined as NULL
+        $data['source'] = isset($data['source']) ? $data['source'] : 'API';
 
         # Create the ticket with the data (attempt to anyway)
         $errors = array();

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -330,9 +330,9 @@ class ApiXmlDataParser extends XmlDataParser {
             if ($key == "phone" && is_array($value)) {
                 $value = $value[":text"];
             } else if ($key == "alert") {
-                $value = (bool)$value;
+                $value = (bool) (strtolower($value) === 'false' ? false : $value);
             } else if ($key == "autorespond") {
-                $value = (bool)$value;
+                $value = (bool) (strtolower($value) === 'false' ? false : $value);
             } else if ($key == "message") {
                 if (!is_array($value)) {
                     $value = array(


### PR DESCRIPTION
It was previously not possible to use the `alert` and `autorespond` flags in a negative way to prevent those two events, since the ternary operator would have used the `false` ternary value, which was `true`.  This corrects that by allowing the default of `true` to be used only when the `$data` array does not have the appropriate keys set.  Assigning `$data['source']` was altered to use the same formatting and caution against an undefined index error.
