### PR TITLE
Properly escape text bodies for canned responses

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -678,7 +678,7 @@ class TicketsAjaxAPI extends AjaxController {
                 Http::response(422, 'Unknown ticket variable');
 
             // Ticket thread variables are assumed to be quotes
-            $response = "<br/><blockquote>$response</blockquote><br/>";
+            $response = "<br/><blockquote>{$response->asVar()}</blockquote><br/>";
 
             //  Return text if html thread is not enabled
             if (!$cfg->isHtmlThreadEnabled())

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1412,10 +1412,9 @@ class TextThreadBody extends ThreadBody {
 
         switch ($output) {
         case 'html':
-            return '<div style="white-space:pre-wrap">'
-                .Format::clickableurls(Format::htmlchars($this->body)).'</div>';
         case 'email':
-            return '<div style="white-space:pre-wrap">'.$this->body.'</div>';
+            return '<div style="white-space:pre-wrap">'
+                .Format::htmlchars($this->body).'</div>';
         case 'pdf':
             return nl2br($this->body);
         default:


### PR DESCRIPTION
This patch changes the default formatting for text bodies used in emails, ticket thread, and canned response quoting so that white-space in text bodies is properly preserved. Previously, the text was treated as raw HTML and was not properly escaped, nor was the original whitespace preserved.

Fixes #1490
