### PR TITLE
Remove improper usage of func_get_args

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -459,10 +459,9 @@ class VerySimpleModel {
     static function lookup($criteria) {
         // Model::lookup(1), where >1< is the pk value
         if (!is_array($criteria)) {
-            $criteria = array();
-            $pk = static::getMeta('pk');
-            foreach (func_get_args() as $i=>$f)
-                $criteria[$pk[$i]] = $f;
+            $val = $criteria;
+            $pk = static::getMeta('pk')[0];
+            $criteria = array($pk => $val);
 
             // Only consult cache for PK lookup, which is assumed if the
             // values are passed as args rather than an array


### PR DESCRIPTION
In PHP 7 func_get_args will  "do the right thing" if a argument has been mutated, even if it was passed by value.

In this case it ensured that if non-array value was passed in then the resulting criteria would be:
`array($pk => array())`

This should make progress toward #2602 