### PR TITLE
Fixes issue #3620.

### DIFF
--- a/include/Spyc.php
+++ b/include/Spyc.php
@@ -615,10 +615,12 @@ class Spyc {
       return false;
     }
 
+    if (is_string($value) && preg_match('/^0x[0-9a-fA-F]+$/', $value)) {
+      return hexdec($value);
+    }
+
     if (is_numeric($value)) {
       if ($value === '0') return 0;
-      if (stripos($value, '0x') === 0)
-        $value = hexdec($value);
       if (rtrim ($value, 0) === $value)
         $value = (float)$value;
       return $value;


### PR DESCRIPTION
Change to the Spyc library to correctly convert hex strings to INTs under PHP 7. Should fix issue #3620