### PR TITLE
FIX: Return-Path header is landing in spam boxes

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -561,6 +561,7 @@ class Mailer {
 
         //No SMTP or it failed....use php's native mail function.
         $mail = mail::factory('mail');
+        $mail->_params = '-f'.$this->getEmail()->getEmail();
         // Ensure the To: header is properly encoded.
         $to = $headers['To'];
         $result = $mail->send($to, $headers, $body);

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -560,8 +560,8 @@ class Mailer {
         }
 
         //No SMTP or it failed....use php's native mail function.
-        $mail = mail::factory('mail');
-        $mail->_params = '-f'.$this->getEmail()->getEmail();
+        $args = array('-f '.$this->getEmail()->getEmail());
+        $mail = mail::factory('mail', $args);
         // Ensure the To: header is properly encoded.
         $to = $headers['To'];
         $result = $mail->send($to, $headers, $body);


### PR DESCRIPTION
If the Return-Path header does not match the From header, emails are significantly more likely to be blocked by spam filters.
This patch forces the return header to match the from address without having to change php.ini and therefore works properly on servers that have multiple apps sending from multiple email addresses for example shared hosting, multiple support emails in one instance etc.
