### PR TITLE
filters: Fix several small, major issues

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -137,7 +137,7 @@ class Filter {
     }
 
     function stopOnMatch() {
-        return ($this->ht['stop_on_match']);
+        return ($this->ht['stop_onmatch']);
     }
 
     function matchAllRules() {
@@ -738,7 +738,7 @@ class TicketFilter {
         $res = $this->getAllActive();
         if($res) {
             while (list($id) = db_fetch_row($res))
-                array_push($this->filters, new Filter($id));
+                $this->filters[] = new Filter($id);
         }
 
         return $this->filters;
@@ -765,35 +765,24 @@ class TicketFilter {
         return $this->short_list;
     }
     /**
-     * Determine if the filters that match the received vars indicate that
-     * the email should be rejected
-     *
-     * Returns FALSE if the email should be acceptable. If the email should
-     * be rejected, the first filter that matches and has reject ticket set is
-     * returned.
-     */
-    function shouldReject() {
-        foreach ($this->getMatchingFilterList() as $filter) {
-            # Set reject if this filter indicates that the email should
-            # be blocked; however, don't unset $reject, because if it
-            # was set by another rule that did not set stopOnMatch(), we
-            # should still honor its configuration
-            if ($filter->rejectOnMatch()) return $filter;
-        }
-        return false;
-    }
-    /**
      * Determine if any filters match the received email, and if so, apply
      * actions defined in those filters to the ticket-to-be-created.
+     *
+     * Throws:
+     * RejectedException if the email should not be acceptable. If the email
+     * should be rejected, the first filter that matches and has reject
+     * ticket set is returned.
      */
     function apply(&$ticket) {
         foreach ($this->getMatchingFilterList() as $filter) {
+            if ($filter->rejectOnMatch())
+                throw new RejectedException($filter);
             $filter->apply($ticket, $this->vars);
             if ($filter->stopOnMatch()) break;
         }
     }
 
-    /* static */ function getAllActive() {
+    function getAllActive() {
 
         $sql='SELECT id FROM '.FILTER_TABLE
             .' WHERE isactive=1 '
@@ -946,6 +935,19 @@ class TicketFilter {
         $sources=array('web' => 'Web', 'email' => 'Email', 'phone' => 'Web', 'staff' => 'Web', 'api' => 'API');
 
         return $sources[strtolower($origin)];
+    }
+}
+
+class RejectedException extends Exception {
+    var $filter;
+
+    function __construct(Filter $filter) {
+        parent::__construct('Ticket rejected by a filter');
+        $this->filter = $filter;
+    }
+
+    function getRejectingFilter() {
+        return $this->filter;
     }
 }
 

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -318,7 +318,8 @@ class User extends UserModel {
             // Add in special `name` and `email` fields
             foreach (array('name', 'email') as $name) {
                 if ($f = $entry->getForm()->getField($name))
-                    $vars['field.'.$f->get('id')] = $this->getName();
+                    $vars['field.'.$f->get('id')] =
+                        $name == 'name' ? $this->getName() : $this->getEmail();
             }
         }
         return $vars;


### PR DESCRIPTION
- Fix incorrect mapping to user email address
- Fix early rejecting of tickets — even if a filter earlier in the
  matching filter list had "stop on match" set
- Fix ::stopOnMatch referring to incorrect db field

The new logic abandons the early rejection logic in ticket create. Instead, the normal validation is completed as usual. Thereafter, the filter is initialized and applied to the ticket. Upon rejection, a RejectedException is thrown by the ::apply() method of the TicketFilter. The Ticket::create() method will handle the exception and reject the ticket.
