### PR TITLE
Update for compatibility w/ PHP 7, E_STRICT

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,3 +1,29 @@
+osTicket v1.9.13
+================
+### Enhancements
+  * Help topic can be specified by the ID number in the URL for client new
+    ticket page (#2735)
+
+### Improvements
+  * Fix crash requesting registration email as a guest, thanks @bailey86
+    (#2552)
+  * Fix attachment filename encoding (#2586)
+  * Fix bounce message loop for message alert to a bad agent email address
+    (#2639)
+  * Sort help topic names case insensitively (#2350)
+  * Fix redactor toolbar appearing over the overlay (#2697)
+  * Add help tip for primary role, thanks @colonelpopcorn (#2680)
+  * Add icons to assigned-to column, thanks @antriver (#2695)
+  * Upgrade to htmLawed 1.20 (#2935)
+  * Fix stripping of `src` attribute in `iframe` elements (#2940)
+
+### Performance and Security
+  * Reduce memory usage processing attachments, thanks @ericLemanissier (#2491,
+    #2492)
+  * Protect access to files shown in the FileUpload field (#2618)
+  * Always perform validation server-side for ajax uploads (e3c9e0f)
+  * Decode html entities before scrubbing (#2940)
+
 osTicket v1.9.12
 ================
 ### Improvements

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,3 +1,15 @@
+osTicket v1.9.15
+================
+### Enhancements
+ * Introduce the concept of Trusted Proxies and Local Networks (8ca6bc30)
+
+### Performance and Security
+ * Fix memory leak when applying `Use Reply-To Email` ticket filter
+ * action (8ca6bc30)
+ * XSS: Sanitize and validate HTTP_X_FORWARDED_FOR header (#3439,
+        * b794c599)
+ * XSS: Encode html chars on help desk title/name (#3439, a57de770)
+
 osTicket v1.9.14
 ================
 ### Enhancements

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,3 +1,28 @@
+osTicket v1.9.14
+================
+### Enhancements
+  * alerts: Do not include the manager with the members (#2974)
+
+### Improvements
+  * Only change SLA if target department has an SLA
+  * Unify ticket source and preserve original (e.g Web) source on ticket
+    edit
+  * filedrop: Use jQuery to remove filenode
+  * pjax: Do not assume href attribute is set
+  * Default to system default, if staff does not have page limit set, thanks
+    @antriver (#2951)
+  * plugins: Assume plugins might not have configuration
+  * oops: Make sure __toString returns a string
+  * autoresponse: Do not send out new message auto-response to ticket owner
+    as well as collaborators on new ticket (#2639)
+  * auth: Consider the destination clicked prior to SSO authentication,
+    thanks @jdelhome3578 (#2916)
+  * config: Add error message and default for max_open_tickets setting (#2914)
+  * auth: This issue only impacts SSO auth plugins, @thanks kevinoconnor7
+    (#2641)
+  * i18n: Support language pack compilation with new support for parallel
+    releases with v1.10.x
+
 osTicket v1.9.13
 ================
 ### Enhancements

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -49,11 +49,7 @@ class Bootstrap {
     }
 
     function https() {
-       return
-            (isset($_SERVER['HTTPS'])
-                && strtolower($_SERVER['HTTPS']) == 'on')
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
-                && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https');
+       return osTicket::is_https();
     }
 
     function defineTables($prefix) {
@@ -319,6 +315,7 @@ ini_set('include_path', './'.PATH_SEPARATOR.INCLUDE_DIR.PATH_SEPARATOR.PEAR_DIR)
 require(INCLUDE_DIR.'class.osticket.php');
 require(INCLUDE_DIR.'class.misc.php');
 require(INCLUDE_DIR.'class.http.php');
+require(INCLUDE_DIR.'class.validator.php');
 
 // Determine the path in the URI used as the base of the osTicket
 // installation
@@ -330,12 +327,7 @@ Bootstrap::init();
 #CURRENT EXECUTING SCRIPT.
 define('THISPAGE', Misc::currentURL());
 
-define('DEFAULT_MAX_FILE_UPLOADS',ini_get('max_file_uploads')?ini_get('max_file_uploads'):5);
-define('DEFAULT_PRIORITY_ID',1);
+define('DEFAULT_MAX_FILE_UPLOADS', ini_get('max_file_uploads') ?: 5);
+define('DEFAULT_PRIORITY_ID', 1);
 
-#Global override
-if (isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-    // Take the left-most item for X-Forwarded-For
-    $_SERVER['REMOTE_ADDR'] = trim(array_pop(
-        explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])));
 ?>

--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -38,7 +38,7 @@ class ConfigAjaxAPI extends AjaxController {
               'lang'            => $lang,
               'short_lang'      => $sl,
               'has_rtl'         => $rtl,
-              'page_size'       => $thisstaff->getPageLimit(),
+              'page_size'       => $thisstaff->getPageLimit() ?: PAGE_LIMIT,
         );
         return $this->json_encode($config);
     }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -166,6 +166,7 @@ class OsticketConfig extends Config {
         'help_topic_sort_mode' => 'a',
         'client_verify_email' => 1,
         'verify_email_addrs' => 1,
+        'max_open_tickets' => 0,
     );
 
     function OsticketConfig($section=null) {

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -156,7 +156,7 @@ class DynamicForm extends VerySimpleModel {
         return parent::save($refetch);
     }
 
-    function delete() {
+    function delete($pk = null) {
         if (!$this->isDeletable())
             return false;
         else
@@ -625,7 +625,7 @@ class DynamicFormField extends VerySimpleModel {
         return count($this->errors()) == 0;
     }
 
-    function delete() {
+    function delete($pk = null) {
         // Don't really delete form fields as that will screw up the data
         // model. Instead, just drop the association with the form which
         // will give the appearance of deletion. Not deleting means that
@@ -636,7 +636,7 @@ class DynamicFormField extends VerySimpleModel {
         $this->save();
     }
 
-    function save() {
+    function save($refetch = null) {
         if (count($this->dirty))
             $this->set('updated', new SqlFunction('NOW'));
         return parent::save();
@@ -1026,7 +1026,7 @@ class DynamicFormEntry extends VerySimpleModel {
         return $dirty;
     }
 
-    function delete() {
+    function delete($pk = null) {
         foreach ($this->getAnswers() as $a)
             $a->delete();
         return parent::delete();
@@ -1158,7 +1158,7 @@ class DynamicFormEntryAnswer extends VerySimpleModel {
         return is_string($v) ? $v : (string) $this->getValue();
     }
 
-    function delete() {
+    function delete($pk = null) {
         if (!parent::delete())
             return false;
 
@@ -1183,7 +1183,7 @@ class SelectionField extends FormField {
         return $this->_list;
     }
 
-    function getWidget() {
+    function getWidget($widgetClass = null) {
         $config = $this->getConfiguration();
         $widgetClass = false;
         if ($config['widget'] == 'typeahead')
@@ -1384,7 +1384,8 @@ class SelectionField extends FormField {
 }
 
 class TypeaheadSelectionWidget extends ChoicesWidget {
-    function render($how) {
+    function render($mode = null) {
+        $how = $mode;
         if ($how == 'search')
             return parent::render($how);
 

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -918,11 +918,16 @@ class DynamicFormEntry extends VerySimpleModel {
      * entry.
      */
     function addMissingFields() {
+        if (!($form = $this->getForm())
+            // The form for this entry was removed. No missing fields to
+            // consider
+            return;
+
         // Track deletions
         foreach ($this->getAnswers() as $answer)
             $answer->deleted = true;
 
-        foreach ($this->getForm()->getDynamicFields() as $field) {
+        foreach ($form->getDynamicFields() as $field) {
             $found = false;
             foreach ($this->getAnswers() as $answer) {
                 if ($answer->get('field_id') == $field->get('id')) {

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -918,7 +918,7 @@ class DynamicFormEntry extends VerySimpleModel {
      * entry.
      */
     function addMissingFields() {
-        if (!($form = $this->getForm())
+        if (!($form = $this->getForm()))
             // The form for this entry was removed. No missing fields to
             // consider
             return;

--- a/include/class.error.php
+++ b/include/class.error.php
@@ -17,7 +17,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 
-class Error extends Exception {
+class ErrorOs extends Exception {
     static $title = '';
     static $sendAlert = true;
 

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -315,15 +315,15 @@ class Filter {
         elseif ($this->getTeamId()) $ticket['teamId']=$this->getTeamId();
         #       Override name with reply-to information from the TicketFilter
         #       match
-        if ($this->useReplyToEmail() && $info['reply-to']) {
-            $changed = $info['reply-to'] != $ticket['email']
-                || ($info['reply-to-name'] && $ticket['name'] != $info['reply-to-name']);
+        if ($this->useReplyToEmail()
+                && $info['reply-to']
+                && strcasecmp($info['reply-to'], $ticket['email'])) {
+
             $ticket['email'] = $info['reply-to'];
             if ($info['reply-to-name'])
                 $ticket['name'] = $info['reply-to-name'];
-            if ($changed)
-                throw new FilterDataChanged($ticket);
 
+            throw new FilterDataChanged($ticket);
         }
 
         # Use canned response.

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -343,7 +343,7 @@ class DynamicList extends VerySimpleModel implements CustomList {
         return parent::save($refetch);
     }
 
-    function delete() {
+    function delete($pk = null) {
         $fields = DynamicFormField::objects()->filter(array(
             'type'=>'list-'.$this->id))->count();
         if ($fields == 0)
@@ -622,7 +622,7 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
         return $this->save();
     }
 
-    function delete() {
+    function delete($pk = null) {
         # Don't really delete, just unset the list_id to un-associate it with
         # the list
         $this->set('list_id', null);
@@ -1110,7 +1110,7 @@ class TicketStatus  extends VerySimpleModel implements CustomListItem {
         return $this->save(true);
     }
 
-    function delete() {
+    function delete($pk = null) {
 
         // Statuses with tickets are not deletable
         if (!$this->isDeletable())
@@ -1123,7 +1123,7 @@ class TicketStatus  extends VerySimpleModel implements CustomListItem {
         return __($this->getName());
     }
 
-    static function create($ht) {
+    static function create($ht = null) {
 
         if (!isset($ht['mode']))
             $ht['mode'] = 1;

--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -345,7 +345,7 @@ class Organization extends OrganizationModel {
         return $this->save();
     }
 
-    function delete() {
+    function delete($pk = null) {
         if (!parent::delete())
             return false;
 

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -430,6 +430,37 @@ class osTicket {
         }
     }
 
+   /*
+    * getTrustedProxies
+    *
+    * Get defined trusted proxies
+    */
+
+    static function getTrustedProxies() {
+        static $proxies = null;
+        // Parse trusted proxies from config file
+        if (!isset($proxies) && defined('TRUSTED_PROXIES'))
+            $proxies = array_filter(
+                    array_map('trim', explode(',', TRUSTED_PROXIES)));
+
+        return $proxies ?: array();
+    }
+
+    /*
+     * getLocalNetworkAddresses
+     *
+     * Get defined local network addresses
+     */
+    static function getLocalNetworkAddresses() {
+        static $ips = null;
+        // Parse local addreses from config file
+        if (!isset($ips) && defined('LOCAL_NETWORKS'))
+            $ips = array_filter(
+                    array_map('trim', explode(',', LOCAL_NETWORKS)));
+
+        return $ips ?: array();
+    }
+
     static function get_root_path($dir) {
 
         /* If run from the commandline, DOCUMENT_ROOT will not be set. It is
@@ -474,14 +505,96 @@ class osTicket {
         return null;
     }
 
+    /*
+     * get_client_ip
+     *
+     * Get client IP address from "Http_X-Forwarded-For" header by following a
+     * chain of trusted proxies.
+     *
+     * "Http_X-Forwarded-For" header value is a comma+space separated list of IP
+     * addresses, the left-most being the original client, and each successive
+     * proxy that passed the request all the way to the originating IP address.
+     *
+     */
+    static function get_client_ip($header='HTTP_X_FORWARDED_FOR') {
+
+        // Request IP
+        $ip = $_SERVER['REMOTE_ADDR'];
+        // Trusted proxies.
+        $proxies = self::getTrustedProxies();
+        // Return current IP address if header is not set and
+        // request is not from a trusted proxy.
+        if (!isset($_SERVER[$header])
+                || !$proxies
+                || !self::is_trusted_proxy($ip, $proxies))
+            return $ip;
+
+        // Get chain of proxied ip addresses
+        $ips = array_map('trim', explode(',', $_SERVER[$header]));
+        // Add request IP to the chain
+        $ips[] = $ip;
+        // Walk the chain in reverse - remove invalid IPs
+        $ips = array_reverse($ips);
+        foreach ($ips as $k => $ip) {
+            // Make sure the IP is valid and not a trusted proxy
+            if ($k && !Validator::is_ip($ip))
+                unset($ips[$k]);
+            elseif ($k && !self::is_trusted_proxy($ip, $proxies))
+                return $ip;
+        }
+
+        // We trust the 400 lb hacker... return left most valid IP
+        return array_pop($ips);
+    }
+
+    /*
+     * Checks if the IP is that of a trusted proxy
+     *
+     */
+    static function is_trusted_proxy($ip, $proxies=array()) {
+        $proxies = $proxies ?: self::getTrustedProxies();
+        // We don't have any proxies set.
+        if (!$proxies)
+            return false;
+        // Wildcard set - trust all proxies
+        else if ($proxies == '*')
+            return true;
+
+        return ($proxies && Validator::check_ip($ip, $proxies));
+    }
+
+    /**
+     * is_local_ip
+     *
+     * Check if a given IP is part of defined local address blocks
+     *
+     */
+    static function is_local_ip($ip, $ips=array()) {
+        $ips = $ips
+            ?: self::getLocalNetworkAddresses()
+            ?: array();
+
+        foreach ($ips as $addr) {
+            if (Validator::check_ip($ip, $addr))
+                return true;
+        }
+
+        return false;
+    }
+
     /**
      * Returns TRUE if the request was made via HTTPS and false otherwise
      */
     function is_https() {
-        return (isset($_SERVER['HTTPS'])
+
+        // Local server flags
+        if (isset($_SERVER['HTTPS'])
                 && strtolower($_SERVER['HTTPS']) == 'on')
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
-                && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https');
+            return true;
+
+        // Check if SSL was terminated by a loadbalancer
+        return (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+                && !strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https'));
     }
 
     /* returns true if script is being executed via commandline */

--- a/include/class.sequence.php
+++ b/include/class.sequence.php
@@ -228,7 +228,7 @@ class RandomSequence extends Sequence {
         return $this->next($format);
     }
 
-    function save() {
+    function save($refetch = null) {
         throw new RuntimeException('RandomSequence is not database-backed');
     }
 }

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -233,7 +233,13 @@ class Ticket {
     }
 
     static function getSources() {
-        return self::$sources;
+        static $translated = false;
+        if (!$translated) {
+            foreach (static::$sources as $k=>$v)
+                static::$sources[$k] = __($v);
+        }
+
+        return static::$sources;
     }
 
     //Getters

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1845,19 +1845,18 @@ class Ticket {
         }
 
         // Do not auto-respond to bounces and other auto-replies
-        if ($alerts)
-            $alerts = isset($vars['flags'])
+        $autorespond = isset($vars['flags'])
                 ? !$vars['flags']['bounce'] && !$vars['flags']['auto-reply']
                 : true;
-        if ($alerts && $message->isBounceOrAutoReply())
-            $alerts = false;
+        if ($autorespond && $message->isBounceOrAutoReply())
+            $autorespond = false;
 
-        $this->onMessage($message, $alerts); //must be called b4 sending alerts to staff.
+        $this->onMessage($message, $autorespond); //must be called b4 sending alerts to staff.
 
-        if ($alerts && $cfg && $cfg->notifyCollabsONNewMessage())
+        if ($autorespond && $cfg && $cfg->notifyCollabsONNewMessage())
             $this->notifyCollaborators($message, array('signature' => ''));
 
-        if (!$alerts)
+        if (!($alerts && $autorespond))
             return $message; //Our work is done...
 
         $dept = $this->getDept();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1045,14 +1045,19 @@ class Ticket {
                 $sentlist[]=$cfg->getAdminEmail();
             }
 
-            //Only alerts dept members if the ticket is NOT assigned.
-            if($cfg->alertDeptMembersONNewTicket() && !$this->isAssigned()) {
-                if(($members=$dept->getMembersForAlerts()))
-                    $recipients=array_merge($recipients, $members);
+            // Only alerts dept members if the ticket is NOT assigned.
+            $manager = $dept->getManager();
+            if ($cfg->alertDeptMembersONNewTicket() && !$this->isAssigned()
+                && ($members = $dept->getMembersForAlerts())
+            ) {
+                foreach ($members as $M)
+                    if ($M != $manager)
+                        $recipients[] = $M;
             }
 
-            if($cfg->alertDeptManagerONNewTicket() && $dept && ($manager=$dept->getManager()))
-                $recipients[]= $manager;
+            if ($cfg->alertDeptManagerONNewTicket() && $manager) {
+                $recipients[] = $manager;
+            }
 
             // Account manager
             if ($cfg->alertAcctManagerONNewMessage()

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1851,9 +1851,9 @@ class Ticket {
         if ($autorespond && $message->isBounceOrAutoReply())
             $autorespond = false;
 
-        $this->onMessage($message, $autorespond); //must be called b4 sending alerts to staff.
+        $this->onMessage($message, ($autorespond && $alerts)); //must be called b4 sending alerts to staff.
 
-        if ($autorespond && $cfg && $cfg->notifyCollabsONNewMessage())
+        if ($autorespond && $alerts && $cfg && $cfg->notifyCollabsONNewMessage())
             $this->notifyCollaborators($message, array('signature' => ''));
 
         if (!($alerts && $autorespond))

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -60,6 +60,11 @@ class Ticket {
             /* @trans */ 'Phone',
             'Email' =>
             /* @trans */ 'Email',
+
+            'Web' =>
+            /* @trans */ 'Web',
+            'API' =>
+            /* @trans */ 'API',
             'Other' =>
             /* @trans */ 'Other',
             );
@@ -2223,6 +2228,11 @@ class Ticket {
             elseif(strtotime($vars['duedate'].' '.$vars['time'])<=time())
                 $errors['duedate']=__('Due date must be in the future');
         }
+
+        if (isset($vars['source']) // Check ticket source if provided
+                && !array_key_exists($vars['source'], Ticket::getSources()))
+            $errors['source'] = sprintf( __('Invalid source given - %s'),
+                    Format::htmlchars($vars['source']));
 
         // Validate dynamic meta-data
         $forms = DynamicFormEntry::forTicket($this->getId());

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -54,6 +54,16 @@ class Ticket {
 
     var $thread; //Thread obj.
 
+    // Ticket Sources
+    static protected $sources =  array(
+            'Phone' =>
+            /* @trans */ 'Phone',
+            'Email' =>
+            /* @trans */ 'Email',
+            'Other' =>
+            /* @trans */ 'Other',
+            );
+
     function Ticket($id) {
         $this->id = 0;
         $this->load($id);
@@ -215,6 +225,10 @@ class Ticket {
             return true;
 
         return false;
+    }
+
+    static function getSources() {
+        return self::$sources;
     }
 
     //Getters
@@ -2911,8 +2925,11 @@ class Ticket {
 
         if(!$thisstaff || !$thisstaff->canCreateTickets()) return false;
 
-        if($vars['source'] && !in_array(strtolower($vars['source']),array('email','phone','other')))
-            $errors['source']=sprintf(__('Invalid source given - %s'),Format::htmlchars($vars['source']));
+        if (isset($vars['source']) // Check ticket source if provided
+                && !array_key_exists($vars['source'], Ticket::getSources()))
+            $errors['source'] = sprintf( __('Invalid source given - %s'),
+                    Format::htmlchars($vars['source']));
+
 
         if (!$vars['uid']) {
             //Special validation required here

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -773,7 +773,13 @@ class Ticket {
     }
 
     function setSLAId($slaId) {
-        if ($slaId == $this->getSLAId()) return true;
+        if ($slaId == $this->getSLAId())
+            return true;
+
+        $sla = null;
+        if ($slaId && !($sla = Sla::lookup($slaId)))
+            return false;
+
         return db_query(
              'UPDATE '.TICKET_TABLE.' SET sla_id='.db_input($slaId)
             .' WHERE ticket_id='.db_input($this->getId()))
@@ -1567,8 +1573,9 @@ class Ticket {
         $dept = $this->getDept();
 
         // Set SLA of the new department
-        if(!$this->getSLAId() || $this->getSLA()->isTransient())
-            $this->selectSLAId();
+        if (!$this->getSLAId() || $this->getSLA()->isTransient())
+            if (($slaId=$this->getDept()->getSLAId()))
+                $this->selectSLAId($slaId);
 
         // Make sure the new department allows assignment to the
         // currently assigned agent (if any)

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -29,7 +29,7 @@ class UserEmailModel extends VerySimpleModel {
     );
 
     function __toString() {
-        return $this->address;
+        return (string) $this->address;
     }
 }
 

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -51,7 +51,7 @@ class TicketModel extends VerySimpleModel {
         return $this->ticket_id;
     }
 
-    function delete() {
+    function delete($pk = null) {
 
         if (($ticket=Ticket::lookup($this->getId())) && @$ticket->delete())
             return true;
@@ -575,7 +575,7 @@ class User extends UserModel {
         return parent::save($refetch);
     }
 
-    function delete() {
+    function delete($pk = null) {
 
         // Refuse to delete a user with tickets
         if ($this->tickets->count())

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -183,24 +183,8 @@ class Validator {
         return ($url && ($info=parse_url($url)) && $info['host']);
     }
 
-    function is_ip($ip) {
-
-        if(!$ip or empty($ip))
-            return false;
-
-        $ip=trim($ip);
-        # Thanks to http://stackoverflow.com/a/1934546
-        if (function_exists('inet_pton')) { # PHP 5.1.0
-            # Let the built-in library parse the IP address
-            return @inet_pton($ip) !== false;
-        } else if (preg_match(
-            '/^(?>(?>([a-f0-9]{1,4})(?>:(?1)){7}|(?!(?:.*[a-f0-9](?>:|$)){7,})'
-            .'((?1)(?>:(?1)){0,5})?::(?2)?)|(?>(?>(?1)(?>:(?1)){5}:|(?!(?:.*[a-f0-9]:){5,})'
-            .'(?3)?::(?>((?1)(?>:(?1)){0,3}):)?)?(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])'
-            .'(?>\.(?4)){3}))$/iD', $ip)) {
-            return true;
-        }
-        return false;
+    static function is_ip($ip) {
+        return filter_var(trim($ip), FILTER_VALIDATE_IP) !== false;
     }
 
     function is_username($username, &$error='') {
@@ -209,6 +193,100 @@ class Validator {
         elseif (!preg_match('/^[\p{L}\d._-]+$/u', $username))
             $error = __('Username contains invalid characters');
         return $error == '';
+    }
+
+
+    /*
+     * check_ip
+     * Checks if an IP (IPv4 or IPv6) address is contained in the list of given IPs or subnets.
+     *
+     * @credit - borrowed from Symfony project
+     *
+     */
+    public static function check_ip($ip, $ips) {
+
+        if (!Validator::is_ip($ip))
+            return false;
+
+        $method = substr_count($ip, ':') > 1 ? 'check_ipv6' : 'check_ipv4';
+        $ips = is_array($ips) ? $ips : array($ips);
+        foreach ($ips as $_ip) {
+            if (self::$method($ip, $_ip)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * check_ipv4
+     * Compares two IPv4 addresses.
+     * In case a subnet is given, it checks if it contains the request IP.
+     *
+     * @credit - borrowed from Symfony project
+     */
+    public static function check_ipv4($ip, $cidr) {
+
+        if (false !== strpos($cidr, '/')) {
+            list($address, $netmask) = explode('/', $cidr, 2);
+
+            if ($netmask === '0')
+                return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+
+            if ($netmask < 0 || $netmask > 32)
+                return false;
+
+        } else {
+            $address = $cidr;
+            $netmask = 32;
+        }
+
+        return 0 === substr_compare(
+                sprintf('%032b', ip2long($ip)),
+                sprintf('%032b', ip2long($address)),
+                0, $netmask);
+    }
+
+    /**
+     * Compares two IPv6 addresses.
+     * In case a subnet is given, it checks if it contains the request IP.
+     *
+     * @credit - borrowed from Symfony project
+     * @author David Soria Parra <dsp at php dot net>
+     *
+     * @see https://github.com/dsp/v6tools
+     *
+     */
+    public static function check_ipv6($ip, $cidr) {
+
+        if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1')))
+            return false;
+
+        if (false !== strpos($cidr, '/')) {
+            list($address, $netmask) = explode('/', $cidr, 2);
+            if ($netmask < 1 || $netmask > 128)
+                return false;
+        } else {
+            $address = $cidr;
+            $netmask = 128;
+        }
+
+        $bytesAddr = unpack('n*', @inet_pton($address));
+        $bytesTest = unpack('n*', @inet_pton($ip));
+        if (!$bytesAddr || !$bytesTest)
+            return false;
+
+        for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; ++$i) {
+            $left = $netmask - 16 * ($i - 1);
+            $left = ($left <= 16) ? $left : 16;
+            $mask = ~(0xffff >> $left) & 0xffff;
+            if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     function process($fields,$vars,&$errors){

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -107,6 +107,39 @@ define('TABLE_PREFIX','%CONFIG-PREFIX');
 
 # define('ROOT_PATH', '/support/');
 
+
+# Option: TRUSTED_PROXIES (default: <none>)
+#
+# To support running osTicket installation on a web servers that sit behind a
+# load balancer, HTTP cache, or other intermediary (reverse) proxy; it's
+# necessary to define trusted proxies to protect against forged http headers
+#
+# osTicket supports passing the following http headers from a trusted proxy;
+# - HTTP_X_FORWARDED_FOR    =>  Chain of client's IPs
+# - HTTP_X_FORWARDED_PROTO  =>  Client's HTTP protocal (http | https)
+#
+# You'll have to explicitly define comma separated IP addreseses or CIDR of
+# upstream proxies to trust. Wildcard "*" (not recommended) can be used to
+# trust all chained IPs as proxies in cases that ISP/host doesn't provide
+# IPs of loadbalancers or proxies.
+#
+# References:
+# http://en.wikipedia.org/wiki/X-Forwarded-For
+#
+
+define('TRUSTED_PROXIES', '');
+
+
+# Option: LOCAL_NETWORKS (default: 127.0.0.0/24)
+#
+# When running osTicket as part of a cluster it might become necessary to
+# whitelist local/virtual networks that can bypass some authentication/checks.
+#
+# define comma separated IP addreseses or enter CIDR of local network.
+
+define('LOCAL_NETWORKS', '127.0.0.0/24');
+
+
 #
 # Session Storage Options
 # ---------------------------------------------------

--- a/include/pear/Mail/smtp.php
+++ b/include/pear/Mail/smtp.php
@@ -346,7 +346,7 @@ class Mail_smtp extends Mail {
         }
 
         include_once 'Net/SMTP.php';
-        $this->_smtp = &new Net_SMTP($this->host,
+        $this->_smtp = new Net_SMTP($this->host,
                                      $this->port,
                                      $this->localhost);
 

--- a/include/staff/footer.inc.php
+++ b/include/staff/footer.inc.php
@@ -45,7 +45,7 @@ if ($.support.pjax) {
   $(document).on('click', 'a', function(event) {
     if (!$(this).hasClass('no-pjax')
         && !$(this).closest('.no-pjax').length
-        && $(this).attr('href')[0] != '#')
+        && $(this).attr('href').charAt(0) != '#')
       $.pjax.click(event, {container: $('#pjax-container'), timeout: 2000});
   })
 }

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -1,5 +1,9 @@
 <?php
 header("Content-Type: text/html; charset=UTF-8");
+
+$title = ($ost && ($title=$ost->getPageTitle()))
+    ? $title : ('osTicket :: '.__('Staff Control Panel'));
+
 if (!isset($_SERVER['HTTP_X_PJAX'])) { ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html <?php
@@ -14,7 +18,7 @@ if (($lang = Internationalization::getCurrentLanguage())
     <meta http-equiv="cache-control" content="no-cache" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="x-pjax-version" content="<?php echo GIT_VERSION; ?>">
-    <title><?php echo ($ost && ($title=$ost->getPageTitle()))?$title:'osTicket :: '.__('Staff Control Panel'); ?></title>
+    <title><?php echo Format::htmlchars($title); ?></title>
     <!--[if IE]>
     <style type="text/css">
         .tip_shadow { display:block !important; }

--- a/include/staff/plugin.inc.php
+++ b/include/staff/plugin.inc.php
@@ -1,9 +1,9 @@
 <?php
-
-$info=array();
+$info = array();
+$page = null;
 if($plugin && $_REQUEST['a']!='add') {
     $config = $plugin->getConfig();
-    if (!($page = $config->hasCustomConfig())) {
+    if ($config && !($page = $config->hasCustomConfig())) {
         if ($config)
             $form = $config->getForm();
         if ($form && $_POST)

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -139,7 +139,9 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             <td><?php echo __('Maximum <b>Open</b> Tickets');?>:</td>
             <td>
                 <input type="text" name="max_open_tickets" size=4 value="<?php echo $config['max_open_tickets']; ?>">
-                <?php echo __('per end user'); ?> <i class="help-tip icon-question-sign" href="#maximum_open_tickets"></i>
+                <?php echo __('per end user'); ?>
+                <span class="error">*&nbsp;<?php echo $errors['max_open_tickets']; ?></span>
+                <i class="help-tip icon-question-sign" href="#maximum_open_tickets"></i>
             </td>
         </tr>
         <tr>

--- a/include/staff/syslogs.inc.php
+++ b/include/staff/syslogs.inc.php
@@ -139,7 +139,7 @@ else
                 <td>&nbsp;<a class="tip" href="#log/<?php echo $row['log_id']; ?>"><?php echo Format::htmlchars($row['title']); ?></a></td>
                 <td><?php echo $row['log_type']; ?></td>
                 <td>&nbsp;<?php echo Format::db_daydatetime($row['created']); ?></td>
-                <td><?php echo $row['ip_address']; ?></td>
+                <td><?php echo Format::htmlchars($row['ip_address']); ?></td>
             </tr>
             <?php
             } //end of while.

--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -62,12 +62,17 @@ if ($_POST)
             </td>
             <td>
                 <select name="source">
-                    <option value="" selected >&mdash; <?php echo __('Select Source');?> &mdash;</option>
-                    <option value="Phone" <?php echo ($info['source']=='Phone')?'selected="selected"':''; ?>><?php echo __('Phone');?></option>
-                    <option value="Email" <?php echo ($info['source']=='Email')?'selected="selected"':''; ?>><?php echo __('Email');?></option>
-                    <option value="Web"   <?php echo ($info['source']=='Web')?'selected="selected"':''; ?>><?php echo __('Web');?></option>
-                    <option value="API"   <?php echo ($info['source']=='API')?'selected="selected"':''; ?>><?php echo __('API');?></option>
-                    <option value="Other" <?php echo ($info['source']=='Other')?'selected="selected"':''; ?>><?php echo __('Other');?></option>
+                    <option value="" selected >&mdash; <?php
+                        echo __('Select Source');?> &mdash;</option>
+                    <?php
+                    $source = $info['source'] ?: 'Phone';
+                    foreach (Ticket::getSources() as $k => $v) {
+                        echo sprintf('<option value="%s" %s>%s</option>',
+                                $k,
+                                ($source == $k ) ? 'selected="selected"' : '',
+                                $v);
+                    }
+                    ?>
                 </select>
                 &nbsp;<font class="error"><b>*</b>&nbsp;<?php echo $errors['source']; ?></font>
             </td>

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -118,9 +118,14 @@ if ($_POST)
             </td>
             <td>
                 <select name="source">
-                    <option value="Phone" selected="selected"><?php echo __('Phone'); ?></option>
-                    <option value="Email" <?php echo ($info['source']=='Email')?'selected="selected"':''; ?>><?php echo __('Email'); ?></option>
-                    <option value="Other" <?php echo ($info['source']=='Other')?'selected="selected"':''; ?>><?php echo __('Other'); ?></option>
+                    <?php
+                    $source = $info['source'] ?: 'Phone';
+                    foreach (Ticket::getSources() as $k => $v)
+                        echo sprintf('<option value="%s" %s>%s</option>',
+                                $k,
+                                ($source == $k ) ? 'selected="selected"' : '',
+                                $v);
+                    ?>
                 </select>
                 &nbsp;<font class="error"><b>*</b>&nbsp;<?php echo $errors['source']; ?></font>
             </td>

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -120,7 +120,9 @@ if ($_POST)
                 <select name="source">
                     <?php
                     $source = $info['source'] ?: 'Phone';
-                    foreach (Ticket::getSources() as $k => $v)
+                    $sources = Ticket::getSources();
+                    unset($sources['Web'], $sources['API']);
+                    foreach ($sources as $k => $v)
                         echo sprintf('<option value="%s" %s>%s</option>',
                                 $k,
                                 ($source == $k ) ? 'selected="selected"' : '',

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -256,7 +256,7 @@ if($ticket->isOverdue())
                     <td><?php
                         echo Format::htmlchars($ticket->getSource());
 
-                        if($ticket->getIP())
+                        if (!strcasecmp($ticket->getSource(), 'Web') && $ticket->getIP())
                             echo '&nbsp;&nbsp; <span class="faded">('.$ticket->getIP().')</span>';
                         ?>
                     </td>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -257,7 +257,7 @@ if($ticket->isOverdue())
                         echo Format::htmlchars($ticket->getSource());
 
                         if (!strcasecmp($ticket->getSource(), 'Web') && $ticket->getIP())
-                            echo '&nbsp;&nbsp; <span class="faded">('.$ticket->getIP().')</span>';
+                            echo '&nbsp;&nbsp; <span class="faded">('.Format::htmlchars($ticket->getIP()).')</span>';
                         ?>
                     </td>
                 </tr>

--- a/js/filedrop.field.js
+++ b/js/filedrop.field.js
@@ -248,7 +248,7 @@
     files: [],
     deletable: true,
     shim: !window.FileReader,
-    queuefiles: 4
+    queuefiles: 1
   };
 
   $.fn.filedropbox.messages = {

--- a/js/filedrop.field.js
+++ b/js/filedrop.field.js
@@ -197,7 +197,7 @@
         var i = this.uploads.indexOf(filenode);
         if (i !== -1)
             this.uploads.splice(i,1);
-        filenode.slideUp('fast', function() { this.remove(); });
+        filenode.slideUp('fast', function() { $(this).remove(); });
       }
     },
     cancelUpload: function(node) {

--- a/login.php
+++ b/login.php
@@ -124,7 +124,8 @@ elseif ($user = UserAuthenticationBackend::processSignOn($errors, false)) {
         }
     }
     elseif ($user instanceof AuthenticatedUser) {
-        Http::redirect('tickets.php');
+        Http::redirect($_SESSION['_client']['auth']['dest']
+                ?: 'tickets.php');
     }
 }
 

--- a/main.inc.php
+++ b/main.inc.php
@@ -27,6 +27,9 @@ Bootstrap::i18n_prep();
 Bootstrap::loadCode();
 Bootstrap::connect();
 
+#Global override
+$_SERVER['REMOTE_ADDR'] = osTicket::get_client_ip();
+
 if(!($ost=osTicket::start()) || !($cfg = $ost->getConfig()))
 Bootstrap::croak(__('Unable to load config info from DB. Get tech support.'));
 

--- a/scp/login.php
+++ b/scp/login.php
@@ -67,7 +67,7 @@ elseif ($_GET['do']) {
 elseif (!$thisstaff || !($thisstaff->getId() || $thisstaff->isValid())) {
     if (($user = StaffAuthenticationBackend::processSignOn($errors, false))
             && ($user instanceof StaffSession))
-       @header("Location: $dest");
+       Http::redirect($dest);
 }
 
 define("OSTSCPINC",TRUE); //Make includes happy!

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -108,7 +108,7 @@ $ost->addExtraHeader('<meta name="csrf_token" content="'.$ost->getCSRFToken().'"
 $_SESSION['TZ_OFFSET']=$thisstaff->getTZoffset();
 $_SESSION['TZ_DST']=$thisstaff->observeDaylight();
 
-define('PAGE_LIMIT', $thisstaff->getPageLimit()?$thisstaff->getPageLimit():DEFAULT_PAGE_LIMIT);
+define('PAGE_LIMIT', $thisstaff->getPageLimit() ?: DEFAULT_PAGE_LIMIT);
 
 $tabs=array();
 $submenu=array();

--- a/setup/cli/modules/i18n.php
+++ b/setup/cli/modules/i18n.php
@@ -188,9 +188,9 @@ class i18n_Compiler extends Module {
         }
         foreach ($langs as $l) {
             list($code, $js) = $this->_http_get(
-                'http://imperavi.com/webdownload/redactor/lang/?lang='
-                .strtolower($l));
-            if ($code == 200 && ($js != 'File not found')) {
+                sprintf('https://imperavi.com/download/redactor/langs/%s/',
+                    strtolower($l)));
+            if ($code == 200 && strlen($js) > 100) {
                 $phar->addFromString('js/redactor.js', $js);
                 break;
             }

--- a/setup/test/tests/test.validation.php
+++ b/setup/test/tests/test.validation.php
@@ -54,6 +54,19 @@ class TestValidation extends Test {
         #$this->assert(Validator::is_email('δοκιμή@παράδειγμα.δοκιμή'));
         #$this->assert(Validator::is_email('甲斐@黒川.日本'));
     }
+
+    function testIPAddresses() {
+
+        // Validate IP Addreses
+        $this->assert(Validator::is_ip('127.0.0.1'));
+        $this->assert(Validator::is_ip('192.168.129.74'));
+
+        // Test IP check
+        $this->assert(Validator::check_ip('127.0.0.1', '127.0.0.0/24'));
+        $this->assert(Validator::check_ip('192.168.129.42',
+                    ['127.0.0.0/24', '192.168.129.0/24']));
+        $this->assert(!Validator::check_ip('10.0.5.15', '127.0.0.0/24'));
+    }
 }
 return 'TestValidation';
 ?>


### PR DESCRIPTION
Many method declarations were not matching their parents & triggered warnings. Added matching variables defaulting to `null`.

PHP 7 also introduces a built-in `Error` class which triggered a Fatal Error. Renaming osTicket's Error class to ErrorOs seems to fix, but haven't yet tested everything.