### PR TITLE
Fix page size returned in ajax config

### DIFF
--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -38,7 +38,7 @@ class ConfigAjaxAPI extends AjaxController {
               'lang'            => $lang,
               'short_lang'      => $sl,
               'has_rtl'         => $rtl,
-              'page_size'       => $thisstaff->getPageLimit(),
+              'page_size'       => PAGE_LIMIT,
         );
         return $this->json_encode($config);
     }


### PR DESCRIPTION
The config returned by **/scp/ajax.php/config/scp** would return 0 if the agent had their "Maximum page size" set to "system default". In that case it should return the global system setting for maximum page size.

This was causing the Statistics not to load on the Dashboard page, with this error:
[![](http://img.ctrlv.in/img/16/03/06/56dc2eef92b32.png)](http://ctrlv.in/722941)
Because of these lines line **dashoard.inc.js**:
```
                    if (i % pagesize === 0)
                        b = $('<tbody>').attr({'page':i/pagesize+1}).addClass('hidden').appendTo(q);
                    row = json.data[i];
                    tr = $('<tr>').appendTo(b);
```
So this PR also fixes that.