### PR TITLE
alerts: Do not include the manager with the members

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1350,13 +1350,16 @@ implements RestrictedAccess, Threadable {
                 $sentlist[] = $this->getEmail();
 
             // Only alerts dept members if the ticket is NOT assigned.
-            if ($cfg->alertDeptMembersONNewTicket() && !$this->isAssigned()) {
-                if (($members = $dept->getMembersForAlerts()))
-                    $recipients = array_merge($recipients, $members->all());
+            $manager = $dept->getManager();
+            if ($cfg->alertDeptMembersONNewTicket() && !$this->isAssigned()
+                && ($members = $dept->getMembersForAlerts())
+            ) {
+                foreach ($members as $M)
+                    if ($M != $manager)
+                        $recipients[] = $M;
             }
 
-            if ($cfg->alertDeptManagerONNewTicket() && $dept &&
-                    ($manager=$dept->getManager())) {
+            if ($cfg->alertDeptManagerONNewTicket() && $manager) {
                 $recipients[] = $manager;
             }
 


### PR DESCRIPTION
This fixes an issue, where the department manager cannot be excluded from the new ticket alert if the members of the department are checked. Considering there is a separate selection for the manager, this patch adjusts the system so the manager of the department only receives the new ticket alert if the manager checkbox is set. Otherwise, only the members of the department other than the manager receive the alert.