### PR TITLE
Show only my teams in My tickets. Fixes #2899

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -102,7 +102,7 @@ case 'assigned':
     $results_type=__('My Tickets');
     $tickets->filter(Q::any(array(
         'staff_id'=>$thisstaff->getId(),
-        Q::all(array('staff_id' => 0, 'team_id__gt' => 0)),
+        Q::all(array('staff_id' => 0, 'team_id__in' => array_filter($thisstaff->getTeams()))),
     )));
     $queue_sort_options = array('updated', 'priority,updated',
         'priority,created', 'priority,due', 'due', 'answered', 'number',


### PR DESCRIPTION
This should fix #2899, which caused any ticket assigned to a team to appear in the "my tickets" list, even though the agent was not part of that team.