### PR TITLE
Notify collaborators when new Ticket is created

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1356,6 +1356,14 @@ implements RestrictedAccess, Threadable {
             );
             $email->sendAutoReply($this->getOwner(), $msg['subj'], $msg['body'],
                 null, $options);
+            
+            // Notify collaborators also on New Ticket
+            if ($cfg->notifyCollabsONNewMessage()) {    // Check if Collaborators should be notified.
+                $this->notifyCollaborators(
+                    $message,
+                    array('signature' => ($dept && $dept->isPublic())?$dept->getSignature():'')
+                );
+            }
         }
 
         // Send alert to out sleepy & idle staff.


### PR DESCRIPTION
Before this, collaborators were notified only on tickets updates.
Now, when a new Ticket is created, the owner and the collaborators will be notified by email.
