### PR TITLE
iFrame 

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -136,7 +136,8 @@ class Format {
             // Remove empty nodes
             $xpath = new DOMXPath($doc);
             static $eE = array('area'=>1, 'br'=>1, 'col'=>1, 'embed'=>1,
-                'hr'=>1, 'img'=>1, 'input'=>1, 'isindex'=>1, 'param'=>1);
+                    'iframe' => 1, 'hr'=>1, 'img'=>1, 'input'=>1,
+                    'isindex'=>1, 'param'=>1);
             do {
                 $done = true;
                 $nodes = $xpath->query('//*[not(text()) and not(node())]');
@@ -218,6 +219,17 @@ class Format {
     static function __html_cleanup($el, $attributes=0) {
         static $eE = array('area'=>1, 'br'=>1, 'col'=>1, 'embed'=>1,
             'hr'=>1, 'img'=>1, 'input'=>1, 'isindex'=>1, 'param'=>1);
+
+        // We're dealing with closing tag
+        if ($attributes === 0)
+            return "</{$el}>";
+
+        // Remove iframe and embed without src (perhaps striped by spec)
+        // It would be awesome to rickroll such entry :)
+        if (in_array($el, array('iframe', 'embed'))
+                && (!isset($attributes['src']) || empty($attributes['src'])))
+            return '';
+
         // Clean unexpected class values
         if (isset($attributes['class'])) {
             $classes = explode(' ', $attributes['class']);
@@ -268,7 +280,20 @@ class Format {
         }
     }
 
-    function safe_html($html, $balance=1) {
+    function safe_html($html, $options=array()) {
+
+        $options = array_merge(array(
+                    // Balance html tags
+                    'balance' => 1,
+                    // Decoding special html char like &lt; and &gt; which
+                    // can be used to skip cleaning
+                    'decode' => true
+                    ),
+                $options);
+
+        if ($options['decode'])
+            $html = Format::htmldecode($html);
+
         // Remove HEAD and STYLE sections
         $html = preg_replace(
             array(':<(head|style|script).+?</\1>:is', # <head> and <style> sections
@@ -278,9 +303,11 @@ class Format {
             ),
             array('', '', '', ''),
             $html);
+
+        // HtmLawed specific config only
         $config = array(
             'safe' => 1, //Exclude applet, embed, iframe, object and script tags.
-            'balance' => $balance,
+            'balance' => $options['balance'],
             'comment' => 1, //Remove html comments (OUTLOOK LOVE THEM)
             'tidy' => -1,
             'deny_attribute' => 'id',


### PR DESCRIPTION
This pull request addresses a case where iframe gets dropped as well was potential XSS security exploit in html cleanup.

* Whitelist iframe as allowed html node without content when dom (php-xml) is used to balance the tags.

* Decode html entities before sanitization to avoid potential htmLawed bypass. By default, Format::safe_html will now decode html entities before the balancing and cleanup is done.
