### PR TITLE
Notification of overdue tickets

### DIFF
--- a/api/notify_overdue.php
+++ b/api/notify_overdue.php
@@ -1,0 +1,11 @@
+<?php
+@chdir(dirname(__FILE__).'/'); //Change dir.
+require('api.inc.php');
+
+if (!osTicket::is_cli())
+    die(__('cron.php only supports local cron calls - use http -> api/tasks/cron'));
+
+require_once(INCLUDE_DIR.'class.ticket.php');
+Ticket::triggerOverdue();
+?>
+

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2921,5 +2921,41 @@ class Ticket {
         }
    }
 
+   //  trigger overdue ticket notification
+   function notifyOverdue($whine=true) {
+
+        global $cfg;
+
+        if(!$this->isOverdue())
+            return true;
+
+        $this->logEvent('overdue reminder');
+        $this->onOverdue($whine);
+
+        return true;
+    }
+
+	// Find overdue tickets and send notify the owners
+    function triggerOverdue() {
+
+        $sql='SELECT ticket_id FROM '.TICKET_TABLE.' T1 '
+            .' INNER JOIN '.TICKET_STATUS_TABLE.' status
+                ON (status.id=T1.status_id AND status.state="open") '
+            .' LEFT JOIN '.SLA_TABLE.' T2 ON (T1.sla_id=T2.id AND T2.isactive=1) '
+            .' WHERE isoverdue=1 '
+            .' ORDER BY T1.created';
+
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            while(list($id)=db_fetch_row($res)) {
+                if( $ticket=Ticket::lookup($id) ) 
+			$ticket->notifyOverdue();
+            }
+        } else {
+            //TODO: Trigger escalation on already overdue tickets - make sure last overdue event > grace_period.
+
+        }
+   }
+
+
 }
 ?>


### PR DESCRIPTION
Set up the system to provide mechanisms to send periodically a reminder
of overdue tickets.
Two methods are added to the Ticket class. One is notifyOverdue that
will send the message and the second is triggerOverdue that will find
the overdue tickets in the system.
Finally notify_overdue.php has been added in the api folder. This can
be run periodically with crontab.
