### PR TITLE
Changed ticket create date to be the email date

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -39,7 +39,7 @@ class TicketApiController extends ApiController {
 
         if(!strcasecmp($format, 'email')) {
             $supported = array_merge($supported, array('header', 'mid',
-                'emailId', 'to-email-id', 'ticketId', 'reply-to', 'reply-to-name',
+                'emailId', 'to-email-id', 'ticketId', 'reply-to', 'reply-to-name','date',
                 'in-reply-to', 'references', 'thread-type',
                 'mailflags' => array('bounce', 'auto-reply', 'spam', 'viral'),
                 'recipients' => array('*' => array('name', 'email', 'source'))

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -254,6 +254,10 @@ class Mail_Parse {
         return Format::mimedecode($this->struct->headers['subject'], $this->charset);
     }
 
+    function getDate(){
+        return Format::mimedecode($this->struct->headers['date'], $this->charset);
+    }
+
     function getReplyTo() {
         if (!($header = @$this->struct->headers['reply-to']))
             return null;
@@ -605,6 +609,7 @@ class EmailDataParser {
         $data['emailId'] = 0;
         $data['recipients'] = array();
         $data['subject'] = $parser->getSubject();
+        $data['date'] = $parser->getDate();
         $data['header'] = $parser->getHeader();
         $data['mid'] = $parser->getMessageId();
         $data['priorityId'] = $parser->getPriority();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3329,8 +3329,8 @@ implements RestrictedAccess, Threadable {
         //We are ready son...hold on to the rails.
         $number = $topic ? $topic->getNewTicketNumber() : $cfg->getNewTicketNumber();
         $ticket = new static(array(
-            'created' => SqlFunction::NOW(),
-            'lastupdate' => SqlFunction::NOW(),
+            'created' => date('Y-m-d G:i', strtotime( $vars['date'] ) ),
+            'lastupdate' => date('Y-m-d G:i', strtotime( $vars['date'] ) ),
             'number' => $number,
             'user' => $user,
             'dept_id' => $deptId,


### PR DESCRIPTION
Changed ticket create date to be the email date as opposed to the ingestion date of the email into osTicket. 
This should happen for a couple reasons
   1. Historical emails must have date preserved on import
   2. If the ticket system goes down or is having problems, it should not throw off dates. This may work as an unintended penalty for downtime.
   3. Multiple emails received at very close times may show as out of order.