### PR TITLE
%{response} insteed correct response

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1512,6 +1512,7 @@ implements RestrictedAccess, Threadable {
 
         $vars = array_merge($vars, array(
             'message' => (string) $entry,
+	    'response' => (string) $entry,
             'poster' => $poster ?: _S('A collaborator'),
             )
         );


### PR DESCRIPTION
Avoid answers to collaborators with %{response} insteed correct text.