### PR TITLE
Fix issue with getStartDate() conversion (used at the dashboard)

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -43,8 +43,8 @@ class OverviewReport {
         $format =  $format ?: $this->format;
         if ($translate) {
             $format = str_replace(
-                    array('y', 'Y', 'm'),
-                    array('yy', 'yyyy', 'mm'),
+                    array('yyy', 'yy', 'y', 'Y', 'm'),
+                    array('y', 'y', 'yyyy', 'yyyy', 'mm'),
                     $format);
         }
 


### PR DESCRIPTION
Hi guys,

discovered another date related issue. We're using the date format `dd.MM.yyy`  (configured under `Admin panel -> Settings -> System -> Date and Time Format (= Advanced) -> Date Format`) and this seems to make some issue when it's converted to ISO8601 with the getStartDate() function. The conversion is triggered under `Admin Panel -> Dashboard` when you select a date at the report timeframe field and hit the button "Refresh" to show the result. 

**Actual behavior**
`dd.MM.yyy` , e.g. `19.01.2017` gets converted to ISO8601 `2017-01-19` and then back to `19.01.002017` - as you can see, there are 2 `00` before `2017` and that is the issue.

**Expected behavior**
`dd.MM.yyy`, so `19.01.2017` shall be converted to ISO8601 `2017-01-19` and then back to `19.01.2017` which does not happen since `y` is replaced with `yy`, but we have `yyy` which is then replaced to `yyyyyy` leading to `002017` as the result.

To fix this issue, I added another replacement, so that `yyy` is replaced in the first step with a single `y` and then in the second step the `y` is replaced with `yyyy` (and not just `yy` since I guess it just looks better to have `2017` and not just `17`)

So, now we have one issue fixed, but another one is still open! What happens when we configure `yy` in the admin panel for the year?!
To fix that issue too and don't get a result of `19.01.00002017` another replacement for `yy` = `y` after the first replacement of `yyy` = `y` is necessary ;)

This way every configured year value in the admin panel, either `yyy` or `yy` or `yyyy` or just `y`, the replacement works correctly now - tested it several times with 1.10 to be sure and hope you can verify when reviewing it! :D

Cheers,
Michael