### PR TITLE
fix auto refresh rate options

### DIFF
--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -189,7 +189,7 @@ if ($avatar->isChangeable()) { ?>
                    for($i=1; $i <=30; $i+=$y) {
                      $sel=($staff->auto_refresh_rate==$i)?'selected="selected"':'';
                      echo sprintf('<option value="%d" %s>%s</option>', $i, $sel,
-                        sprintf(_N('Every minute', 'Every %d minutes', $i), $i));
+                        _N('Every minute', sprintf('Every %d minutes', $i), $i));
                      if($i>9)
                         $y=2;
                    } ?>


### PR DESCRIPTION
When auto refresh rate equals 1 you finish with the following sprinf code

`sprintf('Every minute', $i)`

which leads to sprintf warning when a staff member tries to edit his profile.

This fixes the problem.