### PR TITLE
Allow for preselecting help topic

### DIFF
--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -10,8 +10,12 @@ if($thisclient && $thisclient->isValid()) {
 $info=($_POST && $errors)?Format::htmlchars($_POST):$info;
 
 $form = null;
-if (!$info['topicId'])
-    $info['topicId'] = $cfg->getDefaultTopicId();
+if (!$info['topicId']) {
+    if (array_key_exists('topicId',$_GET) && preg_match('/^\d+$/',$_GET['topicId']) && Topic::lookup($_GET['topicId']))
+        $info['topicId'] = intval($_GET['topicId']);
+    else
+        $info['topicId'] = $cfg->getDefaultTopicId();
+}
 
 $forms = array();
 if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {


### PR DESCRIPTION
Preselect a help topic in the GET parameters for open.php

This is the same code that was merged into the 1.9 develop branch, PR [https://github.com/osTicket/osTicket-1.8/pull/2735]. This pull request is to ensure that feature is carried over into the 1.10 version.