### PR TITLE
Email aliases

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -216,7 +216,10 @@ class Email extends VerySimpleModel {
     /******* Static functions ************/
 
    static function getIdByEmail($email) {
-        $qs = static::objects()->filter(array('email' => $email))
+        $qs = static::objects()->filter(Q::any(array(
+                        'email'  => $email,
+                        'userid' => $email
+                        )))
             ->values_flat('email_id');
 
         $row = $qs->first();


### PR DESCRIPTION
Include username when checking if an email address is a system email. This is important for emails that use aliases.

For example: help@domain.com is hosted on Office 365 - the username used to fetch emails might be help@domain.onmicrosoft.com, and should be considered a system email.