### PR TITLE
Pending Ticket Auto Close 1.9.x

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -410,6 +410,10 @@ class OsticketConfig extends Config {
         return $this->defaultSLA;
     }
 
+    function getAutoCloseGrace() {
+        return $this->get('autoclose_grace_period');
+    }
+
     function getAlertEmailId() {
         return $this->get('alert_email_id');
     }
@@ -970,6 +974,7 @@ class OsticketConfig extends Config {
             'default_sla_id'=>$vars['default_sla_id'],
             'max_open_tickets'=>$vars['max_open_tickets'],
             'autolock_minutes'=>$vars['autolock_minutes'],
+            'autoclose_grace_period'=>$vars['autoclose_grace_period'],
             'enable_captcha'=>isset($vars['enable_captcha'])?1:0,
             'auto_claim_tickets'=>isset($vars['auto_claim_tickets'])?1:0,
             'show_assigned_tickets'=>isset($vars['show_assigned_tickets'])?0:1,

--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -29,6 +29,7 @@ class Cron {
         require_once(INCLUDE_DIR.'class.ticket.php');
         require_once(INCLUDE_DIR.'class.lock.php');
         Ticket::checkOverdue(); //Make stale tickets overdue
+        Ticket::ClosePending(); //Close pending tickets
         TicketLock::cleanup(); //Remove expired locks
     }
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3025,6 +3025,7 @@ class Ticket {
 
         }
    }
+
    // Close Pending tickets based on Pending Ticket Auto-Close from config
    function ClosePending() {
 	global $cfg;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2361,6 +2361,13 @@ class Ticket {
                 .'WHERE ticket.isanswered = 1 '
                 . $where
 
+                .'UNION SELECT \'pending\', count( ticket.ticket_id ) AS tickets '
+                .'FROM ' . TICKET_TABLE . ' ticket '
+                .'INNER JOIN '.TICKET_STATUS_TABLE. ' status
+                    ON (ticket.status_id=status.id
+                            AND status.name=\'pending\') '
+                . $where
+
                 .'UNION SELECT \'overdue\', count( ticket.ticket_id ) AS tickets '
                 .'FROM ' . TICKET_TABLE . ' ticket '
                 .'INNER JOIN '.TICKET_STATUS_TABLE. ' status

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3030,18 +3030,20 @@ class Ticket {
    function ClosePending() {
 	global $cfg;
 	
-	$days = $cfg->getAutoCloseGrace();
+	$grace = $cfg->getAutoCloseGrace();
 
-	if($days != 0){ 
+	if($grace != 0){ 
+
+	if($grace == 1){$dayplural = 'day';} else {$dayplural = 'days';}
 
 	// select all tickets marked as 'pending' where updated is older than ($days) days ago
 	$sql  = 'SELECT ticket_id FROM ' .TICKET_TABLE .' ticket '
 		 .' INNER JOIN '.TICKET_STATUS_TABLE.' status ON (status.id=ticket.status_id AND status.name = "pending") '
-	     .' AND TIME_TO_SEC(TIMEDIFF(NOW(),ticket.updated))>='.$days.'*86400';
+	     .' AND TIME_TO_SEC(TIMEDIFF(NOW(),ticket.updated))>='.$grace.'*86400';
 
         if(($res=db_query($sql)) && db_num_rows($res)) {
             while(list($id)=db_fetch_row($res)) {
-                if(($ticket=Ticket::lookup($id)) && $ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$days.' days of no activity.', false));
+                if(($ticket=Ticket::lookup($id)) && $ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$grace.' '.$dayplural.' of no activity.', false));
 	}}}
 
    }

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3018,6 +3018,24 @@ class Ticket {
 
         }
    }
+   // Close Pending tickets based on Pending Ticket Auto-Close from config
+   function ClosePending() {
+	global $cfg;
+	
+	$days = $cfg->getAutoCloseGrace();
 
+	if($days != 0){ 
+
+	// select all tickets marked as 'pending' where updated is older than ($days) days ago
+	$sql  = 'SELECT ticket_id FROM ' .TICKET_TABLE .' ticket '
+		 .' INNER JOIN '.TICKET_STATUS_TABLE.' status ON (status.id=ticket.status_id AND status.name = "pending") '
+	     .' AND TIME_TO_SEC(TIMEDIFF(NOW(),ticket.updated))>='.$days.'*86400';
+
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            while(list($id)=db_fetch_row($res)) {
+                if(($ticket=Ticket::lookup($id)) && $ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$days.' days of no activity.', false));
+	}}}
+
+   }
 }
 ?>

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -76,6 +76,13 @@ agent_collision_avoidance:
         <br><br>
         Enter <span class="doc-desc-opt">0</span> to disable the lockout feature.
 
