### PR TITLE
Client Side Long FAQ Title

### DIFF
--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -113,7 +113,7 @@ fieldset {
 a, .link {
   color: #0072bc;
   text-decoration: none;
-  display: inline-block;
+  display: inline;
   margin-bottom: 1px;
 }
 a:hover, .link:hover {


### PR DESCRIPTION
This addresses issue where long FAQ titles as links don't line up with icons.