### PR TITLE
Remove deprecated constructor

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -653,7 +653,7 @@ class AnnotatedModel {
 class SqlFunction {
     var $alias;
 
-    function SqlFunction($name) {
+    function __construct($name) {
         $this->func = $name;
         $this->args = array_slice(func_get_args(), 1);
     }


### PR DESCRIPTION
In PHP 7 the legacy constructor pattern is deprecated.

This should make progress toward #2602 