### PR TITLE
lock: Set ticket lock on ticket-view

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -989,5 +989,12 @@ $(function() {
             }
         });
     });
+<?php
+    // Set the lock if one exists
+    if ($lock) { ?>
+    autoLock.setLock({
+      id:<?php echo $lock->getId(); ?>,
+      time: <?php echo $cfg->getLockTime(); ?>}, 'acquire');
+<?php } ?>
 });
 </script>

--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -15,6 +15,20 @@
 **********************************************************************/
 var autoLock = {
 
+    // Defaults
+    lockId: 0,
+    timerId: 0,
+    lasteventTime: 0,
+    lastattemptTime: 0,
+    acquireTime: 0,
+    renewTime: 0,
+    renewFreq: 0, //renewal frequency in seconds...based on returned lock time.
+    time: 0,
+    lockAttempts: 0, //Consecutive lock attempt errors
+    maxattempts: 2, //Maximum failed lock attempts before giving up.
+    warn: true,
+    retry: true,
+
     addEvent: function(elm, evType, fn, useCapture) {
         if(elm.addEventListener) {
             elm.addEventListener(evType, fn, useCapture);
@@ -111,18 +125,6 @@ var autoLock = {
         void(autoLock.tid=parseInt($(':input[name=id]',fObj).val()));
         void(autoLock.lockTime=parseInt($(':input[name=locktime]',fObj).val()));
 
-        autoLock.lockId=0;
-        autoLock.timerId=0;
-        autoLock.lasteventTime=0;
-        autoLock.lastattemptTime=0;
-        autoLock.acquireTime=0;
-        autoLock.renewTime=0;
-        autoLock.renewFreq=0; //renewal frequency in seconds...based on returned lock time.
-        autoLock.time=0;
-        autoLock.lockAttempts=0; //Consecutive lock attempt errors
-        autoLock.maxattempts=2; //Maximum failed lock attempts before giving up.
-        autoLock.warn=true;
-        autoLock.retry=true;
         autoLock.watchDocument();
         autoLock.resetTimer();
         autoLock.addEvent(window,'unload',autoLock.releaseLock,true); //Release lock regardless of any activity.


### PR DESCRIPTION
Since the automatic lock was being acquired but not passed to the autoLock system, the automatically acquired lock was not being release on away navigation.

This patch addresses the issue by passing the automatically acquired lock id to the autoLock system on ticket-view page load and change the ::Init() method so that the lock id is not cleared with the ::Init() method is called by the page load.

Fixes #1434
