### PR TITLE
orm: Partially revert 8ab4432ff7

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -297,23 +297,6 @@ class FAQ extends VerySimpleModel {
         return $att;
     }
 
-    function getAttachmentsLinks($separator=' ',$target='') {
-
-        $str='';
-        if ($attachments = $this->getLocalAttachments()->all()) {
-            foreach($attachments as $attachment ) {
-            /* The h key must match validation in file.php */
-            if($attachment['size'])
-                $size=sprintf('&nbsp;<small>(<i>%s</i>)</small>',Format::file_size($attachment['size']));
-
-            $str.=sprintf('<a class="Icon file no-pjax" href="%s" target="%s">%s</a>%s&nbsp;%s',
-                    $attachment['download_url'], $target, Format::htmlchars($attachment['name']), $size, $separator);
-
-            }
-        }
-        return $str;
-    }
-
     function delete() {
         try {
             parent::delete();

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -1138,7 +1138,7 @@ class QuerySet implements IteratorAggregate, ArrayAccess, Serializable, Countabl
     }
 
     function all() {
-        return $this->getIterator();
+        return $this->getIterator()->asArray();
     }
 
     function first() {

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -846,8 +846,8 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                 }
             } elseif ($cfg->alertDeptMembersONTaskTransfer() && !$this->isAssigned()) {
                 // Only alerts dept members if the task is NOT assigned.
-                if ($members = $dept->getMembersForAlerts()->all())
-                    $recipients = array_merge($recipients, $members);
+                foreach ($dept->getMembersForAlerts() as $M)
+                    $recipients[] = $M;
             }
 
             // Always alert dept manager??

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1818,8 +1818,8 @@ implements RestrictedAccess, Threadable {
             }
             elseif ($cfg->alertDeptMembersONOverdueTicket() && !$this->isAssigned()) {
                 // Only alerts dept members if the ticket is NOT assigned.
-                if ($members = $dept->getMembersForAlerts()->all())
-                    $recipients = array_merge($recipients, $members);
+                foreach ($dept->getMembersForAlerts() as $M)
+                    $recipients[] = $M;
             }
             // Always alert dept manager??
             if ($cfg->alertDeptManagerONOverdueTicket()
@@ -2082,8 +2082,8 @@ implements RestrictedAccess, Threadable {
             }
             elseif ($cfg->alertDeptMembersONTransfer() && !$this->isAssigned()) {
                 // Only alerts dept members if the ticket is NOT assigned.
-                if ($members = $dept->getMembersForAlerts()->all())
-                    $recipients = array_merge($recipients, $members);
+                foreach ($dept->getMembersForAlerts() as $M)
+                    $recipients[] = $M;
             }
 
             // Always alert dept manager??

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -1033,7 +1033,7 @@ class CustomDataTranslation extends VerySimpleModel {
             $criteria['lang'] = $lang;
 
         try {
-            return static::objects()->filter($criteria)->all()->asArray();
+            return static::objects()->filter($criteria)->all();
         }
         catch (OrmException $e) {
             // Translation table might not exist yet — happens on the upgrader

--- a/include/client/templates/sidebar.tmpl.php
+++ b/include/client/templates/sidebar.tmpl.php
@@ -20,7 +20,7 @@ $BUTTONS = isset($BUTTONS) ? $BUTTONS : true;
 <?php } ?>
         <div class="content"><?php
     $faqs = FAQ::getFeatured()->select_related('category')->limit(5);
-    if (count($faqs)) { ?>
+    if ($faqs->all()) { ?>
             <section><div class="header"><?php echo __('Featured Questions'); ?></div>
 <?php   foreach ($faqs as $F) { ?>
             <div><a href="<?php echo ROOT_PATH; ?>kb/faq.php?id=<?php

--- a/include/client/templates/thread-entries.tmpl.php
+++ b/include/client/templates/thread-entries.tmpl.php
@@ -2,7 +2,7 @@
 $events = $events
     ->filter(array('state__in' => array('created', 'closed', 'reopened', 'edited', 'collab')))
     ->order_by('id');
-$events = new IteratorIterator($events->all());
+$events = new IteratorIterator($events->getIterator());
 $events->rewind();
 $event = $events->current();
 

--- a/include/staff/templates/thread-entries.tmpl.php
+++ b/include/staff/templates/thread-entries.tmpl.php
@@ -10,7 +10,7 @@ $cmp = function ($a, $b) use ($sort) {
 };
 
 $events = $events->order_by($sort);
-$events = new IteratorIterator($events->all());
+$events = new IteratorIterator($events->getIterator());
 $events->rewind();
 $event = $events->current();
 $htmlId = $options['html-id'] ?: ('thread-'.$this->getId());


### PR DESCRIPTION
This partially reverts a change in the ORM changing the QuerySet::all() method to return an Iterator rather than an array. I spent a while proposing a patch to replace usage of all() with iterations; however, I cannot propose a valid reason to abandon the previous methodology.

This reintroduces the previous behavior: calling all() will yield an array of results from the QuerySet's iteration system.