### PR TITLE
orm: Fix warning for read-only role permission, cleanup Dept::getMembers() usage

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -502,7 +502,7 @@ class TicketsAjaxAPI extends AjaxController {
             if ($ticket->getStaffId() == $thisstaff->getId())
                 $assigned = __('you');
             else
-                $assigneed = $ticket->getAssigned();
+                $assigned = $ticket->getAssigned();
 
             $info['error'] = sprintf(__('%s is currently assigned to <b>%s</b>'),
                     __('This ticket'),

--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -160,10 +160,8 @@ implements TemplateVariable {
         return count($this->getMembers());
     }
 
-    function getMembers($criteria=null) {
-        global $cfg;
-
-        if (!$this->_members || $criteria) {
+    function getMembers() {
+        if (!isset($this->_members)) {
             $members = Staff::objects()
                 ->distinct('staff_id')
                 ->constrain(array(
@@ -178,34 +176,23 @@ implements TemplateVariable {
                     'dept_access__dept_id' => $this->getId(),
                 )));
 
-            // TODO: Consider moving this into ::getAvailableMembers
-            if ($criteria && $criteria['available']) {
-                $members->filter(array(
-                    'isactive' => 1,
-                    'onvacation' => 0,
-                ));
-            }
-
-            $members = Staff::nsort($members);
-
-            if ($criteria)
-                return $members;
-
-            $this->_members = $members;
+            $this->_members = Staff::nsort($members);
         }
         return $this->_members;
     }
 
     function getAvailableMembers() {
-        return $this->getMembers(array('available'=>1));
+        $members = clone $this->getMembers();
+        return $members->filter(array(
+            'isactive' => 1,
+            'onvacation' => 0,
+        ));
     }
 
     function getPrimaryMembers() {
-
         if (!isset($this->_primary_members)) {
             $members = clone $this->getMembers();
             $members->filter(array('dept_id' =>$this->getId()));
-            $members = Staff::nsort($members);
             $this->_primary_members = $members->all();
         }
 
@@ -213,21 +200,20 @@ implements TemplateVariable {
     }
 
     function getExtendedMembers() {
-
         if (!isset($this->_exended_members)) {
             // We need a query set so we can sort the names
             $members = StaffDeptAccess::objects();
             $members->filter(array('dept_id' => $this->getId()));
             $members = Staff::nsort($members, 'staff__');
             $extended = array();
-            foreach($members->all() as $member) {
-                if (!$member->staff) continue;
+            foreach($members as $member) {
+                if (!$member->staff)
+                    continue;
                 // Annoted the staff model with alerts and role
-                $extended[] =  new AnnotatedModel($member->staff, array(
-                            'alerts'  => $member->isAlertsEnabled(),
-                            'role_id' => $member->role_id,
-                            )
-                        );
+                $extended[] = new AnnotatedModel($member->staff, array(
+                    'alerts'  => $member->isAlertsEnabled(),
+                    'role_id' => $member->role_id,
+                ));
             }
 
             $this->_extended_members = $extended;
@@ -238,7 +224,6 @@ implements TemplateVariable {
 
     // Get members  eligible members only
     function getAssignees() {
-
         $members = clone $this->getAvailableMembers();
         // If restricted then filter to primary members ONLY!
         if ($this->assignMembersOnly())
@@ -325,21 +310,19 @@ implements TemplateVariable {
     }
 
     function isManager($staff) {
-
-        if(is_object($staff)) $staff=$staff->getId();
+        if (is_object($staff))
+            $staff = $staff->getId();
 
         return ($this->getManagerId() && $this->getManagerId()==$staff);
     }
 
     function isMember($staff) {
-
         if (is_object($staff))
             $staff = $staff->getId();
 
-        $members = $this->getMembers() ?: $this->members;
-
-        return ($members->findFirst(array(
-                        'staff_id' => $staff)));
+        return $members->getIterator()->findFirst(array(
+            'staff_id' => $staff
+        ));
     }
 
     function isPublic() {

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2281,7 +2281,7 @@ class AssigneeField extends ChoiceField {
             $criteria = $this->getCriteria();
             $agents = array();
             if (($dept=$config['dept']) && $dept->assignMembersOnly()) {
-                if (($members = $dept->getMembers($criteria)))
+                if (($members = $dept->getAvailableMembers()))
                     foreach ($members as $member)
                         $agents[$member->getId()] = $member;
             } else {

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -293,7 +293,7 @@ class VerySimpleModel {
         'pk' => false
     );
 
-    var $ht;
+    var $ht = array();
     var $dirty = array();
     var $__new__ = false;
     var $__deleted__ = false;


### PR DESCRIPTION
This fixes an issue where the `$ht` variable is not properly initialized by the ORM. It is assumed to be a valid array in the constructor, and its items are run through the ::set() method. Therefore, if an empty array is received, the `$ht` variable will remain null, since nothing is ever set.

This also fixes a misspelled variable in the claim dialog if a ticket is currently assigned to a team only.

It also cleans up usage of `getMembers` in class Dept. In ::isMember(), there is now no reason that a call to ::getMembers() would fail, so it can be assumed that a QuerySet instance is returned.

I also think we should merge #3090