### PR TITLE
Add ability to email attachments to agents

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -810,6 +810,10 @@ class OsticketConfig extends Config {
         return ($this->get('email_attachments'));
     }
 
+    function emailAttachmentsToAgents() {
+        return ($this->get('email_attachments_agents'));
+    }
+
     function allowAttachments() {
         return ($this->get('allow_attachments'));
     }
@@ -1014,6 +1018,7 @@ class OsticketConfig extends Config {
             'add_email_collabs'=>isset($vars['add_email_collabs'])?1:0,
             'reply_separator'=>$vars['reply_separator'],
             'email_attachments'=>isset($vars['email_attachments'])?1:0,
+            'email_attachments_agents'=>isset($vars['email_attachments_agents'])?1:0,
          ));
     }
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1002,6 +1002,9 @@ class Ticket {
 
             $msg = $this->replaceVars($msg->asArray(), array('message' => $message));
 
+            /** @var message $message */
+            $attachments = $cfg->emailAttachmentsToAgents()?$message->getAttachments():array();
+
             $recipients=$sentlist=array();
             //Exclude the auto responding email just incase it's from staff member.
             if ($message->isAutoReply())
@@ -1010,7 +1013,7 @@ class Ticket {
             //Alert admin??
             if($cfg->alertAdminONNewTicket()) {
                 $alert = $this->replaceVars($msg, array('recipient' => 'Admin'));
-                $email->sendAlert($cfg->getAdminEmail(), $alert['subj'], $alert['body'], null, $options);
+                $email->sendAlert($cfg->getAdminEmail(), $alert['subj'], $alert['body'], $attachments, $options);
                 $sentlist[]=$cfg->getAdminEmail();
             }
 
@@ -1036,7 +1039,7 @@ class Ticket {
             foreach( $recipients as $k=>$staff) {
                 if(!is_object($staff) || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
                 $alert = $this->replaceVars($msg, array('recipient' => $staff));
-                $email->sendAlert($staff, $alert['subj'], $alert['body'], null, $options);
+                $email->sendAlert($staff, $alert['subj'], $alert['body'], $attachments, $options);
                 $sentlist[] = $staff->getEmail();
             }
         }
@@ -1282,6 +1285,10 @@ class Ticket {
                     'activity' => $vars['activity'],
                     'comments' => $vars['comments']));
 
+        /** @var ThreadEntry $threadEntry */
+        $threadEntry = $vars['threadentry'];
+        $attachments = $cfg->emailAttachmentsToAgents()?$threadEntry->getAttachments():array();
+
         $isClosed = $this->isClosed();
         $sentlist=array();
         foreach ($recipients as $k=>$staff) {
@@ -1297,7 +1304,7 @@ class Ticket {
                     )
                 continue;
             $alert = $this->replaceVars($msg, array('recipient' => $staff));
-            $email->sendAlert($staff, $alert['subj'], $alert['body'], null, $options);
+            $email->sendAlert($staff, $alert['subj'], $alert['body'], $attachments, $options);
             $sentlist[$staff->getEmail()] = 1;
         }
 
@@ -1842,6 +1849,8 @@ class Ticket {
 
             $msg = $this->replaceVars($msg->asArray(), $variables);
 
+            $attachments = $cfg->emailAttachmentsToAgents()?$message->getAttachments():array();
+
             //Build list of recipients and fire the alerts.
             $recipients=array();
             //Last respondent.
@@ -1874,7 +1883,7 @@ class Ticket {
             foreach( $recipients as $k=>$staff) {
                 if(!$staff || !$staff->getEmail() || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
                 $alert = $this->replaceVars($msg, array('recipient' => $staff));
-                $email->sendAlert($staff, $alert['subj'], $alert['body'], null, $options);
+                $email->sendAlert($staff, $alert['subj'], $alert['body'], $attachments, $options);
                 $sentlist[] = $staff->getEmail();
             }
         }

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -74,6 +74,7 @@ core:
     hide_staff_name: 0
     overlimit_notice_active: 0
     email_attachments: 1
+    email_attachments_agents: 0
     number_format: '######'
     sequence_id: 0
     log_level: 2

--- a/include/i18n/en_US/help/tips/settings.email.yaml
+++ b/include/i18n/en_US/help/tips/settings.email.yaml
@@ -124,6 +124,18 @@ default_mta:
         <span class="doc-desc-title">Default MTA</span> takes care of
         email delivery process for outgoing emails without SMTP setting.
 
+email_attachments:
+    title: Email Attachments to Users
+    content: >
+        If enabled, any attachments an Agent may attach to a ticket response will
+        be also included in the email to the User.
+
+email_attachments_agents:
+    title: Email Attachments to Agents
+    content: >
+        If enabled, any attachments a User or another Agent may attach in a new ticket,
+        response, or internal note, will be included in the alert email sent to Agents.
+
 verify_email_addrs:
     title: Verify Email Addresses
     content: >

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -142,9 +142,3 @@ max_file_size:
         Choose a maximum file size for attachments uploaded by agents. This
         includes canned attachments, knowledge base articles, and
         attachments to ticket replies.
-
-ticket_response_files:
-    title: Ticket Response Files
-    content: >
-        If enabled, any attachments an Agent may attach to a ticket response will
-        be also included in the email to the User.

--- a/include/staff/settings-emails.inc.php
+++ b/include/staff/settings-emails.inc.php
@@ -167,7 +167,11 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config)
             <td>
                 <input type="checkbox" name="email_attachments" <?php echo $config['email_attachments']?'checked="checked"':''; ?>>
                 <?php echo __('Email attachments to the user'); ?>
-                <i class="help-tip icon-question-sign" href="#ticket_response_files"></i>
+                <i class="help-tip icon-question-sign" href="#email_attachments"></i>
+                &nbsp;
+                <input type="checkbox" name="email_attachments_agents" <?php echo $config['email_attachments_agents']?'checked="checked"':''; ?>>
+                <?php echo __('Email attachments to agents'); ?>
+                <i class="help-tip icon-question-sign" href="#email_attachments_agents"></i>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
Adds a new setting: "Email attachments to agents" (off by default).
When attachments are added when making a ticket, a user replies to a ticket, an internal reply is added, or another agent replies, they can be added to the agent alert emails.

Also fixed a bug where the tip when hovering over "email attachments to the user" was empty.
