### PR TITLE
XSS:  Validate HTTP_X_FORWARDED_FOR header.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -50,11 +50,7 @@ class Bootstrap {
     }
 
     function https() {
-       return
-            (isset($_SERVER['HTTPS'])
-                && strtolower($_SERVER['HTTPS']) == 'on')
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
-                && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https');
+       return osTicket::is_https();
     }
 
     static function defineTables($prefix) {
@@ -335,6 +331,7 @@ ini_set('include_path', './'.PATH_SEPARATOR.INCLUDE_DIR.PATH_SEPARATOR.PEAR_DIR)
 require(INCLUDE_DIR.'class.osticket.php');
 require(INCLUDE_DIR.'class.misc.php');
 require(INCLUDE_DIR.'class.http.php');
+require(INCLUDE_DIR.'class.validator.php');
 
 // Determine the path in the URI used as the base of the osTicket
 // installation
@@ -342,6 +339,7 @@ if (!defined('ROOT_PATH') && ($rp = osTicket::get_root_path(dirname(__file__))))
     define('ROOT_PATH', rtrim($rp, '/').'/');
 
 Bootstrap::init();
+Bootstrap::loadConfig();
 
 #CURRENT EXECUTING SCRIPT.
 define('THISPAGE', Misc::currentURL());
@@ -350,8 +348,5 @@ define('DEFAULT_MAX_FILE_UPLOADS',ini_get('max_file_uploads')?ini_get('max_file_
 define('DEFAULT_PRIORITY_ID',1);
 
 #Global override
-if (isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-    // Take the left-most item for X-Forwarded-For
-    $_SERVER['REMOTE_ADDR'] = trim(array_pop(
-        explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])));
+$_SERVER['REMOTE_ADDR'] = osTicket::get_client_ip();
 ?>

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -107,6 +107,39 @@ define('TABLE_PREFIX','%CONFIG-PREFIX');
 
 # define('ROOT_PATH', '/support/');
 
+
+# Option: TRUSTED_PROXIES (default: <none>)
+#
+# To support running osTicket installation on a web servers that sit behind a
+# load balancer, HTTP cache, or other intermediary (reverse) proxy; it's
+# necessary to define trusted proxies to protect against forged http headers
+#
+# osTicket supports passing the following http headers from a trusted proxy;
+# - HTTP_X_FORWARDED_FOR    =>  Chain of client's IPs
+# - HTTP_X_FORWARDED_PROTO  =>  Client's HTTP protocal (http | https)
+#
+# You'll have to explicitly define comma separated IP addreseses or CIDR of
+# upstream proxies to trust. Wildcard "*" (not recommended) can be used to
+# trust all chained IPs as proxies in cases that ISP/host doesn't provide
+# IPs of loadbalancers or proxies.
+#
+# References:
+# http://en.wikipedia.org/wiki/X-Forwarded-For
+#
+
+define('TRUSTED_PROXIES', '');
+
+
+# Option: LOCAL_NETWORKS (default: 127.0.0.0/24)
+#
+# When running osTicket as part of a cluster it might become necessary to
+# whitelist local/virtual networks that can bypass some authentication/checks.
+#
+# define comma separated IP addreseses or enter CIDR of local network.
+
+define('LOCAL_NETWORKS', '127.0.0.0/24');
+
+
 #
 # Session Storage Options
 # ---------------------------------------------------

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -1,5 +1,9 @@
 <?php
 header("Content-Type: text/html; charset=UTF-8");
+
+$title = ($ost && ($title=$ost->getPageTitle()))
+    ? $title : ('osTicket :: '.__('Staff Control Panel'));
+
 if (!isset($_SERVER['HTTP_X_PJAX'])) { ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html<?php
@@ -17,7 +21,7 @@ if ($lang) {
     <meta http-equiv="cache-control" content="no-cache" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="x-pjax-version" content="<?php echo GIT_VERSION; ?>">
-    <title><?php echo ($ost && ($title=$ost->getPageTitle()))?$title:'osTicket :: '.__('Staff Control Panel'); ?></title>
+    <title><?php echo Format::htmlchars($title); ?></title>
     <!--[if IE]>
     <style type="text/css">
         .tip_shadow { display:block !important; }

--- a/include/staff/syslogs.inc.php
+++ b/include/staff/syslogs.inc.php
@@ -156,7 +156,7 @@ else
                 <td>&nbsp;<a class="tip" href="#log/<?php echo $row['log_id']; ?>"><?php echo Format::htmlchars($row['title']); ?></a></td>
                 <td><?php echo $row['log_type']; ?></td>
                 <td>&nbsp;<?php echo Format::daydatetime($row['created']); ?></td>
-                <td><?php echo $row['ip_address']; ?></td>
+                <td><?php echo Format::htmlchars($row['ip_address']); ?></td>
             </tr>
             <?php
             } //end of while.

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -355,7 +355,7 @@ if($ticket->isOverdue())
                         echo Format::htmlchars($ticket->getSource());
 
                         if (!strcasecmp($ticket->getSource(), 'Web') && $ticket->getIP())
-                            echo '&nbsp;&nbsp; <span class="faded">('.$ticket->getIP().')</span>';
+                            echo '&nbsp;&nbsp; <span class="faded">('.Format::htmlchars($ticket->getIP()).')</span>';
                         ?>
                     </td>
                 </tr>

--- a/main.inc.php
+++ b/main.inc.php
@@ -21,7 +21,6 @@ if(isset($_SERVER['SCRIPT_NAME'])
     die('kwaheri rafiki!');
 
 require('bootstrap.php');
-Bootstrap::loadConfig();
 Bootstrap::defineTables(TABLE_PREFIX);
 Bootstrap::i18n_prep();
 Bootstrap::loadCode();

--- a/setup/test/tests/test.validation.php
+++ b/setup/test/tests/test.validation.php
@@ -54,6 +54,19 @@ class TestValidation extends Test {
         #$this->assert(Validator::is_email('δοκιμή@παράδειγμα.δοκιμή'));
         #$this->assert(Validator::is_email('甲斐@黒川.日本'));
     }
+
+    function testIPAddresses() {
+
+        // Validate IP Addreses
+        $this->assert(Validator::is_ip('127.0.0.1'));
+        $this->assert(Validator::is_ip('192.168.129.74'));
+
+        // Test IP check
+        $this->assert(Validator::check_ip('127.0.0.1', '127.0.0.0/24'));
+        $this->assert(Validator::check_ip('192.168.129.42',
+                    ['127.0.0.0/24', '192.168.129.0/24']));
+        $this->assert(!Validator::check_ip('10.0.5.15', '127.0.0.0/24'));
+    }
 }
 return 'TestValidation';
 ?>


### PR DESCRIPTION
Prior versions of osTicket blindly trusted http headers set by upstream proxies or agents. This pull request addresses possible remote XSS injection via X_FORWARDED_FOR header by introducing HTTP options to define a list of Trusted Proxies as well as address space of trusted Local Networks. CIDR notation (subnets) are supported.

**HTTP Option: TRUSTED_PROXIES (default: <none>**
To support running osTicket installation on a web servers that sit behind a load balancer, HTTP cache, or other intermediary (reverse) proxy; it's necessary to define trusted proxies to protect against forged http headers.

**HTTP Option: LOCAL_NETWORKS (default: 127.0.0.0/24)**
When running osTicket as part of a cluster it might become necessary to white list local/virtual networks that can bypass some authentication checks.

**Validate Upstream IP Addresses**
Validate CLIENT_IP to make sure it's a valid IP address. Address prior entries by forcing html chars encoding on display.