### PR TITLE
Retrieving ticket information via API

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -24,6 +24,8 @@ require_once INCLUDE_DIR."class.dispatcher.php";
 
 $dispatcher = patterns('',
         url_post("^/tickets\.(?P<format>xml|json|email)$", array('api.tickets.php:TicketApiController','create')),
+        url_post("^/status\.(?P<format>xml|json)$", array('api.tickets.php:TicketApiController','status')),
+        url_post("^/delete\.(?P<format>xml|json)$", array('api.tickets.php:TicketApiController','delete')),
         url('^/tasks/', patterns('',
                 url_post("^cron$", array('api.cron.php:CronApiController', 'execute'))
          ))


### PR DESCRIPTION
Added 2 Routes for the API. One for extracting information out of tickets (status.json/xml), one for deleting them (delete.json/xml - The purpose behind this was to delete tickets that were created to test the create-API).

Incorporated functions "status" and "delete", as well as a helperfunction into api.tickets.php.
It is now possible to directly assign an API-created ticket to a staffmember via staffmember-email and/or a department via department name.

The status method allows to access any property as well as any get-methods of a ticket specified by number, as well as the properties and get-functions of the result of said get-methods. It then returns them encoded as json.

The delete method simply deletes tickets via the specified ticketnumber.