+autoclose_grace_period:
+    title: Pending Ticket Auto-Close
+    content: >
+        Enter the number of Days before a ticket marked <b>Pending</b> will be Auto-Closed by the system.
+        <br><br>
+        Enter <span class="doc-desc-opt">0</span> to disable the Auto-Close feature.
+
 email_ticket_priority:
     title: Email Ticket Priority
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -150,6 +150,14 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td><?php echo __('<b>Pending</b> Ticket Auto-Close'); ?>:</td>
+            <td>
+                <input type="text" name="autoclose_grace_period" size=4 value="<?php echo $config['autoclose_grace_period']; ?>">&nbsp;Day(s)&nbsp;
+                <font class="error"><?php echo $errors['autoclose_grace_period']; ?></font>
+                <i class="help-tip icon-question-sign" href="#autoclose_grace_period"></i>
+            </td>
+        </tr>
+        <tr>
             <td><?php echo __('Human Verification');?>:</td>
             <td>
                 <input type="checkbox" name="enable_captcha" <?php echo $config['enable_captcha']?'checked="checked"':''; ?>>

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -30,6 +30,11 @@ switch(strtolower($_REQUEST['status'])){ //Status is overloaded
         $status='open';
 		$results_type=__('Open Tickets');
         break;
+    case 'pending':
+        $status='pending';
+        $showpending=true;
+		$results_type=__('Pending Tickets');
+        break;
     case 'closed':
         $status='closed';
 		$results_type=__('Closed Tickets');
@@ -105,6 +110,8 @@ if($staffId && ($staffId==$thisstaff->getId())) { //My tickets
     $qwhere.=' AND ticket.isoverdue=1 ';
 }elseif($showanswered) { ////Answered
     $qwhere.=' AND ticket.isanswered=1 ';
+}elseif($showpending) { ////Pending
+    $qwhere.=' AND status.name="pending" ';
 }elseif(!strcasecmp($status, 'open') && !$search) { //Open queue (on search OPEN means all open tickets - regardless of state).
     //Showing answered tickets on open queue??
     if(!$cfg->showAnsweredTickets())

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -433,6 +433,14 @@ if($stats['overdue']) {
         $sysnotice=sprintf(__('%d overdue tickets!'),$stats['overdue']);
 }
 
+if($stats['pending']) {
+        $nav->addSubMenu(array('desc'=>__('Pending').' ('.number_format($stats['pending']).')',
+                               'title'=>__('Pending Tickets'),
+                               'href'=>'tickets.php?status=pending',
+                               'iconclass'=>'Ticket'),
+                            ($_REQUEST['status']=='pending'));  
+}
+
 if($thisstaff->showAssignedOnly() && $stats['closed']) {
     $nav->addSubMenu(array('desc'=>__('My Closed Tickets').' ('.number_format($stats['closed']).')',
                            'title'=>__('My Closed Tickets'),


### PR DESCRIPTION
This will automatically close Pending Status tickets based on a database value entered on the ticket settings page.
To do:
- [ ] remove pending ticket queue and stats after #2577 implementation

Need help:
- [ ] set status using status name instead of id
