### PR TITLE
Un-Assign Agent when a Ticket is assigned to a Team

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2208,6 +2208,7 @@ implements RestrictedAccess, Threadable {
                         );
             } else {
                 $this->team_id = $assignee->getId();
+                $this->staff_id = 0;
                 $evd = array('team' => $assignee->getId());
             }
         } else {


### PR DESCRIPTION
When an Agent assigns a Ticket to a Team it is obvious that action is required by the Team being assigned. If the Ticket is already assigned to an Agent, assigning to a Team will not remove the Agent, and therefore the Team will not be sent a notification of a ticket assigned to the Team as the Ticket already has an Agent assigned.

This update removes the Agent from the Ticket during the assigning to the Team. In this way the Team assigned will receive the notification that a Ticket has been assigned to the Team for action.