### PR TITLE
i18n: Ensure UTF-8 locale is set

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -290,6 +290,10 @@ class Bootstrap {
         }
         if (extension_loaded('iconv'))
             iconv_set_encoding('internal_encoding', 'UTF-8');
+
+        // Set the default locale to UTF-8. It will be changed by
+        // ::setLocaleForUser() later for web requests. See #2910
+        Translation::setLocale(LC_ALL, 'en_US.UTF-8');
     }
 
     function croak($message) {


### PR DESCRIPTION
This is required for system requests such as email piping. Since a user is not logged in for the request, the system locale will not be set and text might get corrupted based on the PHP configuration.

Fixes #2910