### PR TITLE
Do NOT reopen closed ticket on auto-reply

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1156,7 +1156,10 @@ class Ticket {
         }
 
         // Reopen if closed AND reopenable
-        if ($this->isClosed() && $this->isReopenable())
+        // We're also checking autorespond flag because we don't want to
+        // reopen closed tickets on auto-reply from end user. This is not to
+        // confused with autorespond on new message setting
+        if ($autorespond && $this->isClosed() && $this->isReopenable())
             $this->reopen();
 
        /**********   double check auto-response  ************/


### PR DESCRIPTION
Do not reopen closed ticket, if the system can reliably determine that the new message is an
auto-response/reply from the end user.
