### PR TITLE
New Task Alert Footer

### DIFF
--- a/include/i18n/en_US/templates/email/task.alert.yaml
+++ b/include/i18n/en_US/templates/email/task.alert.yaml
@@ -32,7 +32,7 @@ body: |
     <br>
     <br>
     <hr>
-    <div>To view or respond to the ticket, please <a
+    <div>To view or respond to the task, please <a
     href="%{task.staff_link}">login</a> to the support system</div>
     <em style="font-size: small">Your friendly Customer Support System</em>
     <br>


### PR DESCRIPTION
This addresses #3580 where the wrong name is used in the footer, instead of 'ticket' it's 'task'.