### PR TITLE
Make `cron` signals conform to documentation.

### DIFF
--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -107,7 +107,7 @@ class Cron {
         self::MaybeOptimizeTables();
 
         $data = array('autocron'=>false);
-        Signal::send('cron', $data);
+        Signal::send('cron', null, $data);
     }
 }
 ?>

--- a/scp/autocron.php
+++ b/scp/autocron.php
@@ -66,7 +66,7 @@ if($cfg && $cfg->isAutoCronEnabled()) { //ONLY fetch tickets if autocron is enab
 }
 
 $data = array('autocron'=>true);
-Signal::send('cron', $data);
+Signal::send('cron', null, $data);
 
 ob_end_clean();
 ?>


### PR DESCRIPTION
The [signal documentation](https://github.com/osTicket/osTicket/blob/develop/setup/doc/signals.md) for the `cron` signal states that the context is `null`. But it was missing until now (and the `$data` parameter was wrongly forwarded as`$object`)