### PR TITLE
Pure PHP workaround for some cases when PATH_INFO is not set and can't be set

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -370,7 +370,15 @@ class osTicket {
         if(isset($_SERVER['ORIG_PATH_INFO']))
             return $_SERVER['ORIG_PATH_INFO'];
 
-        //TODO: conruct possible path info.
+        if (preg_match("/^(.+\/.*\.php)(\?)?(\/.+)$/", $_SERVER['REQUEST_URI'], $URI_PATH_INFO)) {
+            $constPathInfo = $URI_PATH_INFO[3];
+
+            if (preg_match("/(.*)\?(.*)/", $constPathInfo)) {
+                $constPathInfo = substr($constPathInfo, 0, strripos($constPathInfo, "?"));
+            }
+
+            return $constPathInfo;
+        }
 
         return null;
     }


### PR DESCRIPTION
Pure PHP workaround for some cases when PATH_INFO is not set and can't be set, based on the $_SERVER['REQUEST_URI'] variable