### PR TITLE
thread: Add support for emoji characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ osTicket is supported by several magical open source projects including:
   * [php-gettext](https://launchpad.net/php-gettext/)
   * [phpseclib](http://phpseclib.sourceforge.net/)
   * [Spyc](http://github.com/mustangostang/spyc)
+  * [Twitter Emoji](https://github.com/twitter/twemoji)

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -75,7 +75,7 @@ function db_connect($host, $user, $passwd, $options = array()) {
         'COLLATION_CONNECTION'  => 'utf8_general_ci',
         'SQL_MODE'              => '',
     ), 'session');
-    $__db->set_charset('utf8');
+    $__db->set_charset('utf8mb4');
 
     $__db->autocommit(true);
 

--- a/include/staff/footer.inc.php
+++ b/include/staff/footer.inc.php
@@ -54,6 +54,7 @@ if(is_object($thisstaff) && $thisstaff->isStaff()) { ?>
 <script type="text/javascript" src="<?php echo ROOT_PATH; ?>scp/js/jquery.dropdown.js"></script>
 <script type="text/javascript" src="<?php echo ROOT_PATH; ?>scp/js/bootstrap-tooltip.js"></script>
 <script type="text/javascript" src="<?php echo ROOT_PATH; ?>js/fabric.min.js"></script>
+<script src="//twemoji.maxcdn.com/2/twemoji.min.js"></script>
 <link type="text/css" rel="stylesheet" href="<?php echo ROOT_PATH; ?>scp/css/tooltip.css">
 <script type="text/javascript">
     getConfig().resolve(<?php

--- a/include/staff/templates/thread-entries.tmpl.php
+++ b/include/staff/templates/thread-entries.tmpl.php
@@ -91,5 +91,9 @@ foreach (Attachment::objects()->filter(array(
         if ($.thread)
             $.thread.onLoad(container,
                     {autoScroll: <?php echo $sort == 'id' ? 'true' : 'false'; ?>});
+
+        $('#'+container).find('div.thread-entry').each(function(i,e){
+            twemoji.parse(e);
+        });
     });
 </script>

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2921,6 +2921,11 @@ a.attachment {
     margin-bottom: 0.3em;
 }
 
+.thread-body .emoji.emoji.emoji {
+    width: 1.2em;
+    height: 1.2em;
+}
+
 /* FIXME: Drop this with select2 4.0.1
  * Fixes a rendering issue on Safari
  */


### PR DESCRIPTION
This adds emoji support to the ticket thread. This is especially useful for platforms which do not have built in emoji symbols. It also fixes the issue where `real_escape_string` converts emoji characters to querstion marks (`?`).

This requires MySQL 5.6 and manual conversion of the %thread_entry.body field to be collation utf8mb4.

Fixes #1475