### PR TITLE
Fix typo: should be search, not pattern

### DIFF
--- a/include/html2text.php
+++ b/include/html2text.php
@@ -1014,7 +1014,7 @@ function mb_wordwrap($string, $width=75, $break="\n", $cut=false) {
   } else {
     // Anchor the beginning of the pattern with a lookahead
     // to avoid crazy backtracking when words are longer than $width
-    $pattern = '/(?=[\s\p{Ps}])(.{1,'.$width.'})(?:\s|$|(\p{Ps}))/uS';
+    $search = '/(?=[\s\p{Ps}])(.{1,'.$width.'})(?:\s|$|(\p{Ps}))/uS';
     $replace = '$1'.$break.'$2';
   }
   return rtrim(preg_replace($search, $replace, $string), $break);


### PR DESCRIPTION
I am getting the following warning in my logs:
`PHP Warning:  preg_replace(): Compilation failed: numbers out of order in {} quantifier at offset 25 in osticket/include/html2text.php on line 1020`

thus I looked into that file to understand what the problem is. My IDE directly noticed that in function mb_wordwrap (see below) the variable `pattern` is unused. If you look closer, you see the pattern is named `search` in the if clause, but `pattern` in the else clause. I assume this is not intended?

``` php
function mb_wordwrap($string, $width=75, $break="\n", $cut=false) {
  if ($cut) {
    // Match anything 1 to $width chars long followed by whitespace or EOS,
    // otherwise match anything $width chars long
    $search = '/((?>[^\n\p{M}]\p{M}*){1,'.$width.'})(?:[ \n]|$|(\p{Ps}))|((?>[^\n\p{M}]\p{M}*){'
          .$width.'})/uS'; # <?php
    $replace = '$1$3'.$break.'$2';
  } else {
    // Anchor the beginning of the pattern with a lookahead
    // to avoid crazy backtracking when words are longer than $width
    $pattern = '/(?=[\s\p{Ps}])(.{1,'.$width.'})(?:\s|$|(\p{Ps}))/uS';
    $replace = '$1'.$break.'$2';
  }
  return rtrim(preg_replace($search, $replace, $string), $break);
}`
```
