### PR TITLE
fix incorrect decoding of HTML tag brackets in message content

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -292,7 +292,7 @@ class Format {
                     'balance' => 1,
                     // Decoding special html char like &lt; and &gt; which
                     // can be used to skip cleaning
-                    'decode' => true
+                    'decode' => false
                     ),
                 $options);
 


### PR DESCRIPTION
This fixes incorrect decoding of &lt; and &gt; in the content of e-mail messages when rich formatting is enabled.

Currently, whenever a message contains an XML-like tag (e.g. <s>), correctly encoded into &lt; and &gt; entities, osTicket decodes these and tries to interpret them as HTML which it shouldn't do.