### PR TITLE
Passive Email Threading

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2336,6 +2336,8 @@ implements RestrictedAccess, Threadable {
                 : true;
         if ($autorespond && $message->isBounceOrAutoReply())
             $autorespond = false;
+        elseif ($autorespond && isset($vars['autorespond']))
+            $autorespond = $vars['autorespond'];
 
         $this->onMessage($message, ($autorespond && $alerts)); //must be called b4 sending alerts to staff.
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1535,7 +1535,7 @@ implements RestrictedAccess, Threadable {
         }
     }
 
-    function onMessage($message, $autorespond=true) {
+    function onMessage($message, $autorespond=true, $reopen=true) {
         global $cfg;
 
         $this->isanswered = 0;
@@ -1547,7 +1547,7 @@ implements RestrictedAccess, Threadable {
         // We're also checking autorespond flag because we don't want to
         // reopen closed tickets on auto-reply from end user. This is not to
         // confused with autorespond on new message setting
-        if ($autorespond && $this->isClosed() && $this->isReopenable()) {
+        if ($reopen && $this->isClosed() && $this->isReopenable()) {
             $this->reopen();
             // Auto-assign to closing staff or the last respondent if the
             // agent is available and has access. Otherwise, put the ticket back
@@ -2334,12 +2334,13 @@ implements RestrictedAccess, Threadable {
         $autorespond = isset($vars['mailflags'])
                 ? !$vars['mailflags']['bounce'] && !$vars['mailflags']['auto-reply']
                 : true;
+        $reopen = $autorespond; // Do not reopen bounces
         if ($autorespond && $message->isBounceOrAutoReply())
-            $autorespond = false;
+            $autorespond = $reopen= false;
         elseif ($autorespond && isset($vars['autorespond']))
             $autorespond = $vars['autorespond'];
 
-        $this->onMessage($message, ($autorespond && $alerts)); //must be called b4 sending alerts to staff.
+        $this->onMessage($message, ($autorespond && $alerts), $reopen); //must be called b4 sending alerts to staff.
 
         if ($autorespond && $alerts && $cfg && $cfg->notifyCollabsONNewMessage())
             $this->notifyCollaborators($message, array('signature' => ''));
@@ -2406,6 +2407,7 @@ implements RestrictedAccess, Threadable {
                 $sentlist[] = $staff->getEmail();
             }
         }
+
         return $message;
     }
 
@@ -2827,6 +2829,7 @@ implements RestrictedAccess, Threadable {
         if (!$this->save())
             return false;
 
+	$vars['note'] = ThreadEntryBody::clean($vars['note']);
         if ($vars['note'])
             $this->logNote(_S('Ticket Updated'), $vars['note'], $thisstaff);
 
@@ -2899,9 +2902,11 @@ implements RestrictedAccess, Threadable {
     }
 
     static function isTicketNumberUnique($number) {
-        return 0 === static::objects()
+        $num = static::objects()
             ->filter(array('number' => $number))
-            ->count();
+	    ->count();
+
+	return ($num === 0);
     }
 
     /* Quick staff's tickets stats */


### PR DESCRIPTION
Add basic support for threading email conversations happening outside the system. Autoresponders are paused when threading is on passive mode. Alerts may still go out to agents as configured.

- [ ] Stripping or collapsing  quoted reply will require plenty of work. 


