### PR TITLE
Don't clean the config file, re-deploy rewritten files

### DIFF
--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -99,7 +99,7 @@ class Unpacker extends Module {
         if (!is_file($path))
             return null;
 
-        if (!preg_match_all('/^(\w+) (.+)$/mu', file_get_contents($path),
+        if (!preg_match_all('/^([\w:,]+) (.+)$/mu', file_get_contents($path),
             $lines, PREG_PATTERN_ORDER)
         ) {
             return null;
@@ -168,8 +168,12 @@ class Unpacker extends Module {
                 if (!$force && is_file($target)
                         && false === ($flag = $this->isChanged($file, $hash)))
                     continue;
-                if ($verbose)
-                    $this->stdout->write($target."\n");
+                if ($verbose) {
+                    $msg = $target;
+                    if (is_string($flag))
+                        $msg = "$msg ({$flag})";
+                    $this->stdout->write("$msg\n");
+                }
                 if ($dryrun)
                     continue;
                 if (!is_dir($destination))

--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -156,6 +156,7 @@ class Unpacker extends Module {
     function unpackage($folder, $destination, $recurse=0, $exclude=false) {
         $dryrun = $this->getOption('dry-run', false);
         $verbose = $this->getOption('verbose') || $dryrun;
+        $force = $this->getOption('force', false);
         if (substr($destination, -1) !== '/')
             $destination .= '/';
         foreach (glob($folder, GLOB_BRACE|GLOB_NOSORT) as $file) {
@@ -164,7 +165,8 @@ class Unpacker extends Module {
             if (is_file($file)) {
                 $target = $destination . basename($file);
                 $hash = $this->hashFile($file);
-                if (is_file($target) && !$this->isChanged($file, $hash))
+                if (!$force && is_file($target)
+                        && false === ($flag = $this->isChanged($file, $hash)))
                     continue;
                 if ($verbose)
                     $this->stdout->write($target."\n");


### PR DESCRIPTION
With the advent of the MANIFEST file, files which are rewritten when deployed, such as those which have the GIT hash in the query string to force browser reloading, were no longer deployed unless the content of those files changed.

This patch adds a flag to the MANIFEST file to indicate that the file was rewritten when it was deployed. This allows the file to be deployed and rewritten again when the deployment is run, but also adds an indication to the console output to distinguish deploying changes as opposed to deploying rewrites.

It also improves the exclusion mechanism for cleaning so the .MANIFEST and ost-config.php files are not cleaned from the deployment target.

Maybe fixes #3025