### PR TITLE
I18n language pack versioning

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -550,7 +550,10 @@ abstract class Plugin {
         $P = new Phar($phar);
         $sig = $P->getSignature();
         $info = array();
-        if ($r = dns_get_record($sig['hash'].'.'.self::$verify_domain, DNS_TXT)) {
+        $ignored = null;
+        if ($r = dns_get_record($sig['hash'].'.'.self::$verify_domain.'.',
+            DNS_TXT, $ignored, $ignored, true)
+        ) {
             foreach ($r as $rec) {
                 foreach (explode(';', $rec['txt']) as $kv) {
                     list($k, $v) = explode('=', trim($kv));

--- a/include/cli/modules/i18n.php
+++ b/include/cli/modules/i18n.php
@@ -318,6 +318,8 @@ class i18n_Compiler extends Module {
 
         if (!function_exists('openssl_get_privatekey'))
             $this->fail('OpenSSL extension required for signing');
+        if (!$options['pkey'] || !file_exists($options['pkey']))
+            $this->fail('Signing private key (-P) required');
         $private = openssl_get_privatekey(
                 file_get_contents($options['pkey']));
         if (!$private)

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -171,22 +171,24 @@ if (!$lv) { ?>
 <?php
     foreach (Internationalization::availableLanguages() as $info) {
         $p = $info['path'];
-        if ($info['phar']) $p = 'phar://' . $p;
-        if (file_exists($p . '/MANIFEST.php')) {
-            $manifest = (include $p . '/MANIFEST.php'); ?>
+        if ($info['phar'])
+            $p = 'phar://' . $p;
+?>
     <h3><strong><?php echo Internationalization::getLanguageDescription($info['code']); ?></strong>
         &mdash; <?php echo $manifest['Language']; ?>
-<?php       if ($info['phar'])
-                Plugin::showVerificationBadge($info['path']);
-            ?>
+<?php   if ($info['phar'])
+            Plugin::showVerificationBadge($info['path']); ?>
         </h3>
         <div><?php echo sprintf('<code>%s</code> — %s', $info['code'],
                 str_replace(ROOT_DIR, '', $info['path'])); ?>
+<?php   if (file_exists($p . '/MANIFEST.php')) {
+            $manifest = (include $p . '/MANIFEST.php'); ?>
             <br/> <?php echo __('Version'); ?>: <?php echo $manifest['Version'];
                 ?>, <?php echo sprintf(__('for version %s'),
                     'v'.($manifest['Phrases-Version'] ?: '1.9')); ?>
             <br/> <?php echo __('Built'); ?>: <?php echo $manifest['Build-Date']; ?>
+<?php   } ?>
         </div>
-<?php }
+<?php
     } ?>
 </div>

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -180,8 +180,12 @@ if (!$lv) { ?>
                 Plugin::showVerificationBadge($info['path']);
             ?>
         </h3>
-        <div><?php echo __('Version'); ?>: <?php echo $manifest['Version']; ?>,
-            <?php echo __('Built'); ?>: <?php echo $manifest['Build-Date']; ?>
+        <div><?php echo sprintf('<code>%s</code> — %s', $info['code'],
+                str_replace(ROOT_DIR, '', $info['path'])); ?>
+            <br/> <?php echo __('Version'); ?>: <?php echo $manifest['Version'];
+                ?>, <?php echo sprintf(__('for version %s'),
+                    'v'.($manifest['Phrases-Version'] ?: '1.9')); ?>
+            <br/> <?php echo __('Built'); ?>: <?php echo $manifest['Build-Date']; ?>
         </div>
 <?php }
     } ?>

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2322,7 +2322,9 @@ tr.disabled th {
 }
 
 .label {
-    float: right;
+    display: inline-block;
+    position: relative;
+    bottom: 1px;
     margin-bottom: 4px;
     font-size: 11px;
     padding: 0px 7px;


### PR DESCRIPTION
Since two major versions will internationalization support will soon be available, the language pack system will need a way to indicate which major version of osTicket the phrases were compiled for. This patch adds a `Phrases-Version` tag to the MANIFEST, which will be a copy of the MAJOR_VERSION included in the messages.pot file created via `make-pot`. Then, a `Build-Major-Version` tag is added to the MANIFEST which represents the version of osTicket used to compile the language pack.

It also adds a `-b` option to the `build` command for the i18n cli applet. It causes the build to use a particular branch of the Crowdin language phrases.