### PR TITLE
Edit master/include/class.page.php to not error

### DIFF
--- a/include/class.page.php
+++ b/include/class.page.php
@@ -33,7 +33,7 @@ class Page {
         $sql='SELECT page.*, count(topic.page_id) as topics '
             .' FROM '.PAGE_TABLE.' page '
             .' LEFT JOIN '.TOPIC_TABLE. ' topic ON(topic.page_id=page.id) '
-            . ' WHERE page.content_id='.db_input($id)
+            . ' WHERE page.id='.db_input($id)
             . ($lang ? ' AND lang='.db_input($lang) : '')
             .' GROUP By page.id';
 


### PR DESCRIPTION
Finally upgraded to 1.9 and was getting loads of errors like this: 
```
[SELECT page.*, count(topic.page_id) as topics  FROM ot_content page  LEFT JOIN ot_help_topic topic ON(topic.page_id=page.id)  WHERE page.page_id=3 GROUP By page.id]

Unknown column 'page.page_id' in 'where clause'<br />
<br />
---- Backtrace ----<br />
#0 (root)/include/mysqli.php(177): osTicket->logDBError('DB Error #1054', '[SELECT page.*,...')<br />
#1 (root)/include/class.page.php(40): db_query('SELECT page.*, ...')<br />
#2 (root)/include/class.page.php(25): Page->load('3', false)<br />
#3 (root)/include/class.page.php(227): Page->Page('3')<br />
#4 (root)/scp/pages.php(20): Page::lookup('3')<br />
#5 {main}
```


Looks like 1.10 uses a completely different system, so not likely to be an issue for long, but for others searching for this fix, here you go!.

Creating pull request against master.. living on the edge! :dash: 