### PR TITLE
Feature :: Auto Close for v1.10

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -207,6 +207,8 @@ class OsticketConfig extends Config {
         'agent_avatar' => 'gravatar.mm',
         'ticket_lock' => 2, // Lock on activity
         'max_open_tickets' => 0,
+        'autoclose_duration' => 72,
+        'autoclose_status_id' => 0,
     );
 
     function OsticketConfig($section=null) {
@@ -481,6 +483,14 @@ class OsticketConfig extends Config {
             $this->defaultDept=Dept::lookup($this->getDefaultDeptId());
 
         return $this->defaultDept;
+    }
+
+    function getAutoCloseDuration() {
+        return $this->get('autoclose_duration');
+    }
+ 
+    function getAutoCloseStatusId() {
+        return $this->get('autoclose_status_id');
     }
 
     function getDefaultEmailId() {
@@ -1250,6 +1260,8 @@ class OsticketConfig extends Config {
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],
+            'autoclose_duration'=>$vars['autoclose_duration'],
+            'autoclose_status_id'=>$vars['autoclose_status_id'],
         ));
     }
 

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -1221,6 +1221,8 @@ class OsticketConfig extends Config {
         $f['default_ticket_status_id'] = array('type'=>'int', 'required'=>1, 'error'=>__('Selection required'));
         $f['default_priority_id']=array('type'=>'int',   'required'=>1, 'error'=>__('Selection required'));
         $f['max_open_tickets']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter valid numeric value'));
+        $f['autoclose_status_id'] = array('type'=>'int', 'required'=>1, 'error'=>__('Selection required'));
+        $f['autoclose_duration']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter valid numeric value'));
 
 
         if($vars['enable_captcha']) {

--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -28,6 +28,7 @@ class Cron {
     function TicketMonitor() {
         require_once(INCLUDE_DIR.'class.ticket.php');
         Ticket::checkOverdue(); //Make stale tickets overdue
+        Ticket::AutoClose(); //Auto Close tickets
         // Cleanup any expired locks
         require_once(INCLUDE_DIR.'class.lock.php');
         Lock::cleanup();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3615,5 +3615,29 @@ implements RestrictedAccess, Threadable {
 
         require STAFFINC_DIR.'templates/tickets-actions.tmpl.php';
     }
+   function AutoClose() {
+        global $cfg;
+        
+        $grace = $cfg->getAutoCloseDuration();
+        $graceStatusId = $cfg->getAutoCloseStatusId();
+        
+        if($graceStatusId != 0){ 
+            if($grace == 1){
+                $plural = 'hour';
+                } else {
+                $plural = 'hours';
+            }
+            // select all tickets marked as selected status from config page where updated is older than ($grace) hours ago
+            $sql  = 'SELECT ticket_id FROM '.TICKET_TABLE.' ticket '
+                    .' INNER JOIN '.TICKET_STATUS_TABLE.' status ON (status.id=ticket.status_id AND status_id = '. $graceStatusId .') '
+                    .' AND TIME_TO_SEC(TIMEDIFF(NOW(),ticket.updated))>='.$grace.'*3600';
+            if(($res=db_query($sql)) && db_num_rows($res)) {
+                while(list($id)=db_fetch_row($res)) {
+                    if($ticket=Ticket::lookup($id)) 
+                        $ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$grace.' '.$plural.' of no activity.',$errors, false);
+                }
+            }
+        }
+   }
 }
 ?>

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3615,7 +3615,9 @@ implements RestrictedAccess, Threadable {
 
         require STAFFINC_DIR.'templates/tickets-actions.tmpl.php';
     }
-   function AutoClose() {
+    
+    // Close tickets based on Ticket Auto-Close from config
+    function AutoClose() {
         global $cfg;
         
         $grace = $cfg->getAutoCloseDuration();
@@ -3627,10 +3629,12 @@ implements RestrictedAccess, Threadable {
                 } else {
                 $plural = 'hours';
             }
+            
             // select all tickets marked as selected status from config page where updated is older than ($grace) hours ago
             $sql  = 'SELECT ticket_id FROM '.TICKET_TABLE.' ticket '
                     .' INNER JOIN '.TICKET_STATUS_TABLE.' status ON (status.id=ticket.status_id AND status_id = '. $graceStatusId .') '
                     .' AND TIME_TO_SEC(TIMEDIFF(NOW(),ticket.updated))>='.$grace.'*3600';
+            
             if(($res=db_query($sql)) && db_num_rows($res)) {
                 while(list($id)=db_fetch_row($res)) {
                     if($ticket=Ticket::lookup($id)) 

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -79,6 +79,19 @@ show_related_tickets:
         Show all related tickets on user login - otherwise access is restricted to
         one ticket view per login
 
+autoclose_status:
+    title: Ticket Auto-Close Status
+    content: >
+        The Auto Close function will use this status to find tickets 
+        that will be marked <b>Closed</b> after the <b>Ticket Auto-Close Duration</b>.
+
+autoclose_duration:
+    title: Ticket Auto-Close Duration
+    content: >
+        Enter the number of Hours before a ticket marked with the 
+        <b>Ticket Auto-Close Status</b> selected status will be 
+        Auto-Closed by the system.
+
 human_verification:
     title: Human Verification
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -203,7 +203,7 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
-            <td><?php echo __('Ticket Auto-Close'); ?>:</td>
+            <td><?php echo __('Ticket Auto-Close Duration'); ?>:</td>
             <td>
                 <input type="text" name="autoclose_duration" size=4 value="<?php echo $config['autoclose_duration']; ?>">&nbsp;Hour(s)&nbsp;
                 <font class="error"><?php echo $errors['autoclose_duration']; ?></font>

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -171,6 +171,46 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
                 <i class="help-tip icon-question-sign" href="#maximum_open_tickets"></i>
             </td>
         </tr>
+            <td width="180">
+                <?php echo __('Ticket Auto-Close Status'); ?>:
+            </td>
+            <td>
+                <span>
+                <select name="autoclose_status_id">
+		<option value="0">&mdash; <?php echo __('Disabled');?> &mdash;</option>
+                <?php
+                $criteria = array('states' => array('open','closed'));
+                foreach (TicketStatusList::getStatuses($criteria) as $status) {
+                    $name = $status->getName();
+                if (!($isenabled = $status->isEnabled()))
+                        $name.=' '.__('(disabled)');
+
+                    echo sprintf('<option value="%d" %s %s>%s</option>',
+                            $status->getId(),
+                            ($config['autoclose_status_id'] ==
+                             $status->getId() && $isenabled)
+                             ? 'selected="selected"' : '',
+                             $isenabled ? '' : 'disabled="disabled"',
+                             $name
+                            );
+                }
+                ?>
+                </select>
+                &nbsp;
+                <span class="error">*&nbsp;<?php echo $errors['autoclose_status_id']; ?></span>
+                <i class="help-tip icon-question-sign" href="#autoclose_status"></i>
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td><?php echo __('Ticket Auto-Close'); ?>:</td>
+            <td>
+                <input type="text" name="autoclose_duration" size=4 value="<?php echo $config['autoclose_duration']; ?>">&nbsp;Hour(s)&nbsp;
+                <font class="error"><?php echo $errors['autoclose_duration']; ?></font>
+                <i class="help-tip icon-question-sign" href="#autoclose_duration"></i>
+            </td>
+        </tr>
+        <tr>
         <tr>
             <td><?php echo __('Human Verification');?>:</td>
             <td>

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -206,7 +206,7 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             <td><?php echo __('Ticket Auto-Close Duration'); ?>:</td>
             <td>
                 <input type="text" name="autoclose_duration" size=4 value="<?php echo $config['autoclose_duration']; ?>">&nbsp;Hour(s)&nbsp;
-                <font class="error"><?php echo $errors['autoclose_duration']; ?></font>
+                <font class="error">*&nbsp;<?php echo $errors['autoclose_duration']; ?></font>
                 <i class="help-tip icon-question-sign" href="#autoclose_duration"></i>
             </td>
         </tr>

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -171,6 +171,7 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
                 <i class="help-tip icon-question-sign" href="#maximum_open_tickets"></i>
             </td>
         </tr>
+        <tr>
             <td width="180">
                 <?php echo __('Ticket Auto-Close Status'); ?>:
             </td>
@@ -210,7 +211,6 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
                 <i class="help-tip icon-question-sign" href="#autoclose_duration"></i>
             </td>
         </tr>
-        <tr>
         <tr>
             <td><?php echo __('Human Verification');?>:</td>
             <td>


### PR DESCRIPTION
This is a rebase PR for the Auto Close feature #2917. This PR will work with v1.10 and also allows for admin to select the status from which will be used to automatically close tickets.

Need help:
- [ ] set status using status name instead of id in AutoClose function
    `class.ticket.php` line 3641 `$ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$grace.' '.$plural.' of no activity.',$errors, false);`

![image](https://cloud.githubusercontent.com/assets/5774055/12360897/a879218c-bb88-11e5-94d5-5e3bfbc1fba6.png)
