### PR TITLE
1.10 :: Fix Last Updated variable for Help Topics

### DIFF
--- a/include/staff/helptopics.inc.php
+++ b/include/staff/helptopics.inc.php
@@ -147,7 +147,7 @@ $order_by = 'sort';
                 <td><?php echo $priority; ?></td>
                 <td><a href="departments.php?id=<?php echo $deptId;
                 ?>"><?php echo $dept; ?></a></td>
-                <td>&nbsp;<?php echo Format::datetime($team->updated); ?></td>
+                <td>&nbsp;<?php echo Format::datetime($topic->updated); ?></td>
             </tr>
             <?php
             } //end of foreach.


### PR DESCRIPTION
Correct variable so that the last updated date and time shows correctly on `scp/helptopics.php`