### PR TITLE
thread: Fix crash processing problem attachments

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -913,9 +913,18 @@ implements TemplateVariable {
                         _S($error_descriptions[$error]));
                 }
                 // No need to log the missing-file error number
-                if ($error != UPLOAD_ERR_NO_FILE)
-                    $this->getThread()->getObject()->logNote(
-                        _S('File Import Error'), $error, _S('SYSTEM'), false);
+                if ($error != UPLOAD_ERR_NO_FILE
+                    && ($thread = $this->getThread())
+                ) {
+                    // Log to the thread directly, since alerts should be
+                    // suppressed and this is defintely a system message
+                    $thread->addNote(array(
+                        'title' => _S('File Import Error'),
+                        'note' => new TextThreadEntryBody($error),
+                        'poster' => 'SYSTEM',
+                        'staffId' => 0,
+                    ));
+                }
                 continue;
             }
 
@@ -2478,7 +2487,7 @@ implements TemplateVariable {
         ));
     }
 
-    function addNote($vars, &$errors) {
+    function addNote($vars, &$errors=array()) {
 
         //Add ticket Id.
         $vars['threadId'] = $this->getId();


### PR DESCRIPTION
The ThreadEntry::normalizeFileInfo() method is called from ::create(), but before the thread entry is saved. Therefore, the ::getThread() and ::getObject() methods may not return a valid object for posting the thread message.

References: #3029