### PR TITLE
ui: Internal note message

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -163,7 +163,12 @@ if($_POST && !$errors):
             $wasOpen = ($ticket->isOpen());
             if(($note=$ticket->postNote($vars, $errors, $thisstaff))) {
 
-                $msg=__('Internal note posted successfully');
+                $msg = sprintf(__('%s: Internal note posted successfully'),
+                        sprintf(__('Ticket #%s'),
+                            sprintf('<a href="tickets.php?id=%d"><b>%s</b></a>',
+                                $ticket->getId(), $ticket->getNumber()))
+                        );
+
                 // Clear attachment list
                 $note_form->setSource(array());
                 $note_form->getField('attachments')->reset();


### PR DESCRIPTION
Make the internal note posted successfully message the same as the reply posted message.

![image](https://cloud.githubusercontent.com/assets/5774055/20102323/bdd36cfe-a593-11e6-91ed-b681c46320be.png)
