### PR TITLE
[Feature] allow template variables injection with Signal

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -139,10 +139,12 @@ class osTicket {
     function replaceTemplateVariables($input, $vars=array()) {
 
         $replacer = new VariableReplacer();
-        $replacer->assign(array_merge($vars,
-            array('url' => $this->getConfig()->getBaseUrl(),
-                'company' => $this->company)
-                    ));
+        $vars = array_merge($vars, array(
+            'url' => $this->getConfig()->getBaseUrl(),
+            'company' => $this->company
+        ));
+        Signal::send('replace.variables', $replacer, $vars);
+        $replacer->assign($vars);
 
         return $replacer->replaceVars($input);
     }


### PR DESCRIPTION
Add a signal call in osTicket::replaceTemplateVariables() so plugins can inject custom template variables in emails.