### PR TITLE
Make FAQ & Pages Attachments Viewable

### DIFF
--- a/include/ajax.draft.php
+++ b/include/ajax.draft.php
@@ -133,7 +133,8 @@ class DraftAjaxAPI extends AjaxController {
             'content_id' => 'cid:'.$f->getKey(),
             // Return draft_id to connect the auto draft creation
             'draft_id' => $draft->getId(),
-            'filelink' => $f->getDownloadUrl(false, 'inline'),
+            'filelink' => $f->getDownloadUrl(
+                ['type' => 'D', 'deposition' => 'inline']),
         ));
     }
 
@@ -346,7 +347,7 @@ class DraftAjaxAPI extends AjaxController {
                 WHERE a.`inline` = 1 AND t.id='.db_input($_GET['threadId']);
         }
 
-        $sql = 'SELECT distinct f.id, COALESCE(a.type, f.ft), a.`name` FROM '.FILE_TABLE
+        $sql = 'SELECT distinct f.id, a.id as aid, COALESCE(a.type, f.ft), a.`name` FROM '.FILE_TABLE
             .' f LEFT JOIN '.ATTACHMENT_TABLE.' a ON (a.file_id = f.id)
             WHERE ((a.`type` IN (\'C\', \'F\', \'T\', \'P\') AND a.`inline` = 1) OR f.ft = \'L\')'
                 .' AND f.`type` LIKE \'image/%\'';
@@ -354,9 +355,11 @@ class DraftAjaxAPI extends AjaxController {
             Http::response(500, 'Unable to lookup files');
 
         $files = array();
-        while (list($id, $type, $name) = db_fetch_row($res)) {
-            $f = AttachmentFile::lookup((int) $id);
-            $url = $f->getDownloadUrl();
+        while (list($id, $aid, $type, $name) = db_fetch_row($res)) {
+            if (!($f = AttachmentFile::lookup((int) $id)))
+                continue;
+
+            $url = $f->getDownloadUrl(['id' => $aid]);
             $files[] = array(
                 // Don't send special sizing for thread items 'cause they
                 // should be cached already by the client

--- a/include/class.category.php
+++ b/include/class.category.php
@@ -38,7 +38,9 @@ class Category extends VerySimpleModel {
     function getName() { return $this->name; }
     function getNumFAQs() { return  $this->faqs->count(); }
     function getDescription() { return $this->description; }
-    function getDescriptionWithImages() { return Format::viewableImages($this->description); }
+    function getDescriptionWithImages() {
+        return Format::viewableImages($this->description);
+    }
     function getNotes() { return $this->notes; }
     function getCreateDate() { return $this->created; }
     function getUpdateDate() { return $this->updated; }

--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -74,7 +74,7 @@ class FAQ extends VerySimpleModel {
     function getQuestion() { return $this->question; }
     function getAnswer() { return $this->answer; }
     function getAnswerWithImages() {
-        return Format::viewableImages($this->answer);
+        return Format::viewableImages($this->answer, ['type' => 'F']);
     }
     function getTeaser() {
         return Format::truncate(Format::striptags($this->answer), 150);
@@ -194,7 +194,8 @@ class FAQ extends VerySimpleModel {
         return $this->_getLocal('answer', $lang);
     }
     function getLocalAnswerWithImages($lang=false) {
-        return Format::viewableImages($this->getLocalAnswer($lang));
+        return Format::viewableImages($this->getLocalAnswer($lang),
+                ['type' => 'F']);
     }
     function _getLocal($what, $lang=false) {
         if (!$lang) {

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -455,14 +455,17 @@ class Format {
     }
 
 
-    function viewableImages($html, $script=false) {
+    function viewableImages($html, $options=array()) {
         $cids = $images = array();
+        $options +=array(
+                'deposition' => 'inline');
         return preg_replace_callback('/"cid:([\w._-]{32})"/',
-        function($match) use ($script, $images) {
+        function($match) use ($options, $images) {
             if (!($file = AttachmentFile::lookup($match[1])))
                 return $match[0];
+
             return sprintf('"%s" data-cid="%s"',
-                $file->getDownloadUrl(false, 'inline', $script), $match[1]);
+                $file->getDownloadUrl($options), $match[1]);
         }, $html);
     }
 

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3862,13 +3862,15 @@ class FreeTextWidget extends Widget {
         if (($attachments=$this->field->getFiles())) { ?>
             <section class="freetext-files">
             <div class="title"><?php echo __('Related Resources'); ?></div>
-            <?php foreach ($attachments as $attach) { ?>
+            <?php foreach ($attachments as $attach) {
+                $filename = Format::htmlchars($attach->getFilename());
+                ?>
                 <div class="file">
                 <a href="<?php echo $attach->file->getDownloadUrl(); ?>"
-                    target="_blank" download="<?php echo $attach->file->getDownloadUrl();
-                    ?>" class="truncate no-pjax">
+                    target="_blank" download="<?php echo $filename; ?>"
+                    class="truncate no-pjax">
                     <i class="icon-file"></i>
-                    <?php echo Format::htmlchars($attach->getFilename()); ?>
+                    <?php echo $filename; ?>
                 </a>
                 </div>
             <?php } ?>

--- a/include/class.page.php
+++ b/include/class.page.php
@@ -70,7 +70,7 @@ class Page extends VerySimpleModel {
         return $this->_getLocal('body', $lang);
     }
     function getBodyWithImages() {
-        return Format::viewableImages($this->getLocalBody());
+        return Format::viewableImages($this->getLocalBody(), ['type' => 'P']);
     }
 
     function _getLocal($what, $lang=false) {

--- a/include/client/faq.inc.php
+++ b/include/client/faq.inc.php
@@ -42,7 +42,8 @@ $category=$faq->getCategory();
     <strong><?php echo __('Attachments');?>:</strong>
 <?php foreach ($attachments as $att) { ?>
     <div>
-    <a href="<?php echo $att->file->getDownloadUrl(); ?>" class="no-pjax">
+    <a href="<?php echo $att->file->getDownloadUrl(['id' => $att->getId()]);
+    ?>" class="no-pjax">
         <i class="icon-file"></i>
         <?php echo Format::htmlchars($att->getFilename()); ?>
     </a>

--- a/include/client/templates/thread-entry.tmpl.php
+++ b/include/client/templates/thread-entry.tmpl.php
@@ -51,7 +51,8 @@ if ($cfg->isAvatarsEnabled() && $user)
 ?>
         <span class="attachment-info">
         <i class="icon-paperclip icon-flip-horizontal"></i>
-        <a class="no-pjax truncate filename" href="<?php echo $A->file->getDownloadUrl();
+        <a  class="no-pjax truncate filename"
+            href="<?php echo $A->file->getDownloadUrl(['id' => $A->getId()]);
             ?>" download="<?php echo Format::htmlchars($A->getFilename()); ?>"
             target="_blank"><?php echo Format::htmlchars($A->getFilename());
         ?></a><?php echo $size;?>

--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -196,7 +196,7 @@ foreach (AttachmentFile::objects()->filter(array(
     'attachments__inline' => true,
 )) as $file) {
     $urls[strtolower($file->getKey())] = array(
-        'download_url' => $file->getDownloadUrl(),
+        'download_url' => $file->getDownloadUrl(['type' => 'H']),
         'filename' => $file->name,
     );
 } ?>

--- a/include/staff/faq-view.inc.php
+++ b/include/staff/faq-view.inc.php
@@ -40,7 +40,8 @@ if ($thisstaff->hasPerm(FAQ::PERM_MANAGE)) { ?>
 <?php foreach ($attachments as $att) { ?>
 <div>
     <i class="icon-paperclip pull-left"></i>
-    <a target="_blank" href="<?php echo $att->file->getDownloadUrl(); ?>"
+    <a target="_blank" href="<?php echo $att->file->getDownloadUrl(['id' =>
+    $att->getId()]); ?>"
         class="attachment no-pjax">
         <?php echo Format::htmlchars($att->getFilename()); ?>
     </a>

--- a/include/staff/templates/thread-entries.tmpl.php
+++ b/include/staff/templates/thread-entries.tmpl.php
@@ -80,7 +80,8 @@ foreach (Attachment::objects()->filter(array(
                 if (!$A->inline)
                     continue;
                 $urls[strtolower($A->file->getKey())] = array(
-                    'download_url' => $A->file->getDownloadUrl(),
+                    'download_url' => $A->file->getDownloadUrl(['id' =>
+                        $A->getId()]),
                     'filename' => $A->getFilename(),
                 );
             }

--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -93,7 +93,8 @@ if ($user && $cfg->isAvatarsEnabled())
 ?>
         <span class="attachment-info">
         <i class="icon-paperclip icon-flip-horizontal"></i>
-        <a class="no-pjax truncate filename" href="<?php echo $A->file->getDownloadUrl();
+        <a class="no-pjax truncate filename" href="<?php echo
+        $A->file->getDownloadUrl(['id' => $A->getId()]);
             ?>" download="<?php echo Format::htmlchars($A->getFilename()); ?>"
             target="_blank"><?php echo Format::htmlchars($A->getFilename());
         ?></a><?php echo $size;?>

--- a/open.php
+++ b/open.php
@@ -82,7 +82,8 @@ if ($ticket
     echo Format::viewableImages(
         $ticket->replaceVars(
             $page->getLocalBody()
-        )
+        ),
+        ['type' => 'P']
     );
 }
 else {


### PR DESCRIPTION
Commit c4579277 introduced an extra administrative security feature to restrict files access to signed in users only, even  if a user has a valid & signed download URL. The feature, however, did not take into account public images & files associated with FAQs and pages such as landing/thank-you pages.

This PR addresses the shortcoming by adding a reference ID (attachment ID) to the download/access URL, that can be used to deduce the model/object type that the file request is associated with. The technique will allow us in the future to enforce ACL at the file level depending on privacy settings and
the security clearance of the user (agent).