### PR TITLE
Fix: Wildcard-Search on incomplete words

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -145,7 +145,7 @@ case 'search':
             $__tickets = $ost->searcher->find($q, $tickets);
             if (!count($__tickets) && preg_match('`\w$`u', $q)) {
                 // Do wildcard search if no hits
-                $__tickets = $ost->searcher->find($q.'*', $tickets);
+                $__tickets = $ost->searcher->find('+'.$q.'*', $tickets);
             }
             $tickets = $__tickets;
             $has_relevance = true;


### PR DESCRIPTION
### Prerequisites

* [x] Can you reproduce the problem in a fresh installation of the "develop" branch?
* [ ] Do you have any errors in the PHP error log, or javascript console?
* [x] Did you check the [osTicket forums](http://osticket.com/forum/categories)?
* [x] Did you [perform a cursory search](https://github.com/osTicket/osTicket/issues) to see if your bug or enhancement is already reported?

### Description
A search for an incomplete word like `apple`  does not return any tickets which contain the word `applepie` or `apples`, even if there is no ticket which contains the word `apple`.
If you do a keyword search in OsTicket and nothing is found, OsTicket tries a wildcard search by adding `*` to the search term. However since the search engine for MySQL uses **IN NAUTRAL LANGUAGE MODE** by default, the wildcard operator is not supported. The mode would automatically switched to **BOOLEAN MODE**, which supports the `*` wildcard, if more than one boolean operator is found.
This pull request just prepends the query with the operator `+` in order to have two operators and make the engine switch to **BOOLEAN MODE**.

If you now search for `apple` and nothing is found, the second search is for `+apple*` in boolean mode (instead of `apple*` in natural language mode), which then finds everything containing words that begin with apple.

### Steps to Reproduce

1. Look for a word with more than 4 charactes like `OsTicket` in your tickets
2. Enter the word, but incomplete in the search box i.e. `osticke`

**Expected behavior:**
The ticket should be found, at least if no other ticket contains the exact (incomplete) word.

**Actual behavior:**
Since the first search with `osticke` does not return results, a second search with `osticke*` is performed. However, since the **NATURAL LANGUAGE MODE** does not support `*` still nothing is found.

### Versions
Current tip of develop, of cause: 4e4908638418920b238ba03eed77583344380853