### PR TITLE
php: Support PHP 7, require at least 5.4

### DIFF
--- a/include/JSON.php
+++ b/include/JSON.php
@@ -129,7 +129,7 @@ class Services_JSON
     *                                   bubble up with an error, so all return values
     *                                   from encode() should be checked with isError()
     */
-    function Services_JSON($use = 0)
+    function __construct($use = 0)
     {
         $this->use = $use;
     }
@@ -779,10 +779,10 @@ if (class_exists('PEAR_Error')) {
 
     class Services_JSON_Error extends PEAR_Error
     {
-        function Services_JSON_Error($message = 'unknown error', $code = null,
+        function __construct($message = 'unknown error', $code = null,
                                      $mode = null, $options = null, $userinfo = null)
         {
-            parent::PEAR_Error($message, $code, $mode, $options, $userinfo);
+            parent::__construct($message, $code, $mode, $options, $userinfo);
         }
     }
 
@@ -793,7 +793,7 @@ if (class_exists('PEAR_Error')) {
      */
     class Services_JSON_Error
     {
-        function Services_JSON_Error($message = 'unknown error', $code = null,
+        function __construct($message = 'unknown error', $code = null,
                                      $mode = null, $options = null, $userinfo = null)
         {
 

--- a/include/PasswordHash.php
+++ b/include/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 

--- a/include/ajax.note.php
+++ b/include/ajax.note.php
@@ -54,14 +54,14 @@ class NoteAjaxAPI extends AjaxController {
             Http::response(403, "Login required");
         elseif (!isset($_POST['note']) || !$_POST['note'])
             Http::response(422, "Send `note` parameter");
-        elseif (!($note = QuickNote::create(array(
-                'staff_id' => $thisstaff->getId(),
-                'body' => Format::sanitize($_POST['note']),
-                'created' => new SqlFunction('NOW'),
-                'ext_id' => $ext_id,
-                ))))
-            Http::response(500, "Unable to create new note");
-        elseif (!$note->save(true))
+
+        $note = new QuickNote(array(
+            'staff_id' => $thisstaff->getId(),
+            'body' => Format::sanitize($_POST['note']),
+            'created' => new SqlFunction('NOW'),
+            'ext_id' => $ext_id,
+        ));
+        if (!$note->save(true))
             Http::response(500, "Unable to create new note");
 
         $show_options = true;

--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -129,7 +129,7 @@ class TicketApiController extends ApiController {
         # Create the ticket with the data (attempt to anyway)
         $errors = array();
 
-        $ticket = Ticket::create2($data, $errors, $data['source'], $autorespond, $alert);
+        $ticket = Ticket::create($data, $errors, $data['source'], $autorespond, $alert);
         # Return errors (?)
         if (count($errors)) {
             if(isset($errors['errno']) && $errors['errno'] == 403)

--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -129,7 +129,7 @@ class TicketApiController extends ApiController {
         # Create the ticket with the data (attempt to anyway)
         $errors = array();
 
-        $ticket = Ticket::create($data, $errors, $data['source'], $autorespond, $alert);
+        $ticket = Ticket::create2($data, $errors, $data['source'], $autorespond, $alert);
         # Return errors (?)
         if (count($errors)) {
             if(isset($errors['errno']) && $errors['errno'] == 403)

--- a/include/class.ajax.php
+++ b/include/class.ajax.php
@@ -25,9 +25,6 @@ require_once (INCLUDE_DIR.'class.api.php');
  * consistency.
  */
 class AjaxController extends ApiController {
-    function AjaxController() {
-    
-    }
     function staffOnly() {
         global $thisstaff;
         if(!$thisstaff || !$thisstaff->isValid()) {

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -19,7 +19,7 @@ class API {
 
     var $ht;
 
-    function API($id) {
+    function __construct($id) {
         $this->id = 0;
         $this->load($id);
     }

--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -130,14 +130,14 @@ extends InstrumentedList {
                 $fileId = $file['id'];
             elseif (isset($file['tmp_name']) && ($F = AttachmentFile::upload($file)))
                 $fileId = $F->getId();
-            elseif ($F = AttachmentFile::createFile($file))
+            elseif ($F = AttachmentFile::create($file))
                 $fileId = $F->getId();
             else
                 continue;
 
             $_inline = isset($file['inline']) ? $file['inline'] : $inline;
 
-            $att = $this->add(Attachment::create(array(
+            $att = $this->add(new Attachment(array(
                 'file_id' => $fileId,
                 'inline' => $_inline ? 1 : 0,
             )));

--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -130,7 +130,7 @@ extends InstrumentedList {
                 $fileId = $file['id'];
             elseif (isset($file['tmp_name']) && ($F = AttachmentFile::upload($file)))
                 $fileId = $F->getId();
-            elseif ($F = AttachmentFile::create($file))
+            elseif ($F = AttachmentFile::createFile($file))
                 $fileId = $F->getId();
             else
                 continue;

--- a/include/class.canned.php
+++ b/include/class.canned.php
@@ -207,7 +207,7 @@ extends VerySimpleModel {
     /*** Static functions ***/
 
     static function create($vars=false) {
-        $faq = parent::create($vars);
+        $faq = new static($vars);
         $faq->created = SqlFunction::NOW();
         return $faq;
     }

--- a/include/class.captcha.php
+++ b/include/class.captcha.php
@@ -18,7 +18,7 @@ class Captcha {
     var $bgimages=array('cottoncandy.png','grass.png','ripple.png','silk.png','whirlpool.png',
                         'bubbles.png','crackle.png','lines.png','sand.png','snakeskin.png');
     var $font = 10;
-    function Captcha($len=6,$font=7,$bg=''){
+    function __construct($len=6,$font=7,$bg=''){
 
         $this->hash = strtoupper(substr(md5(rand(0, 9999)),rand(0, 24),$len));
         $this->font = $font;

--- a/include/class.category.php
+++ b/include/class.category.php
@@ -244,7 +244,7 @@ class Category extends VerySimpleModel {
     }
 
     static function create($vars=false) {
-        $category = parent::create($vars);
+        $category = new static($vars);
         $category->created = SqlFunction::NOW();
         return $category;
     }

--- a/include/class.collaborator.php
+++ b/include/class.collaborator.php
@@ -115,7 +115,7 @@ implements EmailContact, ITicketUser {
     }
 
     static function create($vars=false) {
-        $inst = parent::create($vars);
+        $inst = new static($vars);
         $inst->created = SqlFunction::NOW();
         return $inst;
     }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -98,7 +98,7 @@ class Config {
     }
 
     function create($key, $value) {
-        $item = ConfigItem::create([
+        $item = new ConfigItem([
             $this->section_column => $this->section,
             'key' => $key,
             'value' => $value,
@@ -215,9 +215,10 @@ class OsticketConfig extends Config {
         if (count($this->config) == 0) {
             // Fallback for osticket < 1.7@852ca89e
             $sql='SELECT * FROM '.$this->table.' WHERE id = 1';
+            $meta = ConfigItem::getMeta();
             if (($res=db_query($sql)) && db_num_rows($res))
                 foreach (db_fetch_array($res) as $key=>$value)
-                    $this->config[$key] = new ConfigItem(array('value'=>$value));
+                    $this->config[$key] = $meta->newInstance(array('value'=>$value));
         }
 
         return true;

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -30,7 +30,7 @@ class Config {
     # new settings and the corresponding default values.
     var $defaults = array();                # List of default values
 
-    function Config($section=null, $defaults=array()) {
+    function __construct($section=null, $defaults=array()) {
         if ($section)
             $this->section = $section;
 
@@ -209,8 +209,8 @@ class OsticketConfig extends Config {
         'max_open_tickets' => 0,
     );
 
-    function OsticketConfig($section=null) {
-        parent::Config($section);
+    function __construct($section=null) {
+        parent::__construct($section);
 
         if (count($this->config) == 0) {
             // Fallback for osticket < 1.7@852ca89e

--- a/include/class.crypto.php
+++ b/include/class.crypto.php
@@ -231,7 +231,7 @@ class CryptoAlgo {
 
     var $ciphers = null;
 
-    function  CryptoAlgo($tag) {
+    function __construct($tag) {
         $this->tag_number = $tag;
     }
 
@@ -332,8 +332,8 @@ Class CryptoMcrypt extends CryptoAlgo {
                 ),
             );
 
-    function getCipher($cid=null) {
-        return parent::getCipher($cid, array($this, '_checkCipher'));
+    function getCipher($cid=null, $callback=false) {
+        return parent::getCipher($cid, $callback ?: array($this, '_checkCipher'));
     }
 
    function _checkCipher($c) {
@@ -465,8 +465,8 @@ class CryptoOpenSSL extends CryptoAlgo {
             ? $cipher['method']: '';
     }
 
-    function getCipher($cid) {
-        return parent::getCipher($cid, array($this, '_checkCipher'));
+    function getCipher($cid=null, $callback=false) {
+        return parent::getCipher($cid, $callback ?: array($this, '_checkCipher'));
     }
 
     function _checkCipher($c) {
@@ -580,8 +580,8 @@ class CryptoPHPSecLib extends CryptoAlgo {
         return new $class($c['mode']);
     }
 
-    function getCipher($cid) {
-        return  parent::getCipher($cid, array($this, '_checkCipher'));
+    function getCipher($cid=null, $callback=false) {
+        return  parent::getCipher($cid, $callback ?: array($this, '_checkCipher'));
     }
 
     function _checkCipher($c) {

--- a/include/class.csrf.php
+++ b/include/class.csrf.php
@@ -34,7 +34,7 @@ Class CSRF {
 
     var $csrf;
 
-    function CSRF($name='__CSRFToken__', $timeout=0) {
+    function __construct($name='__CSRFToken__', $timeout=0) {
 
         $this->name = $name;
         $this->timeout = $timeout;

--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -558,9 +558,8 @@ implements TemplateVariable {
     }
 
     static function create($vars=false, &$errors=array()) {
-        $dept = parent::create($vars);
+        $dept = new static($vars);
         $dept->created = SqlFunction::NOW();
-
         return $dept;
     }
 

--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -733,7 +733,7 @@ extends Form {
         return $clean;
     }
 
-    function render($staff=true) {
-        return parent::render($staff, false, array('template' => 'dynamic-form-simple.tmpl.php'));
+    function render($staff=true, $title=false, $options=array()) {
+        return parent::render($staff, $title, $options + array('template' => 'dynamic-form-simple.tmpl.php'));
     }
 }

--- a/include/class.dispatcher.php
+++ b/include/class.dispatcher.php
@@ -21,7 +21,7 @@
  * functions aren't separated
  */
 class Dispatcher {
-    function Dispatcher($file=false) {
+    function __construct($file=false) {
         $this->urls = array();
         $this->file = $file;
     }
@@ -81,7 +81,7 @@ class Dispatcher {
 }
 
 class UrlMatcher {
-    function UrlMatcher($regex, $func, $args=false, $method=false) {
+    function __construct($regex, $func, $args=false, $method=false) {
         # Add the slashes for the Perl syntax
         $this->regex = "@" . $regex . "@";
         $this->func = $func;

--- a/include/class.draft.php
+++ b/include/class.draft.php
@@ -146,7 +146,7 @@ class Draft extends VerySimpleModel {
 
         $vars['created'] = SqlFunction::NOW();
         $vars['staff_id'] = self::getCurrentUserId();
-        $draft = parent::create($vars);
+        $draft = new static($vars);
 
         // Cloned attachments ...
         if (false && $attachments && is_array($attachments))

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -216,7 +216,7 @@ class DynamicForm extends VerySimpleModel {
     }
 
     static function create($ht=false) {
-        $inst = parent::create($ht);
+        $inst = new static($ht);
         $inst->set('created', new SqlFunction('NOW'));
         if (isset($ht['fields'])) {
             $inst->save();
@@ -896,7 +896,7 @@ class DynamicFormField extends VerySimpleModel {
     }
 
     static function create($ht=false) {
-        $inst = parent::create($ht);
+        $inst = new static($ht);
         $inst->set('created', new SqlFunction('NOW'));
         if (isset($ht['configuration']))
             $inst->configuration = JsonDataEncoder::encode($ht['configuration']);
@@ -1288,7 +1288,7 @@ class DynamicFormEntry extends VerySimpleModel {
     }
 
     static function create($ht=false, $data=null) {
-        $inst = parent::create($ht);
+        $inst = new static($ht);
         $inst->set('created', new SqlFunction('NOW'));
         if ($data)
             $inst->setSource($data);
@@ -1297,7 +1297,7 @@ class DynamicFormEntry extends VerySimpleModel {
                 continue;
             if (!$impl->hasData() || !$impl->isStorable())
                 continue;
-            $a = DynamicFormEntryAnswer::create(
+            $a = new DynamicFormEntryAnswer(
                 array('field'=>$field, 'entry'=>$inst));
             $a->field->setAnswer($a);
             $inst->answers->add($a);

--- a/include/class.email.php
+++ b/include/class.email.php
@@ -224,7 +224,7 @@ class Email extends VerySimpleModel {
     }
 
     static function create($vars=false) {
-        $inst = parent::create($vars);
+        $inst = new static($vars);
         $inst->created = SqlFunction::NOW();
         return $inst;
     }

--- a/include/class.error.php
+++ b/include/class.error.php
@@ -17,7 +17,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 
-class Error extends Exception {
+class BaseError extends Exception {
     static $title = '';
     static $sendAlert = true;
 
@@ -42,7 +42,7 @@ class Error extends Exception {
     }
 }
 
-class InitialDataError extends Error {
+class InitialDataError extends BaseError {
     static $title = 'Problem with install initial data';
 }
 
@@ -52,7 +52,7 @@ function raise_error($message, $class=false) {
 }
 
 // File storage backend exceptions
-class IOException extends Error {
+class IOException extends BaseError {
     static $title = 'Unable to read resource content';
 }
 

--- a/include/class.export.php
+++ b/include/class.export.php
@@ -393,7 +393,7 @@ class DatabaseExporter {
         USER_ACCOUNT_TABLE, ORGANIZATION_TABLE, NOTE_TABLE
     );
 
-    function DatabaseExporter($stream, $options=array()) {
+    function __construct($stream, $options=array()) {
         $this->stream = $stream;
         $this->options = $options;
     }

--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -338,7 +338,7 @@ class FAQ extends VerySimpleModel {
     }
 
     static function create($vars=false) {
-        $faq = parent::create($vars);
+        $faq = new static($vars);
         $faq->created = SqlFunction::NOW();
         return $faq;
     }

--- a/include/class.file.php
+++ b/include/class.file.php
@@ -293,7 +293,7 @@ class AttachmentFile extends VerySimpleModel {
                     'tmp_name'=>$file['tmp_name'],
                     );
 
-        return static::createFile($info, $ft, $deduplicate);
+        return static::create($info, $ft, $deduplicate);
     }
 
     static function uploadLogo($file, &$error, $aspect_ratio=2) {
@@ -327,7 +327,7 @@ class AttachmentFile extends VerySimpleModel {
         return false;
     }
 
-    static function createFile(&$file, $ft='T', $deduplicate=true) {
+    static function create(&$file, $ft='T', $deduplicate=true) {
         if (isset($file['encoding'])) {
             switch ($file['encoding']) {
             case 'base64':
@@ -380,7 +380,7 @@ class AttachmentFile extends VerySimpleModel {
             $file['type'] = 'application/octet-stream';
 
 
-        $f = static::create(array(
+        $f = new static(array(
             'type' => strtolower($file['type']),
             'name' => $file['name'],
             'key' => $file['key'],
@@ -445,7 +445,7 @@ class AttachmentFile extends VerySimpleModel {
     }
 
     static function __create($file, &$errors) {
-        return static::createFile($file);
+        return static::create($file);
     }
 
     /**

--- a/include/class.file.php
+++ b/include/class.file.php
@@ -293,7 +293,7 @@ class AttachmentFile extends VerySimpleModel {
                     'tmp_name'=>$file['tmp_name'],
                     );
 
-        return static::create($info, $ft, $deduplicate);
+        return static::createFile($info, $ft, $deduplicate);
     }
 
     static function uploadLogo($file, &$error, $aspect_ratio=2) {
@@ -327,7 +327,7 @@ class AttachmentFile extends VerySimpleModel {
         return false;
     }
 
-    static function create(&$file, $ft='T', $deduplicate=true) {
+    static function createFile(&$file, $ft='T', $deduplicate=true) {
         if (isset($file['encoding'])) {
             switch ($file['encoding']) {
             case 'base64':
@@ -380,7 +380,7 @@ class AttachmentFile extends VerySimpleModel {
             $file['type'] = 'application/octet-stream';
 
 
-        $f = parent::create(array(
+        $f = static::create(array(
             'type' => strtolower($file['type']),
             'name' => $file['name'],
             'key' => $file['key'],
@@ -445,7 +445,7 @@ class AttachmentFile extends VerySimpleModel {
     }
 
     static function __create($file, &$errors) {
-        return static::create($file);
+        return static::createFile($file);
     }
 
     /**

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -530,7 +530,7 @@ class Filter {
 
             switch ($action) {
             case 'N': # new filter action
-                $I = FilterAction::create(array(
+                $I = new FilterAction(array(
                     'type'=>$info,
                     'filter_id'=>$id,
                     'sort' => (int) $sort,

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -37,7 +37,7 @@ class Filter {
         ),
     );
 
-    function Filter($id) {
+    function __construct($id) {
         $this->id=0;
         $this->load($id);
     }
@@ -561,7 +561,7 @@ class FilterRule {
 
     var $filter;
 
-    function FilterRule($id,$filterId=0) {
+    function __construct($id,$filterId=0) {
         $this->id=0;
         $this->load($id,$filterId);
     }
@@ -697,7 +697,7 @@ class TicketFilter {
      *  ---------------
      *  @see Filter::matches() for a complete list of supported keys
      */
-    function TicketFilter($origin, $vars=array()) {
+    function __construct($origin, $vars=array()) {
 
         //Normalize the target based on ticket's origin.
         $this->target = self::origin2target($origin);

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2651,7 +2651,7 @@ class FileUploadField extends FormField {
         if ($file['size'] > $config['size'])
             throw new FileUploadError(__('File size is too large'));
 
-        if (!$F = AttachmentFile::createFile($file))
+        if (!$F = AttachmentFile::create($file))
             throw new FileUploadError(__('Unable to save file'));
 
         return $F;

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2509,14 +2509,14 @@ class FileUploadField extends FormField {
         static $filetypes;
 
         if (!isset($filetypes)) {
-            if (function_exists('apc_fetch')) {
+            if (function_exists('apcu_fetch')) {
                 $key = md5(SECRET_SALT . GIT_VERSION . 'filetypes');
-                $filetypes = apc_fetch($key);
+                $filetypes = apcu_fetch($key);
             }
             if (!$filetypes)
                 $filetypes = YamlDataParser::load(INCLUDE_DIR . '/config/filetype.yaml');
             if ($key)
-                apc_store($key, $filetypes, 7200);
+                apcu_store($key, $filetypes, 7200);
         }
         return $filetypes;
     }

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2166,8 +2166,8 @@ FormField::addFieldTypes(/*@trans*/ 'Dynamic Fields', function() {
 
 
 class DepartmentField extends ChoiceField {
-    function getWidget() {
-        $widget = parent::getWidget();
+    function getWidget($widgetClass=false) {
+        $widget = parent::getWidget($widgetClass);
         if ($widget->value instanceof Dept)
             $widget->value = $widget->value->getId();
         return $widget;
@@ -2177,7 +2177,7 @@ class DepartmentField extends ChoiceField {
         return true;
     }
 
-    function getChoices() {
+    function getChoices($verbose=false) {
         global $cfg;
 
         $choices = array();
@@ -2235,8 +2235,8 @@ class AssigneeField extends ChoiceField {
     var $_choices = null;
     var $_criteria = null;
 
-    function getWidget() {
-        $widget = parent::getWidget();
+    function getWidget($widgetClass=false) {
+        $widget = parent::getWidget($widgetClass);
         if (is_object($widget->value))
             $widget->value = $widget->value->getId();
         return $widget;
@@ -2261,7 +2261,7 @@ class AssigneeField extends ChoiceField {
         $this->_choices = $choices;
     }
 
-    function getChoices() {
+    function getChoices($verbose=false) {
         global $cfg;
 
         if (!isset($this->_choices)) {
@@ -2651,7 +2651,7 @@ class FileUploadField extends FormField {
         if ($file['size'] > $config['size'])
             throw new FileUploadError(__('File size is too large'));
 
-        if (!$F = AttachmentFile::create($file))
+        if (!$F = AttachmentFile::createFile($file))
             throw new FileUploadError(__('Unable to save file'));
 
         return $F;
@@ -3071,7 +3071,7 @@ class TextboxWidget extends Widget {
 
 class TextboxSelectionWidget extends TextboxWidget {
     //TODO: Support multi-input e.g comma separated inputs
-    function render($options=array()) {
+    function render($options=array(), $extraConfig=array()) {
 
         if ($this->value && is_array($this->value))
             $this->value = current($this->value);
@@ -4072,9 +4072,9 @@ class AssignmentForm extends Form {
             return $fields[$name];
     }
 
-    function isValid() {
+    function isValid($include=false) {
 
-        if (!parent::isValid() || !($f=$this->getField('assignee')))
+        if (!parent::isValid($include) || !($f=$this->getField('assignee')))
             return false;
 
         // Do additional assignment validation
@@ -4212,9 +4212,9 @@ class TransferForm extends Form {
         return $this->fields;
     }
 
-    function isValid() {
+    function isValid($include=false) {
 
-        if (!parent::isValid())
+        if (!parent::isValid($include))
             return false;
 
         // Do additional validations

--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -23,7 +23,7 @@ class Internationalization {
     // fallback
     var $langs = array('en_US');
 
-    function Internationalization($language=false) {
+    function __construct($language=false) {
         global $cfg;
 
         if ($cfg && ($lang = $cfg->getPrimaryLanguage()))
@@ -540,7 +540,7 @@ class DataTemplate {
      * template itself does not have to keep track of the language for which
      * it is defined.
      */
-    function DataTemplate($path, $langs=array('en_US')) {
+    function __construct($path, $langs=array('en_US')) {
         foreach ($langs as $l) {
             if (file_exists("{$this->base}/$l/$path")) {
                 $this->lang = $l;

--- a/include/class.knowledgebase.php
+++ b/include/class.knowledgebase.php
@@ -17,7 +17,7 @@ require_once("class.file.php");
 
 class Knowledgebase {
 
-    function Knowledgebase($id) {
+    function __construct($id) {
         $res=db_query(
             'SELECT title, isenabled, dept_id, created, updated '
            .'FROM '.CANNED_TABLE.' WHERE canned_id='.db_input($id));

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -478,7 +478,7 @@ class DynamicList extends VerySimpleModel implements CustomList {
             $ht['configuration'] = JsonDataEncoder::encode($ht['configuration']);
         }
 
-        $inst = parent::create($ht);
+        $inst = new static($ht);
         $inst->set('created', new SqlFunction('NOW'));
 
         if (isset($ht['properties'])) {
@@ -798,7 +798,7 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
         if (isset($ht['properties']) && is_array($ht['properties']))
             $ht['properties'] = JsonDataEncoder::encode($ht['properties']);
 
-        $inst = parent::create($ht);
+        $inst = new static($ht);
 
         // Auto-config properties if any
         if ($ht['configuration'] && is_array($ht['configuration'])) {
@@ -1398,7 +1398,7 @@ implements CustomListItem, TemplateVariable {
 
         $ht['created'] = new SqlFunction('NOW');
 
-        return  parent::create($ht);
+        return new static($ht);
     }
 
     static function lookup($var, $list=null) {

--- a/include/class.lock.php
+++ b/include/class.lock.php
@@ -115,7 +115,7 @@ class Lock extends VerySimpleModel {
             return null;
 
         // Create the new lock.
-        $lock = parent::create(array(
+        $lock = new static(array(
             'created' => SqlFunction::NOW(),
             'staff_id' => $staffId,
             'expire' => SqlExpression::plus(

--- a/include/class.lock.php
+++ b/include/class.lock.php
@@ -128,11 +128,6 @@ class Lock extends VerySimpleModel {
             return $lock;
     }
 
-    static function create($staffId, $lockTime) {
-        if ($lock = self::acquire($staffId, $lockTime))
-            return $lock;
-    }
-
     // Simply remove ALL locks a user (staff) holds on a ticket(s).
     static function removeStaffLocks($staffId, $object=false) {
         $locks = static::objects()->filter(array(

--- a/include/class.log.php
+++ b/include/class.log.php
@@ -19,7 +19,7 @@ class Log {
     var $id;
     var $info;
 
-    function Log($id){
+    function __construct($id){
         $this->id=0;
         return $this->load($id);
     }

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -30,7 +30,7 @@ class Mailer {
     var $smtp = array();
     var $eol="\n";
 
-    function Mailer($email=null, array $options=array()) {
+    function __construct($email=null, array $options=array()) {
         global $cfg;
 
         if(is_object($email) && $email->isSMTPEnabled() && ($info=$email->getSMTPInfo())) { //is SMTP enabled for the current email?

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -792,7 +792,7 @@ class MailFetcher {
             // NOTE: This might not be a "ticket"
             $ticket = $thread->getObject();
         }
-        elseif (($ticket=Ticket::create2($vars, $errors, 'Email'))) {
+        elseif (($ticket=Ticket::create($vars, $errors, 'Email'))) {
             $message = $ticket->getLastMessage();
         }
         else {

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -33,7 +33,7 @@ class MailFetcher {
 
     var $tnef = false;
 
-    function MailFetcher($email, $charset='UTF-8') {
+    function __construct($email, $charset='UTF-8') {
 
 
         if($email && is_numeric($email)) //email_id
@@ -792,7 +792,7 @@ class MailFetcher {
             // NOTE: This might not be a "ticket"
             $ticket = $thread->getObject();
         }
-        elseif (($ticket=Ticket::create($vars, $errors, 'Email'))) {
+        elseif (($ticket=Ticket::create2($vars, $errors, 'Email'))) {
             $message = $ticket->getLastMessage();
         }
         else {

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -32,7 +32,7 @@ class Mail_Parse {
 
     var $tnef = false;      // TNEF encoded mail
 
-    function Mail_parse(&$mimeMessage, $charset=null){
+    function __construct(&$mimeMessage, $charset=null){
 
         $this->mime_message = &$mimeMessage;
 
@@ -581,7 +581,7 @@ class EmailDataParser {
     var $stream;
     var $error;
 
-    function EmailDataParser($stream=null) {
+    function __construct($stream=null) {
         $this->stream = $stream;
     }
 

--- a/include/class.migrater.php
+++ b/include/class.migrater.php
@@ -33,12 +33,10 @@ class DatabaseMigrater {
     var $end;
     var $sqldir;
 
-    function DatabaseMigrater($start, $end, $sqldir) {
-
+    function __construct($start, $end, $sqldir) {
         $this->start = $start;
         $this->end = $end;
         $this->sqldir = $sqldir;
-
     }
 
     function getPatches($stop=null) {

--- a/include/class.nav.php
+++ b/include/class.nav.php
@@ -23,7 +23,7 @@ class StaffNav {
 
     var $staff;
 
-    function StaffNav($staff, $panel='staff'){
+    function __construct($staff, $panel='staff'){
         $this->staff=$staff;
         $this->panel=strtolower($panel);
     }
@@ -206,8 +206,8 @@ class StaffNav {
 
 class AdminNav extends StaffNav{
 
-    function AdminNav($staff){
-        parent::StaffNav($staff, 'admin');
+    function __construct($staff){
+        parent::__construct($staff, 'admin');
     }
 
     function getRegisteredApps() {
@@ -296,7 +296,7 @@ class UserNav {
 
     var $user;
 
-    function UserNav($user=null, $active=''){
+    function __construct($user=null, $active=''){
 
         $this->user=$user;
         $this->navs=$this->getNavs();

--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -448,8 +448,8 @@ implements TemplateVariable {
 
     static function fromVars($vars) {
 
-        if (!($org = Organization::lookup(array('name' => $vars['name'])))) {
-            $org = Organization::create(array(
+        if (!($org = static::lookup(array('name' => $vars['name'])))) {
+            $org = static::create(array(
                 'name' => $vars['name'],
                 'updated' => new SqlFunction('NOW'),
             ));
@@ -474,7 +474,7 @@ implements TemplateVariable {
         // Make sure the name is not in-use
         if (($field=$form->getField('name'))
                 && $field->getClean()
-                && Organization::lookup(array('name' => $field->getClean()))) {
+                && static::lookup(array('name' => $field->getClean()))) {
             $field->addError(__('Organization with the same name already exists'));
             $valid = false;
         }
@@ -483,7 +483,7 @@ implements TemplateVariable {
     }
 
     static function create($vars=false) {
-        $org = parent::create($vars);
+        $org = new static($vars);
 
         $org->created = new SqlFunction('NOW');
         $org->setStatus(self::SHARE_PRIMARY_CONTACT);
@@ -493,7 +493,7 @@ implements TemplateVariable {
     // Custom create called by installer/upgrader to load initial data
     static function __create($ht, &$error=false) {
 
-        $org = Organization::create($ht);
+        $org = static::create($ht);
         // Add dynamic data (if any)
         if ($ht['fields']) {
             $org->save(true);

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -258,7 +258,7 @@ class ModelMeta implements ArrayAccess {
             self::$model_cache = function_exists('apcu_fetch');
         if (self::$model_cache) {
             $key = SECRET_SALT.GIT_VERSION."/orm/{$this['table']}";
-            if ($fields = apc_fetch($key)) {
+            if ($fields = apcu_fetch($key)) {
                 return $fields;
             }
         }

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -110,7 +110,7 @@ class ModelMeta implements ArrayAccess {
         $this->meta = $meta;
 
         if (function_exists('apcu_store')) {
-            apcu_store($apc_key, $this->meta);
+            apcu_store($apc_key, $this->meta, 1800);
         }
     }
 
@@ -255,16 +255,16 @@ class ModelMeta implements ArrayAccess {
 
     function inspectFields() {
         if (!isset(self::$model_cache))
-            self::$model_cache = function_exists('apc_fetch');
+            self::$model_cache = function_exists('apcu_fetch');
         if (self::$model_cache) {
-            $key = md5(SECRET_SALT . GIT_VERSION . $this['table']);
+            $key = SECRET_SALT.GIT_VERSION."/orm/{$this['table']}";
             if ($fields = apc_fetch($key)) {
                 return $fields;
             }
         }
         $fields = DbEngine::getCompiler()->inspectTable($this['table']);
         if (self::$model_cache) {
-            apc_store($key, $fields);
+            apcu_store($key, $fields, 1800);
         }
         return $fields;
     }

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -458,10 +458,11 @@ class VerySimpleModel {
      */
     static function lookup($criteria) {
         // Model::lookup(1), where >1< is the pk value
+        $args = func_get_args();
         if (!is_array($criteria)) {
             $criteria = array();
             $pk = static::getMeta('pk');
-            foreach (func_get_args() as $i=>$f)
+            foreach ($args as $i=>$f)
                 $criteria[$pk[$i]] = $f;
 
             // Only consult cache for PK lookup, which is assumed if the
@@ -653,7 +654,7 @@ class AnnotatedModel {
 class SqlFunction {
     var $alias;
 
-    function SqlFunction($name) {
+    function __construct($name) {
         $this->func = $name;
         $this->args = array_slice(func_get_args(), 1);
     }

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -51,7 +51,7 @@ class osTicket {
     var $company;
     var $plugins;
 
-    function osTicket() {
+    function __construct() {
 
         require_once(INCLUDE_DIR.'class.config.php'); //Config helper
         require_once(INCLUDE_DIR.'class.company.php');

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -27,7 +27,7 @@ class osTicketSession {
     var $id = '';
     var $backend;
 
-    function osTicketSession($ttl=0){
+    function __construct($ttl=0){
         $this->ttl = $ttl ?: ini_get('session.gc_maxlifetime') ?: SESSION_TTL;
 
         // Set osTicket specific session name.

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -164,60 +164,62 @@ abstract class SessionBackend {
     abstract function gc($maxlife);
 }
 
+class SessionData
+extends VerySimpleModel {
+    static $meta = array(
+        'table' => SESSION_TABLE,
+        'pk' => array('session_id'),
+    );
+}
+
 class DbSessionBackend
 extends SessionBackend {
-
-    function read($id){
-        $this->isnew = false;
-        if (!$this->data || $this->id != $id) {
-            $sql='SELECT session_data FROM '.SESSION_TABLE
-                .' WHERE session_id='.db_input($id)
-                .'  AND session_expire>NOW()';
-            if(!($res=db_query($sql)))
-                return false;
-            elseif (db_num_rows($res))
-                list($this->data)=db_fetch_row($res);
-            else
-                // No session data on record -- new session
-                $this->isnew = true;
+    function read($id) {
+        try {
+            $this->data = SessionData::objects()->filter([
+                'session_id' => $id,
+                'session_expire__gt' => SqlFunction::NOW(),
+            ])->one();
             $this->id = $id;
         }
-        $this->data_hash = md5($id.$this->data);
-        return $this->data;
+        catch (DoesNotExist $e) {
+            $this->data = new SessionData(['session_id' => $id]);
+        }
+        catch (OrmException $e) {
+            return false;
+        }
+        return $this->data->session_data;
     }
 
     function update($id, $data){
         global $thisstaff;
 
-        if (md5($id.$data) == $this->data_hash)
-            return;
+        if (defined('DISABLE_SESSION') && $this->data->__new__)
+            return true;
 
-        elseif (defined('DISABLE_SESSION') && $this->isnew)
-            return;
-
-        $ttl = ($this && get_class($this) == 'osTicketSession')
+        $ttl = $this && method_exists($this, 'getTTL')
             ? $this->getTTL() : SESSION_TTL;
 
-        $sql='REPLACE INTO '.SESSION_TABLE.' SET session_updated=NOW() '.
-             ',session_id='.db_input($id).
-             ',session_data=0x'.bin2hex($data).
-             ',session_expire=(NOW() + INTERVAL '.$ttl.' SECOND)'.
-             ',user_id='.db_input($thisstaff?$thisstaff->getId():0).
-             ',user_ip='.db_input($_SERVER['REMOTE_ADDR']).
-             ',user_agent='.db_input($_SERVER['HTTP_USER_AGENT']);
+        assert($this->data->session_id == $id);
 
-        $this->data = '';
-        return (db_query($sql) && db_affected_rows());
+        $this->data->session_data = $data;
+        $this->data->session_expire =
+            SqlFunction::NOW()->plus(SqlInterval::SECOND($ttl));
+        $this->data->user_id = $thisstaff ? $thisstaff->getId() : 0;
+        $this->data->user_ip = $_SERVER['REMOTE_ADDR'];
+        $this->data->user_agent = $_SERVER['HTTP_USER_AGENT'];
+
+        return $this->data->save();
     }
 
     function destroy($id){
-        $sql='DELETE FROM '.SESSION_TABLE.' WHERE session_id='.db_input($id);
-        return (db_query($sql) && db_affected_rows());
+        return SessionData::objects()->filter(['session_id' => $id])->delete();
     }
 
     function gc($maxlife){
-        $sql='DELETE FROM '.SESSION_TABLE.' WHERE session_expire<NOW()';
-        db_query($sql);
+        SessionData::objects()->filter([
+            'session_expire__lte' => SqlFunction::NOW()
+        ])->delete();
     }
 }
 

--- a/include/class.page.php
+++ b/include/class.page.php
@@ -168,7 +168,7 @@ class Page extends VerySimpleModel {
     /* ------------------> Static methods <--------------------- */
 
     static function create($vars=false) {
-        $page = parent::create($vars);
+        $page = new static($vars);
         $page->created = SqlFunction::NOW();
         return $page;
     }

--- a/include/class.pagenate.php
+++ b/include/class.pagenate.php
@@ -24,7 +24,7 @@ class PageNate {
     var $pages;
 
 
-    function PageNate($total,$page,$limit=20,$url='') {
+    function __construct($total,$page,$limit=20,$url='') {
         $this->total = intval($total);
         $this->limit = max($limit, 1 );
         $this->page  = max($page, 1 );

--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -56,7 +56,7 @@ class Ticket2PDF extends mPDFWithLocalImages
 
     var $ticket = null;
 
-	function Ticket2PDF($ticket, $psize='Letter', $notes=false) {
+	function __construct($ticket, $psize='Letter', $notes=false) {
         global $thisstaff;
 
         $this->ticket = $ticket;

--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -8,7 +8,7 @@ class PluginConfig extends Config {
     function __construct($name) {
         // Use parent constructor to place configurable information into the
         // central config table in a namespace of "plugin.<id>"
-        parent::Config("plugin.$name");
+        parent::__construct("plugin.$name");
         foreach ($this->getOptions() as $name => $field) {
             if ($this->exists($name))
                 $this->config[$name]->value = $field->to_php($this->get($name));
@@ -370,7 +370,7 @@ abstract class Plugin {
 
     static $verify_domain = 'updates.osticket.com';
 
-    function Plugin($id) {
+    function __construct($id) {
         $this->id = $id;
         $this->load();
     }

--- a/include/class.role.php
+++ b/include/class.role.php
@@ -383,7 +383,7 @@ extends AbstractForm {
         return $clean;
     }
 
-    function render($staff=true) {
-        return parent::render($staff, false, array('template' => 'dynamic-form-simple.tmpl.php'));
+    function render($staff=true, $title=false, $options=array()) {
+        return parent::render($staff, $title, $options + array('template' => 'dynamic-form-simple.tmpl.php'));
     }
 }

--- a/include/class.role.php
+++ b/include/class.role.php
@@ -193,7 +193,7 @@ class Role extends RoleModel {
     }
 
     static function create($vars=false) {
-        $role = parent::create($vars);
+        $role = new static($vars);
         $role->created = SqlFunction::NOW();
         return $role;
     }

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -230,7 +230,7 @@ class MySqlSearchConfig extends Config {
     var $table = CONFIG_TABLE;
 
     function __construct() {
-        parent::Config("mysqlsearch");
+        parent::__construct("mysqlsearch");
     }
 }
 
@@ -1011,14 +1011,14 @@ class HelpTopicChoiceField extends ChoiceField {
         return true;
     }
 
-    function getChoices() {
+    function getChoices($verbose=false) {
         return Topic::getHelpTopics(false, Topic::DISPLAY_DISABLED);
     }
 }
 
 require_once INCLUDE_DIR . 'class.dept.php';
 class DepartmentChoiceField extends ChoiceField {
-    function getChoices() {
+    function getChoices($verbose=false) {
         return Dept::getDepartments();
     }
 
@@ -1031,7 +1031,7 @@ class DepartmentChoiceField extends ChoiceField {
 }
 
 class AssigneeChoiceField extends ChoiceField {
-    function getChoices() {
+    function getChoices($verbose=false) {
         global $thisstaff;
 
         $items = array(
@@ -1128,7 +1128,7 @@ class AssigneeChoiceField extends ChoiceField {
 }
 
 class TicketStateChoiceField extends ChoiceField {
-    function getChoices() {
+    function getChoices($verbose=false) {
         return array(
             'open' => __('Open'),
             'closed' => __('Closed'),
@@ -1150,7 +1150,7 @@ class TicketStateChoiceField extends ChoiceField {
 }
 
 class TicketFlagChoiceField extends ChoiceField {
-    function getChoices() {
+    function getChoices($verbose=false) {
         return array(
             'isanswered' =>   __('Answered'),
             'isoverdue' =>    __('Overdue'),
@@ -1178,7 +1178,7 @@ class TicketFlagChoiceField extends ChoiceField {
 }
 
 class TicketSourceChoiceField extends ChoiceField {
-    function getChoices() {
+    function getChoices($verbose=false) {
         return array(
             'web' => __('Web'),
             'email' => __('Email'),

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -983,7 +983,7 @@ class SavedSearch extends VerySimpleModel {
     }
 
     static function create($vars=array()) {
-        $inst = parent::create($vars);
+        $inst = new static($vars);
         $inst->created = SqlFunction::NOW();
         return $inst;
     }

--- a/include/class.sequence.php
+++ b/include/class.sequence.php
@@ -205,7 +205,7 @@ class Sequence extends VerySimpleModel {
     }
 
     function __create($data) {
-        $instance = parent::create($data);
+        $instance = new static($data);
         $instance->save();
         return $instance;
     }
@@ -213,9 +213,6 @@ class Sequence extends VerySimpleModel {
 
 class RandomSequence extends Sequence {
     var $padding = '0';
-
-    // Override the ORM constructor and do nothing
-    function __construct($ht=false) {}
 
     function __next($digits=6) {
         if ($digits < 6)

--- a/include/class.setup.php
+++ b/include/class.setup.php
@@ -14,10 +14,10 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 
-Class SetupWizard {
+class SetupWizard {
 
     //Mimimum requirements
-    var $prereq = array('php'   => '5.3',
+    var $prereq = array('php'   => '5.4',
                         'mysql' => '5.0');
 
     //Version info - same as the latest version.
@@ -28,7 +28,7 @@ Class SetupWizard {
     //Errors
     var $errors=array();
 
-    function SetupWizard(){
+    function __construct(){
         $this->errors=array();
         $this->version_verbose = sprintf(__('osTicket %s' /* <%s> is for the version */),
             THIS_VERSION);

--- a/include/class.sla.php
+++ b/include/class.sla.php
@@ -203,7 +203,7 @@ implements TemplateVariable {
     }
 
     static function create($vars=false, &$errors=array()) {
-        $sla = parent::create($vars);
+        $sla = new static($vars);
         $sla->created = SqlFunction::NOW();
         return $sla;
     }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -702,7 +702,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         while(list(, list($team_id, $alerts)) = each($membership)) {
             $member = $this->teams->findFirst(array('team_id' => $team_id));
             if (!$member) {
-                $this->teams->add($member = TeamMember::create(array(
+                $this->teams->add($member = new TeamMember(array(
                     'team_id' => $team_id,
                 )));
             }
@@ -819,7 +819,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
 
 
     static function create($vars=false) {
-        $staff = parent::create($vars);
+        $staff = new static($vars);
         $staff->created = SqlFunction::NOW();
         return $staff;
     }
@@ -1093,7 +1093,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
                 $errors['dept_access'][$dept_id] = __('Agent already has access to this department');
             $da = $this->dept_access->findFirst(array('dept_id' => $dept_id));
             if (!isset($da)) {
-                $da = StaffDeptAccess::create(array(
+                $da = new StaffDeptAccess(array(
                     'dept_id' => $dept_id, 'role_id' => $role_id
                 ));
                 $this->dept_access->add($da);

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -840,7 +840,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $token = Misc::randCode(48); // 290-bits
 
         if (!$content)
-            return new Error(/* @trans */ 'Unable to retrieve password reset email template');
+            return new BaseError(/* @trans */ 'Unable to retrieve password reset email template');
 
         $vars = array(
             'url' => $ost->getConfig()->getBaseUrl(),
@@ -1315,8 +1315,8 @@ extends AbstractForm {
         return $clean;
     }
 
-    function render($staff=true) {
-        return parent::render($staff, false, array('template' => 'dynamic-form-simple.tmpl.php'));
+    function render($staff=true, $title=false, $options=array()) {
+        return parent::render($staff, $title, $options + array('template' => 'dynamic-form-simple.tmpl.php'));
     }
 }
 
@@ -1366,8 +1366,8 @@ extends AbstractForm {
         return $clean;
     }
 
-    function render($staff=true) {
-        return parent::render($staff, false, array('template' => 'dynamic-form-simple.tmpl.php'));
+    function render($staff=true, $title=false, $options=array()) {
+        return parent::render($staff, $title, $options + array('template' => 'dynamic-form-simple.tmpl.php'));
     }
 }
 

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1545,7 +1545,9 @@ class TaskThread extends ObjectThread {
         return MessageThreadEntry::create($vars, $errors);
     }
 
-    static function create($task) {
+    static function create($task=false) {
+        assert($task !== false);
+
         $id = is_object($task) ? $task->getId() : $task;
         $thread = parent::create(array(
                     'object_id' => $id,

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1269,7 +1269,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                 || !$thisstaff->hasPerm(Task::PERM_CREATE, false))
             return null;
 
-        $task = parent::create(array(
+        $task = new static(array(
             'flags' => self::ISOPEN,
             'object_id' => $vars['object_id'],
             'object_type' => $vars['object_type'],

--- a/include/class.team.php
+++ b/include/class.team.php
@@ -203,7 +203,7 @@ implements TemplateVariable {
               $errors['members'][$staff_id] = __('No such agent');
           $member = $this->members->findFirst(array('staff_id' => $staff_id));
           if (!isset($member)) {
-              $member = TeamMember::create(array('staff_id' => $staff_id));
+              $member = new TeamMember(array('staff_id' => $staff_id));
               $this->members->add($member);
           }
           $member->setAlerts($alerts);
@@ -305,7 +305,7 @@ implements TemplateVariable {
     }
 
     static function create($vars=false) {
-        $team = parent::create($vars);
+        $team = new static($vars);
         $team->created = SqlFunction::NOW();
         return $team;
     }

--- a/include/class.team.php
+++ b/include/class.team.php
@@ -375,7 +375,7 @@ extends AbstractForm {
         );
     }
 
-    function render($staff=true) {
-        return parent::render($staff, false, array('template' => 'dynamic-form-simple.tmpl.php'));
+    function render($staff=true, $title=false, $options=array()) {
+        return parent::render($staff, $title, $options + array('template' => 'dynamic-form-simple.tmpl.php'));
     }
 }

--- a/include/class.template.php
+++ b/include/class.template.php
@@ -182,7 +182,7 @@ class EmailTemplateGroup {
         ),
     );
 
-    function EmailTemplateGroup($id){
+    function __construct($id){
         $this->id=0;
         $this->load($id);
     }
@@ -508,7 +508,7 @@ class EmailTemplate {
     var $ht;
     var $_group;
 
-    function EmailTemplate($id, $group=null){
+    function __construct($id, $group=null){
         $this->id=0;
         if ($id) $this->load($id);
         if ($group) $this->_group = $group;

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -534,10 +534,7 @@ class Thread extends VerySimpleModel {
     }
 
     static function create($vars=false) {
-        // $vars is expected to be an array
-        assert(is_array($vars));
-
-        $inst = parent::create($vars);
+        $inst = new static($vars);
         $inst->created = SqlFunction::NOW();
         return $inst;
     }
@@ -964,14 +961,14 @@ implements TemplateVariable {
             $fileId = $file;
         elseif ($file instanceof AttachmentFile)
             $fileId = $file->getId();
-        elseif ($F = AttachmentFile::createFile($file))
+        elseif ($F = AttachmentFile::create($file))
             $fileId = $F->getId();
         elseif (is_array($file) && isset($file['id']))
             $fileId = $file['id'];
         else
             return false;
 
-        $att = Attachment::create(array(
+        $att = new Attachment(array(
             'type' => 'H',
             'object_id' => $this->getId(),
             'file_id' => $fileId,
@@ -1067,7 +1064,7 @@ implements TemplateVariable {
         if (!$id || !$mid)
             return false;
 
-        $this->email_info = ThreadEntryEmailInfo::create(array(
+        $this->email_info = new ThreadEntryEmailInfo(array(
             'thread_entry_id' => $id,
             'mid' => $mid,
         ));
@@ -1359,7 +1356,7 @@ implements TemplateVariable {
         if ($poster && is_object($poster))
             $poster = (string) $poster;
 
-        $entry = parent::create(array(
+        $entry = new static(array(
             'created' => SqlFunction::NOW(),
             'type' => $vars['type'],
             'thread_id' => $vars['threadId'],
@@ -1703,7 +1700,7 @@ class ThreadEvent extends VerySimpleModel {
     }
 
     static function create($ht=false, $user=false) {
-        $inst = parent::create($ht);
+        $inst = new static($ht);
         $inst->timestamp = SqlFunction::NOW();
 
         global $thisstaff, $thisclient;
@@ -1721,7 +1718,7 @@ class ThreadEvent extends VerySimpleModel {
     }
 
     static function forTicket($ticket, $state, $user=false) {
-        $inst = static::create(array(
+        $inst = self::create(array(
             'staff_id' => $ticket->getStaffId(),
             'team_id' => $ticket->getTeamId(),
             'dept_id' => $ticket->getDeptId(),
@@ -2586,7 +2583,6 @@ implements TemplateVariable {
 
 // Ticket thread class
 class TicketThread extends ObjectThread {
-
     static function create($ticket=false) {
         assert($ticket !== false);
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3001,7 +3001,7 @@ implements RestrictedAccess, Threadable {
      *
      *  $autorespond and $alertstaff overrides config settings...
      */
-    static function create2($vars, &$errors, $origin, $autorespond=true,
+    static function create($vars, &$errors, $origin, $autorespond=true,
             $alertstaff=true) {
         global $ost, $cfg, $thisclient, $thisstaff;
 
@@ -3294,7 +3294,7 @@ implements RestrictedAccess, Threadable {
 
         //We are ready son...hold on to the rails.
         $number = $topic ? $topic->getNewTicketNumber() : $cfg->getNewTicketNumber();
-        $ticket = parent::create(array(
+        $ticket = new static(array(
             'created' => SqlFunction::NOW(),
             'lastupdate' => SqlFunction::NOW(),
             'number' => $number,
@@ -3504,7 +3504,7 @@ implements RestrictedAccess, Threadable {
         $create_vars['cannedattachments']
             = $tform->getField('message')->getWidget()->getAttachments()->getClean();
 
-        if (!($ticket=Ticket::create2($create_vars, $errors, 'staff', false)))
+        if (!($ticket=self::create($create_vars, $errors, 'staff', false)))
             return false;
 
         $vars['msgId']=$ticket->getLastMsgId();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3001,7 +3001,7 @@ implements RestrictedAccess, Threadable {
      *
      *  $autorespond and $alertstaff overrides config settings...
      */
-    static function create($vars, &$errors, $origin, $autorespond=true,
+    static function create2($vars, &$errors, $origin, $autorespond=true,
             $alertstaff=true) {
         global $ost, $cfg, $thisclient, $thisstaff;
 
@@ -3504,7 +3504,7 @@ implements RestrictedAccess, Threadable {
         $create_vars['cannedattachments']
             = $tform->getField('message')->getWidget()->getAttachments()->getClean();
 
-        if (!($ticket=Ticket::create($create_vars, $errors, 'staff', false)))
+        if (!($ticket=Ticket::create2($create_vars, $errors, 'staff', false)))
             return false;
 
         $vars['msgId']=$ticket->getLastMsgId();

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -278,7 +278,7 @@ implements TemplateVariable {
     /*** Static functions ***/
 
     static function create($vars=array()) {
-        $topic = parent::create($vars);
+        $topic = new static($vars);
         $topic->created = SqlFunction::NOW();
         return $topic;
     }
@@ -506,14 +506,15 @@ implements TemplateVariable {
                     // Don't add a form more than once
                     continue;
                 }
-                TopicFormModel::create(array(
+                $tf = new TopicFormModel(array(
                     'topic_id' => $this->getId(),
                     'form_id' => $id,
                     'sort' => $sort + 1,
                     'extra' => JsonDataEncoder::encode(
                         array('disable' => $find_disabled($form))
                     )
-                ))->save();
+                ));
+                $tf->save();
             }
         }
         return true;

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -651,16 +651,16 @@ class Translation extends gettext_reader implements Serializable {
     }
 
     static function resurrect($key) {
-        if (!function_exists('apc_fetch'))
+        if (!function_exists('apcu_fetch'))
             return false;
 
         $success = true;
-        if (($translation = apc_fetch($key, $success)) && $success)
+        if (($translation = apcu_fetch($key, $success)) && $success)
             return $translation;
     }
     function cache($key) {
-        if (function_exists('apc_add'))
-            apc_add($key, $this);
+        if (function_exists('apcu_add'))
+            apcu_add($key, $this);
     }
 
 

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -119,7 +119,7 @@ class gettext_reader {
    * @param object Reader the StreamReader object
    * @param boolean enable_cache Enable or disable caching of strings (default on)
    */
-  function gettext_reader($Reader, $enable_cache = true) {
+  function __construct($Reader, $enable_cache = true) {
     // If there isn't a StreamReader, turn on short circuit mode.
     if (! $Reader || isset($Reader->error) ) {
       $this->short_circuit = true;
@@ -462,7 +462,7 @@ class FileReader {
   var $_fd;
   var $_length;
 
-  function FileReader($filename) {
+  function __construct($filename) {
     if (is_resource($filename)) {
         $this->_length = strlen(stream_get_contents($filename));
         rewind($filename);

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -1018,7 +1018,7 @@ class CustomDataTranslation extends VerySimpleModel {
             $ht['text'] = static::encodeComplex($ht['text']);
             $ht['flags'] = ($ht['flags'] ?: 0) | self::FLAG_COMPLEX;
         }
-        return parent::create($ht);
+        return new static($ht);
     }
 
     static function allTranslations($msgid, $type='phrase', $lang=false) {

--- a/include/class.upgrader.php
+++ b/include/class.upgrader.php
@@ -87,7 +87,7 @@ class Upgrader {
 
         //Create a ticket to make the system warm and happy.
         $errors = array();
-        Ticket::create2($vars, $errors, 'api', false, false);
+        Ticket::create($vars, $errors, 'api', false, false);
     }
 
     function getMode() {

--- a/include/class.upgrader.php
+++ b/include/class.upgrader.php
@@ -18,7 +18,7 @@ require_once INCLUDE_DIR.'class.setup.php';
 require_once INCLUDE_DIR.'class.migrater.php';
 
 class Upgrader {
-    function Upgrader($prefix, $basedir) {
+    function __construct($prefix, $basedir) {
         global $ost;
 
         $this->streams = array();
@@ -87,7 +87,7 @@ class Upgrader {
 
         //Create a ticket to make the system warm and happy.
         $errors = array();
-        Ticket::create($vars, $errors, 'api', false, false);
+        Ticket::create2($vars, $errors, 'api', false, false);
     }
 
     function getMode() {
@@ -113,44 +113,6 @@ class Upgrader {
                     . $what);
             return call_user_func_array($callable, $args);
         }
-    }
-
-    function getTask() {
-        if($this->getCurrentStream())
-            return $this->getCurrentStream()->getTask();
-    }
-
-    function doTask() {
-        return $this->getCurrentStream()->doTask();
-    }
-
-    function getErrors() {
-        if ($this->getCurrentStream())
-            return $this->getCurrentStream()->getErrors();
-    }
-
-    function getUpgradeSummary() {
-        if ($this->getCurrentStream())
-            return $this->getCurrentStream()->getUpgradeSummary();
-    }
-
-    function getNextAction() {
-        if ($this->getCurrentStream())
-            return $this->getCurrentStream()->getNextAction();
-    }
-
-    function getNextVersion() {
-        return $this->getCurrentStream()->getNextVersion();
-    }
-
-    function getSchemaSignature() {
-        if ($this->getCurrentStream())
-            return $this->getCurrentStream()->getSchemaSignature();
-    }
-
-    function getSHash() {
-        if ($this->getCurrentStream())
-            return $this->getCurrentStream()->getSHash();
     }
 }
 
@@ -185,7 +147,7 @@ class StreamUpgrader extends SetupWizard {
      * sqldir - (string<path>) Path of sql patches
      * upgrader - (Upgrader) Parent coordinator of parallel stream updates
      */
-    function StreamUpgrader($schema_signature, $target, $stream, $prefix, $sqldir, $upgrader) {
+    function __construct($schema_signature, $target, $stream, $prefix, $sqldir, $upgrader) {
 
         $this->signature = $schema_signature;
         $this->target = $target;

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -206,7 +206,7 @@ implements TemplateVariable {
             elseif (!$name)
                 list($name) = explode('@', $vars['email'], 2);
 
-            $user = User::create(array(
+            $user = new User(array(
                 'name' => Format::htmldecode(Format::sanitize($name, false)),
                 'created' => new SqlFunction('NOW'),
                 'updated' => new SqlFunction('NOW'),
@@ -871,7 +871,7 @@ class UserEmail extends UserEmailModel {
     static function ensure($address) {
         $email = static::lookup(array('address'=>$address));
         if (!$email) {
-            $email = static::create(array('address'=>$address));
+            $email = new static(array('address'=>$address));
             $email->save();
         }
         return $email;
@@ -1146,7 +1146,7 @@ class UserAccount extends VerySimpleModel {
     }
 
     static function createForUser($user, $defaults=false) {
-        $acct = static::create(array('user_id'=>$user->getId()));
+        $acct = new static(array('user_id'=>$user->getId()));
         if ($defaults && is_array($defaults)) {
             foreach ($defaults as $k => $v)
                 $acct->set($k, $v);
@@ -1181,12 +1181,11 @@ class UserAccount extends VerySimpleModel {
 
         if ($errors) return false;
 
-        $account = UserAccount::create(array('user_id' => $user->getId()));
-        if (!$account)
-            return false;
-
-        $account->set('timezone', $vars['timezone']);
-        $account->set('backend', $vars['backend']);
+        $account = new UserAccount(array(
+            'user_id' => $user->getId(),
+            'timezone' => $vars['timezone'],
+            'backend' => $vars['backend'],
+        ));
 
         if ($vars['username'] && strcasecmp($vars['username'], $user->getEmail()))
             $account->set('username', $vars['username']);

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1051,7 +1051,7 @@ class UserAccount extends VerySimpleModel {
         $content = Page::lookupByType($template);
 
         if (!$email ||  !$content)
-            return new Error(sprintf(_S('%s: Unable to retrieve template'),
+            return new BaseError(sprintf(_S('%s: Unable to retrieve template'),
                 $template));
 
         $vars = array(

--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -25,7 +25,7 @@ class UserSession {
    var $ip = '';
    var $validated=FALSE;
 
-   function UserSession($userid){
+   function __construct($userid){
 
       $this->browser=(!empty($_SERVER['HTTP_USER_AGENT'])) ? $_SERVER['HTTP_USER_AGENT'] : $_ENV['HTTP_USER_AGENT'];
       $this->ip=(!empty($_SERVER['REMOTE_ADDR'])) ? $_SERVER['REMOTE_ADDR'] : getenv('REMOTE_ADDR');

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -20,7 +20,7 @@ class Validator {
     var $fields=array();
     var $errors=array();
 
-    function Validator($fields=null) {
+    function __construct($fields=null) {
         $this->setFields($fields);
     }
     function setFields(&$fields){
@@ -99,15 +99,15 @@ class Validator {
                 break;
             case 'phone':
             case 'fax':
-                if(!$this->is_phone($this->input[$k]))
+                if(!self::is_phone($this->input[$k]))
                     $this->errors[$k]=$field['error'];
                 break;
             case 'email':
-                if(!$this->is_email($this->input[$k]))
+                if(!self::is_email($this->input[$k]))
                     $this->errors[$k]=$field['error'];
                 break;
             case 'url':
-                if(!$this->is_url($this->input[$k]))
+                if(!self::is_url($this->input[$k]))
                     $this->errors[$k]=$field['error'];
                 break;
             case 'password':
@@ -116,7 +116,7 @@ class Validator {
                 break;
             case 'username':
                 $error = '';
-                if (!$this->is_username($this->input[$k], $error))
+                if (!self::is_username($this->input[$k], $error))
                     $this->errors[$k]=$field['error'].": $error";
                 break;
             case 'zipcode':
@@ -140,10 +140,11 @@ class Validator {
 
     /*** Functions below can be called directly without class instance.
          Validator::func(var..);  (nolint) ***/
-    function is_email($email, $list=false, $verify=false) {
+    static function is_email($email, $list=false, $verify=false) {
         require_once PEAR_DIR . 'Mail/RFC822.php';
         require_once PEAR_DIR . 'PEAR.php';
-        if (!($mails = Mail_RFC822::parseAddressList($email)) || PEAR::isError($mails))
+        $rfc822 = new Mail_RFC822();
+        if (!($mails = $rfc822->parseAddressList($email)) || PEAR::isError($mails))
             return false;
 
         if (!$list && count($mails) > 1)
@@ -166,24 +167,24 @@ class Validator {
         return true;
     }
 
-    function is_valid_email($email) {
+    static function is_valid_email($email) {
         global $cfg;
         // Default to FALSE for installation
         return self::is_email($email, false, $cfg && $cfg->verifyEmailAddrs());
     }
 
-    function is_phone($phone) {
+    static function is_phone($phone) {
         /* We're not really validating the phone number but just making sure it doesn't contain illegal chars and of acceptable len */
         $stripped=preg_replace("(\(|\)|\-|\.|\+|[  ]+)","",$phone);
         return (!is_numeric($stripped) || ((strlen($stripped)<7) || (strlen($stripped)>16)))?false:true;
     }
 
-    function is_url($url) {
+    static function is_url($url) {
         //XXX: parse_url is not ideal for validating urls but it's ideal for basic checks.
         return ($url && ($info=parse_url($url)) && $info['host']);
     }
 
-    function is_ip($ip) {
+    static function is_ip($ip) {
 
         if(!$ip or empty($ip))
             return false;
@@ -203,7 +204,7 @@ class Validator {
         return false;
     }
 
-    function is_username($username, &$error='') {
+    static function is_username($username, &$error='') {
         if (strlen($username)<2)
             $error = __('Username must have at least two (2) characters');
         elseif (!preg_match('/^[\p{L}\d._-]+$/u', $username))

--- a/include/class.variable.php
+++ b/include/class.variable.php
@@ -27,7 +27,7 @@ class VariableReplacer {
 
     var $errors;
 
-    function VariableReplacer($start_delim='(?:%{|%%7B)', $end_delim='(?:}|%7D)') {
+    function __construct($start_delim='(?:%{|%%7B)', $end_delim='(?:}|%7D)') {
 
         $this->start_delim = $start_delim;
         $this->end_delim = $end_delim;

--- a/include/class.xml.php
+++ b/include/class.xml.php
@@ -18,7 +18,7 @@
 
 class XmlDataParser {
 
-    function XmlDataParser() {
+    function __construct() {
         $this->parser = xml_parser_create('utf-8');
         xml_set_object($this->parser, $this);
         xml_set_element_handler($this->parser, "startElement", "endElement");

--- a/include/class.yaml.php
+++ b/include/class.yaml.php
@@ -36,7 +36,7 @@ class YamlDataParser {
     }
 }
 
-class YamlParserError extends Error {
+class YamlParserError extends BaseError {
     static $title = 'Error parsing YAML document';
 }
 ?>

--- a/include/htmLawed.php
+++ b/include/htmLawed.php
@@ -379,7 +379,8 @@ return $r;
 function hl_spec($t){
 // final $spec
 $s = array();
-$t = str_replace(array("\t", "\r", "\n", ' '), '', preg_replace('/"(?>(`.|[^"])*)"/sme', 'substr(str_replace(array(";", "|", "~", " ", ",", "/", "(", ")", \'`"\'), array("\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\""), "$0"), 1, -1)', trim($t)));
+$t = str_replace(array("\t", "\r", "\n", ' '), '',
+preg_replace_callback('/"(?>(`.|[^"])*)"/sm', function($m) {return substr(str_replace(array(";", "|", "~", " ", ",", "/", "(", ")", '`"'), array("\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\""), $m[0]), 1, -1);}, trim($t)));
 for($i = count(($t = explode(';', $t))); --$i>=0;){
  $w = $t[$i];
  if(empty($w) or ($e = strpos($w, '=')) === false or !strlen(($a =  substr($w, $e+1)))){continue;}

--- a/include/html2text.php
+++ b/include/html2text.php
@@ -561,7 +561,7 @@ class HtmlUnorderedListElement extends HtmlListElement {
 }
 
 class HtmlListItem extends HtmlBlockElement {
-    function HtmlListItem($node, $parent, $number) {
+    function __construct($node, $parent, $number) {
         parent::__construct($node, $parent);
         $this->number = $number;
     }

--- a/include/mpdf/classes/bmp.php
+++ b/include/mpdf/classes/bmp.php
@@ -4,7 +4,7 @@ class bmp {
 
 var $mpdf = null;
 
-function bmp(&$mpdf) {
+function __construct(&$mpdf) {
 	$this->mpdf = $mpdf;
 }
 

--- a/include/mpdf/classes/cssmgr.php
+++ b/include/mpdf/classes/cssmgr.php
@@ -12,7 +12,7 @@ var $tbCSSlvl;
 var $listCSSlvl;
 
 
-function cssmgr(&$mpdf) {
+function __construct(&$mpdf) {
 	$this->mpdf = $mpdf;
 	$this->tablecascadeCSS = array();
 	$this->listcascadeCSS = array();

--- a/include/mpdf/classes/gif.php
+++ b/include/mpdf/classes/gif.php
@@ -26,7 +26,7 @@ class CGIFLZW
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFLZW()
+	function __construct()
 	{
 		$this->MAX_LZW_BITS = 12;
 		unSet($this->Next);
@@ -240,7 +240,7 @@ class CGIFCOLORTABLE
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFCOLORTABLE()
+	function __construct()
 	{
 		unSet($this->m_nColors);
 		unSet($this->m_arColors);
@@ -327,7 +327,7 @@ class CGIFFILEHEADER
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFFILEHEADER()
+	function __construct()
 	{
 		unSet($this->m_lpVer);
 		unSet($this->m_nWidth);
@@ -402,20 +402,6 @@ class CGIFIMAGEHEADER
 
 	///////////////////////////////////////////////////////////////////////////
 
-	// CONSTRUCTOR
-	function CGIFIMAGEHEADER()
-	{
-		unSet($this->m_nLeft);
-		unSet($this->m_nTop);
-		unSet($this->m_nWidth);
-		unSet($this->m_nHeight);
-		unSet($this->m_bLocalClr);
-		unSet($this->m_bInterlace);
-		unSet($this->m_bSorted);
-		unSet($this->m_nTableSize);
-		unSet($this->m_colorTable);
-	}
-
 	///////////////////////////////////////////////////////////////////////////
 
 	function load($lpData, &$hdrLen)
@@ -473,15 +459,8 @@ class CGIFIMAGE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function CGIFIMAGE()
+	function __construct()
 	{
-		unSet($this->m_disp);
-		unSet($this->m_bUser);
-		unSet($this->m_bTrans);
-		unSet($this->m_nDelay);
-		unSet($this->m_nTrans);
-		unSet($this->m_lpComm);
-		unSet($this->m_data);
 		$this->m_gih = new CGIFIMAGEHEADER();
 		$this->m_lzw = new CGIFLZW();
 	}
@@ -647,7 +626,7 @@ class CGIF
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIF()
+	function __construct()
 	{
 		$this->m_gfh     = new CGIFFILEHEADER();
 		$this->m_img     = new CGIFIMAGE();

--- a/include/mpdf/classes/grad.php
+++ b/include/mpdf/classes/grad.php
@@ -4,7 +4,7 @@ class grad {
 
 var $mpdf = null;
 
-function grad(&$mpdf) {
+function __construct(&$mpdf) {
 	$this->mpdf = $mpdf;
 }
 

--- a/include/mpdf/classes/indic.php
+++ b/include/mpdf/classes/indic.php
@@ -2,11 +2,6 @@
 
 class indic {
 
-function indic() {
-
-}
-
-
 function substituteIndic($earr, $lang, $font) {
 	global $voltdata;
 

--- a/include/mpdf/classes/ttfontsuni.php
+++ b/include/mpdf/classes/ttfontsuni.php
@@ -79,7 +79,7 @@ var $TTCFonts;
 var $maxUniChar;
 var $kerninfo;
 
-	function TTFontFile() {
+	function __construct() {
 		$this->maxStrLenRead = 200000;	// Maximum size of glyf table to read in as string (otherwise reads each glyph from file)
 	}
 

--- a/include/mpdf/classes/wmf.php
+++ b/include/mpdf/classes/wmf.php
@@ -5,7 +5,7 @@ class wmf {
 var $mpdf = null;
 var $gdiObjectArray;
 
-function wmf(&$mpdf) {
+function __construct(&$mpdf) {
 	$this->mpdf = $mpdf;
 }
 

--- a/include/mpdf/mpdf.php
+++ b/include/mpdf/mpdf.php
@@ -827,7 +827,7 @@ var $innerblocktags;
 // **********************************
 // **********************************
 
-function mPDF($mode='',$format='A4',$default_font_size=0,$default_font='',$mgl=15,$mgr=15,$mgt=16,$mgb=16,$mgh=9,$mgf=9, $orientation='P') {
+function __construct($mode='',$format='A4',$default_font_size=0,$default_font='',$mgl=15,$mgr=15,$mgt=16,$mgb=16,$mgh=9,$mgf=9, $orientation='P') {
 
 /*-- BACKGROUNDS --*/
 		if (!class_exists('grad', false)) { include(_MPDF_PATH.'classes/grad.php'); }
@@ -1431,7 +1431,6 @@ function _getPageFormat($format) {
 			case 'A': {$format=array(314.65,504.57 );	 break;}		//	'A' format paperback size 111x178mm
 			case 'DEMY': {$format=array(382.68,612.28 );  break;}		//	'Demy' format paperback size 135x216mm
 			case 'ROYAL': {$format=array(433.70,663.30 );  break;}	//	'Royal' format paperback size 153x234mm
-			default: $format = false;
 		}
 	return $format;
 }

--- a/include/pear/Crypt/AES.php
+++ b/include/pear/Crypt/AES.php
@@ -175,7 +175,7 @@ class Crypt_AES extends Crypt_Rijndael {
      * @return Crypt_AES
      * @access public
      */
-    function Crypt_AES($mode = CRYPT_AES_MODE_CBC)
+    function __construct($mode = CRYPT_AES_MODE_CBC)
     {
         if ( !defined('CRYPT_AES_MODE') ) {
             switch (true) {
@@ -237,7 +237,7 @@ class Crypt_AES extends Crypt_Rijndael {
         }
 
         if (CRYPT_AES_MODE == CRYPT_AES_MODE_INTERNAL) {
-            parent::Crypt_Rijndael($this->mode);
+            parent::__construct($this->mode);
         }
 
     }

--- a/include/pear/Crypt/Hash.php
+++ b/include/pear/Crypt/Hash.php
@@ -143,7 +143,7 @@ class Crypt_Hash {
      * @return Crypt_Hash
      * @access public
      */
-    function Crypt_Hash($hash = 'sha1')
+    function __construct($hash = 'sha1')
     {
         if ( !defined('CRYPT_HASH_MODE') ) {
             switch (true) {

--- a/include/pear/Crypt/Rijndael.php
+++ b/include/pear/Crypt/Rijndael.php
@@ -448,7 +448,7 @@ class Crypt_Rijndael {
      * @return Crypt_Rijndael
      * @access public
      */
-    function Crypt_Rijndael($mode = CRYPT_RIJNDAEL_MODE_CBC)
+    function __construct($mode = CRYPT_RIJNDAEL_MODE_CBC)
     {
         switch ($mode) {
             case CRYPT_RIJNDAEL_MODE_ECB:

--- a/include/pear/Mail/RFC822.php
+++ b/include/pear/Mail/RFC822.php
@@ -149,7 +149,7 @@ class Mail_RFC822 {
      *
      * @return object Mail_RFC822 A new Mail_RFC822 object.
      */
-    function Mail_RFC822($address = null, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
+    function __construct($address = null, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
     {
         if (isset($address))        $this->address        = $address;
         if (isset($default_domain)) $this->default_domain = $default_domain;

--- a/include/pear/Mail/mail.php
+++ b/include/pear/Mail/mail.php
@@ -64,7 +64,7 @@ class Mail_mail extends Mail {
      *
      * @param array $params Extra arguments for the mail() function.
      */
-    function Mail_mail($params = null)
+    function __construct($params = null)
     {
         // The other mail implementations accept parameters as arrays.
         // In the interest of being consistent, explode an array into

--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -149,7 +149,7 @@ class Mail_mimeDecode extends PEAR
      * @param string The input to decode
      * @access public
      */
-    function Mail_mimeDecode(&$input)
+    function __construct(&$input)
     {
         list($header, $body)   = $this->_splitBodyHeader($input);
 

--- a/include/pear/Mail/mock.php
+++ b/include/pear/Mail/mock.php
@@ -84,7 +84,7 @@ class Mail_mock extends Mail {
      * @param array Hash containing any parameters.
      * @access public
      */
-    function Mail_mock($params)
+    function __construct($params)
     {
         if (isset($params['preSendCallback']) &&
             is_callable($params['preSendCallback'])) {

--- a/include/pear/Mail/sendmail.php
+++ b/include/pear/Mail/sendmail.php
@@ -56,7 +56,7 @@ class Mail_sendmail extends Mail {
      *              defaults.
      * @access public
      */
-    function Mail_sendmail($params)
+    function __construct($params)
     {
         if (isset($params['sendmail_path'])) {
             $this->sendmail_path = $params['sendmail_path'];

--- a/include/pear/Mail/smtp.php
+++ b/include/pear/Mail/smtp.php
@@ -188,7 +188,7 @@ class Mail_smtp extends Mail {
      *              defaults.
      * @access public
      */
-    function Mail_smtp($params)
+    function __construct($params)
     {
         if (isset($params['host'])) $this->host = $params['host'];
         if (isset($params['port'])) $this->port = $params['port'];
@@ -346,7 +346,7 @@ class Mail_smtp extends Mail {
         }
 
         include_once 'Net/SMTP.php';
-        $this->_smtp = &new Net_SMTP($this->host,
+        $this->_smtp = new Net_SMTP($this->host,
                                      $this->port,
                                      $this->localhost);
 

--- a/include/pear/Math/BigInteger.php
+++ b/include/pear/Math/BigInteger.php
@@ -256,7 +256,7 @@ class Math_BigInteger {
      * @return Math_BigInteger
      * @access public
      */
-    function Math_BigInteger($x = 0, $base = 10)
+    function __construct($x = 0, $base = 10)
     {
         if ( !defined('MATH_BIGINTEGER_MODE') ) {
             switch (true) {

--- a/include/pear/PEAR.php
+++ b/include/pear/PEAR.php
@@ -146,7 +146,7 @@ class PEAR
      * @access public
      * @return void
      */
-    function PEAR($error_class = null)
+    function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -247,7 +247,7 @@ class PEAR
      * @access  public
      * @return  bool    true if parameter is an error
      */
-    function isError($data, $code = null)
+    static function isError($data, $code = null)
     {
         if (!is_a($data, 'PEAR_Error')) {
             return false;
@@ -469,7 +469,7 @@ class PEAR
      * @see PEAR::setErrorHandling
      * @since PHP 4.0.5
      */
-    function &raiseError($message = null,
+    static function &raiseError($message = null,
                          $code = null,
                          $mode = null,
                          $options = null,
@@ -823,7 +823,7 @@ class PEAR_Error
      * @access public
      *
      */
-    function PEAR_Error($message = 'unknown error', $code = null,
+    function __construct($message = 'unknown error', $code = null,
                         $mode = null, $options = null, $userinfo = null)
     {
         if ($mode === null) {

--- a/include/pear/PEAR/FixPHP5PEARWarnings.php
+++ b/include/pear/PEAR/FixPHP5PEARWarnings.php
@@ -1,7 +1,7 @@
 <?php
 if ($skipmsg) {
-    $a = &new $ec($code, $mode, $options, $userinfo);
+    $a = new $ec($code, $mode, $options, $userinfo);
 } else {
-    $a = &new $ec($message, $code, $mode, $options, $userinfo);
+    $a = new $ec($message, $code, $mode, $options, $userinfo);
 }
 ?>

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -41,6 +41,14 @@ $extensions = array(
             'name' => 'fileinfo',
             'desc' => __('Used to detect file types for uploads')
             ),
+        'apcu' => array(
+            'name' => 'APCu',
+            'desc' => __('Improves overall performance')
+            ),
+        'Zend Opcache' => array(
+            'name' => 'Zend Opcache',
+            'desc' => __('Improves overall performance')
+            ),
         );
 
 ?>

--- a/include/upgrader/prereq.inc.php
+++ b/include/upgrader/prereq.inc.php
@@ -15,7 +15,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
             <?php echo __('These items are necessary in order to run the latest version of osTicket.');?>
             <ul class="progress">
                 <li class="<?php echo $upgrader->check_php()?'yes':'no'; ?>">
-                <?php echo sprintf(__('%s or later'), 'PHP v5.3'); ?> - (<small><b><?php echo PHP_VERSION; ?></b></small>)</li>
+                <?php echo sprintf(__('%s or later'), 'PHP v5.4'); ?> - (<small><b><?php echo PHP_VERSION; ?></b></small>)</li>
                 <li class="<?php echo $upgrader->check_mysql()?'yes':'no'; ?>">
                 <?php echo __('MySQLi extension for PHP'); ?>- (<small><b><?php
                     echo extension_loaded('mysqli')?__('module loaded'):__('missing!'); ?></b></small>)</li>

--- a/include/upgrader/streams/core/15b30765-dd0022fb.task.php
+++ b/include/upgrader/streams/core/15b30765-dd0022fb.task.php
@@ -262,7 +262,7 @@ class OldOneSixFile extends VerySimpleModel {
     );
 
     static function create($info) {
-        $I = parent::create($info);
+        $I = new static($info);
         $I->save();
         return $I;
     }

--- a/include/upgrader/streams/core/934954de-f1ccd3bb.task.php
+++ b/include/upgrader/streams/core/934954de-f1ccd3bb.task.php
@@ -7,7 +7,7 @@ class FileImport extends MigrationTask {
         $i18n = new Internationalization('en_US');
         $files = $i18n->getTemplate('file.yaml')->getData();
         foreach ($files as $f) {
-            if (!($file = AttachmentFile::create($f)))
+            if (!($file = AttachmentFile::createFile($f)))
                 continue;
 
             // Ensure the new files are never deleted (attached to Disk)

--- a/include/upgrader/streams/core/934954de-f1ccd3bb.task.php
+++ b/include/upgrader/streams/core/934954de-f1ccd3bb.task.php
@@ -7,7 +7,7 @@ class FileImport extends MigrationTask {
         $i18n = new Internationalization('en_US');
         $files = $i18n->getTemplate('file.yaml')->getData();
         foreach ($files as $f) {
-            if (!($file = AttachmentFile::createFile($f)))
+            if (!($file = AttachmentFile::create($f)))
                 continue;
 
             // Ensure the new files are never deleted (attached to Disk)

--- a/open.php
+++ b/open.php
@@ -39,7 +39,7 @@ if ($_POST) {
     // submitted will be displayed back to the user
     Draft::deleteForNamespace('ticket.client.'.substr(session_id(), -12));
     //Ticket::create...checks for errors..
-    if(($ticket=Ticket::create($vars, $errors, SOURCE))){
+    if(($ticket=Ticket::create2($vars, $errors, SOURCE))){
         $msg=__('Support ticket request created');
         // Drop session-backed form data
         unset($_SESSION[':form-data']);

--- a/open.php
+++ b/open.php
@@ -39,7 +39,7 @@ if ($_POST) {
     // submitted will be displayed back to the user
     Draft::deleteForNamespace('ticket.client.'.substr(session_id(), -12));
     //Ticket::create...checks for errors..
-    if(($ticket=Ticket::create2($vars, $errors, SOURCE))){
+    if(($ticket=Ticket::create($vars, $errors, SOURCE))){
         $msg=__('Support ticket request created');
         // Drop session-backed form data
         unset($_SESSION[':form-data']);

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -21,7 +21,7 @@ class Installer extends SetupWizard {
 
     var $config;
 
-    function Installer($configfile) {
+    function __construct($configfile) {
         $this->config =$configfile;
         $this->errors=array();
     }
@@ -288,7 +288,7 @@ class Installer extends SetupWizard {
         $errors = array();
         $ticket_vars = $i18n->getTemplate('templates/ticket/installed.yaml')
             ->getData();
-        $ticket = Ticket::create($ticket_vars, $errors, 'api', false, false);
+        $ticket = Ticket::create2($ticket_vars, $errors, 'api', false, false);
 
         if ($ticket
             && ($org = Organization::objects()->order_by('id')->one())

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -288,7 +288,7 @@ class Installer extends SetupWizard {
         $errors = array();
         $ticket_vars = $i18n->getTemplate('templates/ticket/installed.yaml')
             ->getData();
-        $ticket = Ticket::create2($ticket_vars, $errors, 'api', false, false);
+        $ticket = Ticket::create($ticket_vars, $errors, 'api', false, false);
 
         if ($ticket
             && ($org = Organization::objects()->order_by('id')->one())

--- a/setup/inc/install-prereq.inc.php
+++ b/setup/inc/install-prereq.inc.php
@@ -15,7 +15,7 @@ if(!defined('SETUPINC')) die('Kwaheri!');
             <?php echo __('These items are necessary in order to install and use osTicket.');?>
             <ul class="progress">
                 <li class="<?php echo $installer->check_php()?'yes':'no'; ?>">
-                <?php echo sprintf(__('%s or greater'), '<span class="ltr">PHP v5.3</span>');?> &mdash; <small class="ltr">(<b><?php echo PHP_VERSION; ?></b>)</small></li>
+                <?php echo sprintf(__('%s or greater'), '<span class="ltr">PHP v5.4</span>');?> &mdash; <small class="ltr">(<b><?php echo PHP_VERSION; ?></b>)</small></li>
                 <li class="<?php echo $installer->check_mysql()?'yes':'no'; ?>">
                 <?php echo __('MySQLi extension for PHP');?> &mdash; <small><b><?php
                     echo extension_loaded('mysqli')?__('module loaded'):__('missing!'); ?></b></small></li>
@@ -38,7 +38,9 @@ if(!defined('SETUPINC')) die('Kwaheri!');
                     echo __('recommended for plugins and language packs');?></li>
                 <li class="<?php echo extension_loaded('intl')?'yes':'no'; ?>">Intl <?php echo __('extension');?> &mdash; <?php
                     echo __('recommended for improved localization');?></li>
-                <li class="<?php echo extension_loaded('apc')?'yes':'no'; ?>">APC <?php echo __('extension');?> &mdash; <?php
+                <li class="<?php echo extension_loaded('apcu')?'yes':'no'; ?>">APCu <?php echo __('extension');?> &mdash; <?php
+                    echo __('(faster performance)');?></li>
+                <li class="<?php echo extension_loaded('Zend OPcache')?'yes':'no'; ?>">Zend OPcache <?php echo __('extension');?> &mdash; <?php
                     echo __('(faster performance)');?></li>
             </ul>
             <div id="bar">


### PR DESCRIPTION
This commit attempts to remove all coding standard warnings emitted by PHP 7.0. There's still some work to be done; but this gets things kinda working.

Fixes #2819
Fixes #2815
Fixes #2602