### PR TITLE
Task duedate format

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1285,7 +1285,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         if ($vars['internal_formdata']['dept_id'])
             $task->dept_id = $vars['internal_formdata']['dept_id'];
         if ($vars['internal_formdata']['duedate'])
-            $task->duedate = $vars['internal_formdata']['duedate'];
+	    $task->duedate = date('Y-m-d G:i', Misc::dbtime($vars['internal_formdata']['duedate']));
 
         if (!$task->save(true))
             return false;


### PR DESCRIPTION
Fixes missing due date on task create caused by invalid datetime format sent to db.

**Pending**
- [ ] Invalid timezone conversion
