### PR TITLE
Don't show featured FAQs when Knowledgebase access is restricted

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -343,7 +343,7 @@ class FAQ extends VerySimpleModel {
 
     static function getFeatured() {
         return self::objects()
-            ->filter(array('ispublished__in'=>array(1,2), 'category__ispublic'=>1))
+            ->filter(array('ispublished__in'=>array(2), 'category__ispublic'=>1))
             ->order_by('-ispublished');
     }
 

--- a/include/client/templates/sidebar.tmpl.php
+++ b/include/client/templates/sidebar.tmpl.php
@@ -19,16 +19,19 @@ $BUTTONS = isset($BUTTONS) ? $BUTTONS : true;
         </div>
 <?php } ?>
         <div class="content"><?php
-    $faqs = FAQ::getFeatured()->select_related('category')->limit(5);
-    if ($faqs->all()) { ?>
-            <section><div class="header"><?php echo __('Featured Questions'); ?></div>
-<?php   foreach ($faqs as $F) { ?>
-            <div><a href="<?php echo ROOT_PATH; ?>kb/faq.php?id=<?php
-                echo urlencode($F->getId());
-                ?>"><?php echo $F->getLocalQuestion(); ?></a></div>
-<?php   } ?>
+    if ($cfg->isKnowledgebaseEnabled()) {
+        $faqs = FAQ::getFeatured()->select_related('category')->limit(5);
+        if ($faqs->all()) { ?>
+            <section>
+                <div class="header"><?php echo __('Featured Questions'); ?></div>
+                <?php foreach ($faqs as $F) { ?>
+                    <div><a href="<?php echo ROOT_PATH; ?>kb/faq.php?id=<?php
+                        echo urlencode($F->getId());
+                        ?>"><?php echo $F->getLocalQuestion(); ?></a></div>
+                <?php } ?>
             </section>
-<?php
+            <?php
+        }
     }
     $resources = Page::getActivePages()->filter(array('type'=>'other'));
     if ($resources->all()) { ?>


### PR DESCRIPTION
While trying osTicket knowledge base, I've found two possible issues with the "Featured Questions" sidebar, in the client interface:

1. The sidebar shows **both public and featured** questions, while I think it should show only the featured ones (ispublished == 2)

2. The sidebar is **visible to unauthenticated/guests users even when knowledge base access is restricted**. Anyway, if an unauthenticated users clicks on an article link within the sidebar the article is not accessible, because the access restriction works correctly. As a possible fix, I've encapsulated the printing of the Featured Questions sidebar within the isKnowledgebaseEnabled check.