### PR TITLE
Ensure case-insensitive file extension comparison

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1587,6 +1587,10 @@ class FileUploadField extends FormField {
                 else {
                     if ($ext[0] != '.')
                         $ext = '.' . $ext;
+
+                    // Ensure that the extension is lower-cased for comparison latr
+                    $ext = strtolower($ext);
+
                     // Add this to the MIME types list so it can be exported to
                     // the @accept attribute
                     if (!isset($extensions[$ext]))


### PR DESCRIPTION
Ensure that when generating the list of acceptable file extensions, that the list is lower cased, because the extension from the filename will be lower-cased before attempting to find the extension in the list of acceptable extensions.
