### PR TITLE
orm: Propagate LEFT joins in join paths

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1143,10 +1143,6 @@ class StaffDeptAccess extends VerySimpleModel {
         'joins' => array(
             'dept' => array(
                 'constraint' => array('dept_id' => 'Dept.id'),
-                // FIXME: The ORM needs a way to support
-                //        staff__dept_access__dept performing a LEFT join b/c
-                //        staff__dept_access is LEFT
-                'null' => true,
             ),
             'staff' => array(
                 'constraint' => array('staff_id' => 'Staff.staff_id'),


### PR DESCRIPTION
If something like `members__staff` is considered leaving the Team model, and the `members` relationship is nullable, and the `staff` relationship is not, in the context of the compiled SQL statement, the second join should also be considered nullable (LEFT join), because otherwise inconsistent results would be returned from the query.

In other words, if a count is considered as an annotation to the Team model instances, Teams with zero members should still be considered as valid teams and should be selected with such an annotation. Before this patch, however, the join between TeamMember and Staff would have been an inner join instead of a LEFT join, which could skew the database results.