### PR TITLE
Parse full UTF-8 encoded sender addresses correctly

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -308,7 +308,7 @@ class MailFetcher {
             // Seems like we have a problem with a UTF-8 binary encoded sender
             // Lets decode on our own what we need
             $fullSender = $this->mime_decode($sender->mailbox); // This is normally "Name Surname" <mailname (everything left of the @)
-            $sender->personal = substr($fullSender, 1, strpos($fullSender, '""')-1);
+            $sender->personal = substr($fullSender, 1, strpos($fullSender, '"')-1);
             $sender->mailbox = substr($fullSender, strpos($fullSender, '<')+1);
         }
         //Just what we need...


### PR DESCRIPTION
When a sender has _Umlauts_ in his name it gets encoded with UTF-8. Normally this is done only with the word it's in. But sometimes the mail server encoded everything left of the @. PHPs **imap_headerinfo** fails to decode it.

For example my address is: `"Tekin Birdüzen" <t_birduezen@maxon.de>`

Normally it gets encoded as: `Tekin =?UTF-8?B?QmlyZMO8emVu?= <t_birduezen@maxon.de>` - This is parsed correctly

But sometimes its encoded as: `=?UTF-8?B?IlRla2luIEJpcmTDvHplbiIgPHRfYmlyZHVlemVu?=@maxon.de` - Here the PHP function fails with _UNEXPECTED_DATA_AFTER_ADDRESS_ although the mail programs like Apple Mail, Thunderbird or FirstClass decode it correctly.