### PR TITLE
Rename Error class

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -12,7 +12,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 require_once(INCLUDE_DIR.'class.signal.php');
-require_once(INCLUDE_DIR.'class.error.php');
+require_once(INCLUDE_DIR.'class.osterror.php');
 
 class AttachmentFile extends VerySimpleModel {
 

--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -14,7 +14,7 @@
 
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
-require_once INCLUDE_DIR.'class.error.php';
+require_once INCLUDE_DIR.'class.osterror.php';
 require_once INCLUDE_DIR.'class.yaml.php';
 
 class Internationalization {

--- a/include/class.osterror.php
+++ b/include/class.osterror.php
@@ -1,6 +1,6 @@
 <?php
 /*********************************************************************
-    class.error.php
+    class.osterror.php
 
     Error handling for PHP < 5.0. Allows for returning a formal error from a
     function since throwing it isn't available. Also allows for consistent
@@ -17,7 +17,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 
-class Error extends Exception {
+class osTicketError extends Exception {
     static $title = '';
     static $sendAlert = true;
 
@@ -42,17 +42,17 @@ class Error extends Exception {
     }
 }
 
-class InitialDataError extends Error {
+class InitialDataError extends osTicketError {
     static $title = 'Problem with install initial data';
 }
 
 function raise_error($message, $class=false) {
-    if (!$class) $class = 'Error';
+    if (!$class) $class = 'osTicketError';
     new $class($message);
 }
 
 // File storage backend exceptions
-class IOException extends Error {
+class IOException extends osTicketError {
     static $title = 'Unable to read resource content';
 }
 

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -15,7 +15,7 @@
 **********************************************************************/
 include_once(INCLUDE_DIR.'class.ticket.php');
 include_once(INCLUDE_DIR.'class.dept.php');
-include_once(INCLUDE_DIR.'class.error.php');
+include_once(INCLUDE_DIR.'class.osterror.php');
 include_once(INCLUDE_DIR.'class.team.php');
 include_once(INCLUDE_DIR.'class.role.php');
 include_once(INCLUDE_DIR.'class.passwd.php');
@@ -840,7 +840,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $token = Misc::randCode(48); // 290-bits
 
         if (!$content)
-            return new Error(/* @trans */ 'Unable to retrieve password reset email template');
+            return new osTicketError(/* @trans */ 'Unable to retrieve password reset email template');
 
         $vars = array(
             'url' => $ost->getConfig()->getBaseUrl(),

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1051,7 +1051,7 @@ class UserAccount extends VerySimpleModel {
         $content = Page::lookupByType($template);
 
         if (!$email ||  !$content)
-            return new Error(sprintf(_S('%s: Unable to retrieve template'),
+            return new osTicketError(sprintf(_S('%s: Unable to retrieve template'),
                 $template));
 
         $vars = array(

--- a/include/class.yaml.php
+++ b/include/class.yaml.php
@@ -23,7 +23,7 @@
 **********************************************************************/
 
 require_once "Spyc.php";
-require_once "class.error.php";
+require_once "class.osterror.php";
 
 class YamlDataParser {
     /* static */
@@ -36,7 +36,7 @@ class YamlDataParser {
     }
 }
 
-class YamlParserError extends Error {
+class YamlParserError extends osTicketError {
     static $title = 'Error parsing YAML document';
 }
 ?>


### PR DESCRIPTION
PHP 7 provides its own Error class which clashes with OsTicket's. Since there's no namespaces being used I just renamed the class to have a localized osTicket specific name.

This should help progress toward #2602