### PR TITLE
thread: Fix regex for ticket # in email subject

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -910,7 +910,10 @@ Class ThreadEntry {
         $match = array();
         if ($subject
                 && $mailinfo['email']
-                && preg_match("/\b#(\S+)/u", $subject, $match)
+                // Required `#` followed by one or more of
+                //      punctuation (-) then letters, numbers, and symbols
+                // (Try not to match closing punctuation (`]`) in [#12345])
+                && preg_match("/#((\p{P}*[^\p{C}\p{Z}\p{P}]+)+)/u", $subject, $match)
                 //Lookup by ticket number
                 && ($ticket = Ticket::lookupByNumber($match[1]))
                 //Lookup the user using the email address


### PR DESCRIPTION
The ticket number regex was changed with the advent of custom ticket numbers, and it matches the closing punctuation in [#12345], that is, the closing bracket would be included in the ticket number sought in the database. Therefore, it would never match the ticket number properly.

The new regex attempts to match punctuation and non-punctuation groups so that punctuation in the middle of the ticket number is matched; however, punctuation at the end is not. So #12345+DEPT will match properly and will ignore any trailing whitespace and punctuation.
