### PR TITLE
forms: Properly scrub email addresses

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -668,7 +668,7 @@ class FormField {
 
         # Validates a user-input into an instance of this field on a dynamic
         # form
-        if ($this->get('required') && !$value && $this->hasData())
+        if ($this->get('required') && !strlen($value) && $this->hasData())
             $this->_errors[] = $this->getLabel()
                 ? sprintf(__('%s is a required field'), $this->getLabel())
                 : __('This is a required field');


### PR DESCRIPTION
This reduces `<an@email.addr>` by removing the angle brackets. It also drops any other valid part of the email address which is not used by osTicket.

Maybe fixes #2473
Maybe fixes #1996
