### PR TITLE
issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+### Prerequisites
+
+* [ ] Can you reproduce the problem in a fresh installation of the "develop" branch?
+* [ ] Do you have any errors in the PHP error log, or javascript console?
+* [ ] Did you check the [osTicket forums](http://osticket.com/forum/categories)?
+* [ ] Did you [perform a cursory search](https://github.com/osTicket/osTicket/issues) to see if your bug or enhancement is already reported?
+
+For more information on how to write a good [bug report](https://github.com/osTicket/osTicket/wiki/Github-Issues-Guidelines)
+
+### Description
+
+[Description of the bug or feature]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expected to happen]
+
+**Actual behavior:** [What actually happened]
+
+### Versions
+
+Admin panel -> Dashboard -> Information which also additionally gives you information about you server.
+
+Also, please include the OS and what version of the OS you're running. As well as your browser and browser version.


### PR DESCRIPTION
To speed up reproduction of issues and minimize unintelligible ones... Atom uses a prefill issue template. This one is tailored for osTicket's repo.