### PR TITLE
Checking if $vars['trans'] is set before doing foreach

### DIFF
--- a/include/class.page.php
+++ b/include/class.page.php
@@ -319,21 +319,25 @@ class Page extends VerySimpleModel {
                 return false;
         }
         // New translations (?)
-        foreach ($vars['trans'] as $lang=>$parts) {
-            $content = array('name' => @$parts['title'], 'body' => Format::sanitize(@$parts['body']));
-            if (!array_filter($content))
-                continue;
-            $t = CustomDataTranslation::create(array(
-                'type'      => 'article',
-                'object_hash' => $tag,
-                'lang'      => $lang,
-                'text'      => $content,
-                'revision'  => 1,
-                'agent_id'  => $thisstaff->getId(),
-                'updated'   => SqlFunction::NOW(),
-            ));
-            if (!$t->save())
-                return false;
+        if ($vars['trans']) {
+
+            foreach ($vars['trans'] as $lang=>$parts) {
+                $content = array('name' => @$parts['title'], 'body' => Format::sanitize(@$parts['body']));
+                if (!array_filter($content))
+                    continue;
+                $t = CustomDataTranslation::create(array(
+                    'type'      => 'article',
+                    'object_hash' => $tag,
+                    'lang'      => $lang,
+                    'text'      => $content,
+                    'revision'  => 1,
+                    'agent_id'  => $thisstaff->getId(),
+                    'updated'   => SqlFunction::NOW(),
+                ));
+                if (!$t->save())
+                    return false;
+            }
+
         }
         return true;
     }


### PR DESCRIPTION
This is my first pull request for osTicket. I couldn't find a pull request that is fixing this issue ([1.10 (364044e8) error saving pages](https://github.com/osTicket/osTicket/issues/2868)) so I figured I'd submit one.

**Commit Message:**
If `$vars['trans']` is not set then it throws the error "Warning:
Invalid argument supplied for foreach() in
/opt/osTicket-git/osTicket-1.8/include/class.page.php on line 322".

This happens when attempting to save a page.

If we check that `$vars['trans']` actually exists or is set then we can
avoid this error.