### PR TITLE
ui: Implement "enable canned responses" config option

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -214,6 +214,10 @@ class OsticketConfig extends Config {
         return ($this->get('enable_kb') && FAQ::countPublishedFAQs());
     }
 
+    function isCannedResponseEnabled() {
+        return $this->get('enable_premade');
+    }
+
     function getVersion() {
         return THIS_VERSION;
     }

--- a/include/class.nav.php
+++ b/include/class.nav.php
@@ -125,6 +125,7 @@ class StaffNav {
     }
 
     function getSubMenus(){ //Private.
+        global $cfg;
 
         $staff = $this->staff;
         $submenus=array();
@@ -163,7 +164,7 @@ class StaffNav {
                     if($staff) {
                         if($staff->canManageFAQ())
                             $subnav[]=array('desc'=>__('Categories'),'href'=>'categories.php','iconclass'=>'faq-categories');
-                        if($staff->canManageCannedResponses())
+                        if ($cfg->isCannedResponseEnabled() && $staff->canManageCannedResponses())
                             $subnav[]=array('desc'=>__('Canned Responses'),'href'=>'canned.php','iconclass'=>'canned');
                     }
                    break;

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -534,6 +534,7 @@ $tcount+= $ticket->getNumNotes();
                     <label><strong><?php echo __('Response');?>:</strong></label>
                 </td>
                 <td>
+<?php if ($cfg->isCannedResponseEnabled()) { ?>
                     <select id="cannedResp" name="cannedResp">
                         <option value="0" selected="selected"><?php echo __('Select a canned response');?></option>
                         <option value='original'><?php echo __('Original Message'); ?></option>
@@ -548,7 +549,7 @@ $tcount+= $ticket->getNumNotes();
                         ?>
                     </select>
                     <br>
-                    <?php
+<?php } # endif (canned-resonse-enabled)
                     $signature = '';
                     switch ($thisstaff->getDefaultSignatureType()) {
                     case 'dept':

--- a/scp/canned.php
+++ b/scp/canned.php
@@ -17,7 +17,8 @@ require('staff.inc.php');
 include_once(INCLUDE_DIR.'class.canned.php');
 
 /* check permission */
-if(!$thisstaff || !$thisstaff->canManageCannedResponses()) {
+if(!$thisstaff || !$thisstaff->canManageCannedResponses()
+        || !$cfg->isCannedResponseEnabled()) {
     header('Location: kb.php');
     exit;
 }


### PR DESCRIPTION
This patch removes the selection of canned responses as well as the canned responses navigation page from the ui when the canned responses feature is disabled.

Fixes #1505
