### PR TITLE
Feature/Ticket Status in Sticky Nav

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -223,6 +223,7 @@ if($ticket->isOverdue())
              title="<?php echo __('Reload'); ?>"><i class="icon-refresh"></i>
              <?php echo sprintf(__('Ticket #%s'), $ticket->getNumber()); ?></a>
             </h2>
+            <h2 class="nav_status"><?php echo sprintf(__(' - %s'), $ticket->getStatus()); ?></h2>
         </div>
     </div>
   </div>

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2610,6 +2610,7 @@ td.indented {
 }
 .sticky.bar.fixed h2 {
   margin: 0;
+  display: inline;
 }
 .sticky.bar:not(.fixed) .sticky.only {
     display:none;

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -458,9 +458,9 @@ var scp_prep = function() {
          }
        }
        if($("div.sticky.bar").hasClass('fixed')){
-         $(".nav-status").show().css("display","inline");
+         $(".nav_status").show().css("display","inline");
        } else {
-         $(".nav-status").hide();
+         $(".nav_status").hide();
        }
     });
   });

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -457,6 +457,11 @@ var scp_prep = function() {
            }, 1);
          }
        }
+       if($("div.sticky.bar").hasClass('fixed')){
+         $(".nav-status").show().css("display","inline");
+       } else {
+         $(".nav-status").hide();
+       }
     });
   });
 


### PR DESCRIPTION
This feature shows the ticket status after the ticket number only when sticky bar is shown. Some people have really long threads and don't want to scroll all the way to the top to see it or they have already changed the status under the reply bar and don't want to scroll all the way up (see [this forum post](http://osticket.com/forum/discussion/89424/ticket-status-in-sticky-bar) and #3560).