### PR TITLE
Fix DatePicker on client side

### DIFF
--- a/js/osticket.js
+++ b/js/osticket.js
@@ -173,13 +173,21 @@ getConfig = (function() {
 
 $.translate_format = function(str) {
     var translation = {
-        'd':'dd',
-        'j':'d',
-        'z':'o',
-        'm':'mm',
-        'F':'MM',
-        'n':'m',
-        'Y':'yy'
+        'DD':   'oo',
+        'D':    'o',
+        'EEEE': 'DD',
+        'EEE':  'D',
+        'MMMM': '||',   // Double replace necessary
+        'MMM':  '|',
+        'MM':   'mm',
+        'M':    'm',
+        '||':   'MM',
+        '|':    'M',
+        'yyyy': '`',
+        'yyy':  '`',
+        'yy':   'y',
+        'y':    'yy',
+        '`':    'yy'
     };
     // Change PHP formats to datepicker ones
     $.each(translation, function(php, jqdp) {


### PR DESCRIPTION
Hi guys,

there's an issue in the datepicker on the client side and this fixes the issue.
Issue was that the date was not correctly translated, so when for example we had configured `yyy-MM-dd` and when a user selected a date using the datepicker on the open.php (custom form with date/time field) it showed `201717-January-1818` instead of `2017-01-18`. This PR fixes this issue and I guess it was forgotten by Jared once he made the format i18n aware in commit https://github.com/osTicket/osTicket/commit/0fbc09ad512552b9c356c983121797b0e6c2c22f, in which he changed it on the backend side, but not on the user / frontend side. Tested it with 1.10.

Cheers,
Michael

PS: WOW, took my colleague and me only 10 minutes to find and fix 😁 