### PR TITLE
Categories: fix manual sorting when pagination is active

### DIFF
--- a/include/staff/helptopics.inc.php
+++ b/include/staff/helptopics.inc.php
@@ -56,6 +56,7 @@ $order_by = 'sort';
  <?php csrf_token(); ?>
  <input type="hidden" name="do" value="mass_process" >
 <input type="hidden" id="action" name="a" value="sort" >
+<input type="hidden" id="p" name="p" value="<?php echo $page; ?>" >
  <table class="list" border="0" cellspacing="1" cellpadding="0" width="940">
 
     <thead>

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -121,11 +121,12 @@ if($_POST){
                         try {
                             $cfg->setTopicSortMode($_POST['help_topic_sort_mode']);
                             if ($cfg->getTopicSortMode() == 'm') {
+                                $p = ($_POST['p'] && is_numeric($_POST['p'])) ? $_POST['p'] : 1;
                                 foreach ($_POST as $k=>$v) {
                                     if (strpos($k, 'sort-') === 0
                                             && is_numeric($v)
                                             && ($t = Topic::lookup(substr($k, 5))))
-                                        $t->setSortOrder($v);
+                                        $t->setSortOrder($v + PAGE_LIMIT * ($p - 1));
                                 }
                             }
                             $msg = __('Successfully set sorting configuration');


### PR DESCRIPTION
Category manual sorting works only on the first page. If you try to change the order on a page different than 1, the elements are renumbered from 1 to PAGE_LIMIT losing their original value.
When you save, these elements are mixed with those on the first page because you get two elements with the same sorting value.
This update fixes the problem tracking the page number where the user pressed "save" to calculate the offset from the first element of the first page, and then adds the offset to the elements value.