### PR TITLE
html: Fix processing of some <html> tags in email

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -305,8 +305,9 @@ class Format {
                   ':<!\[[^]<]+\]>:',            # <![if !mso]> and friends
                   ':<!DOCTYPE[^>]+>:',          # <!DOCTYPE ... >
                   ':<\?[^>]+>:',                # <?xml version="1.0" ... >
+                  ':<html[^>]+:i',              # drop html attributes
             ),
-            array('', '', '', ''),
+            array('', '', '', '', '<html'),
             $html);
 
         // HtmLawed specific config only


### PR DESCRIPTION
This patch removes any contents of an html element when scrubbing html markup. Some markup includes complex namespaces and other information which does not concern the html processing of osTicket. It also messes up the htmLawed processing of the htmLawed.

Thanks @robintoy, @talilon

Maybe fixes #2465
Maybe fixes #2272 

Backport to 1.9.x