### PR TITLE
forms: Fix lag updating the CDATA table

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1413,6 +1413,12 @@ class DynamicFormEntryAnswer extends VerySimpleModel {
         $this->getField()->db_cleanup();
         return true;
     }
+
+    function save($refetch) {
+        if ($this->dirty)
+            unset($this->_value);
+        return parent::save($refetch);
+    }
 }
 
 class SelectionField extends FormField {


### PR DESCRIPTION
This fixes an issue where the CDATA table is updated with the OLD version of an answer after it is updated. That is, after an answer is updated, the CDATA table is also updated to reflect the change; however, the old content of the answer value is used when updating the CDATA value.