### PR TITLE
Attachment Link Target

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -643,7 +643,7 @@ class ThreadEntry {
         return $json;
     }
 
-    function getAttachmentsLinks($file='attachment.php', $target='', $separator=' ') {
+    function getAttachmentsLinks($file='attachment.php', $target='_blank', $separator=' ') {
 
         $str='';
         foreach($this->getAttachments() as $attachment ) {


### PR DESCRIPTION
Change target to `_blank` to open attachment in new window or tab based on browser settings.
