### PR TITLE
forms: Fix crash when editing entries from deleted forms

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -918,11 +918,16 @@ class DynamicFormEntry extends VerySimpleModel {
      * entry.
      */
     function addMissingFields() {
+        if (!($form = $this->getForm())
+            // The form for this entry was removed. No missing fields to
+            // consider
+            return;
+
         // Track deletions
         foreach ($this->getAnswers() as $answer)
             $answer->deleted = true;
 
-        foreach ($this->getForm()->getDynamicFields() as $field) {
+        foreach ($form->getDynamicFields() as $field) {
             $found = false;
             foreach ($this->getAnswers() as $answer) {
                 if ($answer->get('field_id') == $field->get('id')) {


### PR DESCRIPTION
Forms can be deleted if they have entries. Therefore, when editing entries, it should be assumed possible that the form connected to the entry may no longer exist when being edited.

This bug does not affect the v1.10 branch

Fixes #3178