### PR TITLE
List Item Abbreviation

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -172,7 +172,7 @@ class DynamicFormsAjaxAPI extends AjaxController {
                 $item->update([
                     'name' =>   $basic['name'],
                     'value' =>  $basic['value'],
-                    'extra' =>  $basic['extra'],
+                    'abbrev' =>  $basic['extra'],
                 ]);
             }
         }


### PR DESCRIPTION
This addresses issue where list item abbrv. is not update because the update() method is
expects 'abbrev' key.