### PR TITLE
trying to fix timezone problem #3654

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -516,11 +516,12 @@ class Format {
             return '';
 
         if ($fromDb)
-            $timestamp = Misc::db2gmtime($timestamp);
+            $timestamp = new DateTime($timestamp);
 
         if (class_exists('IntlDateFormatter')) {
             $locale = Internationalization::getCurrentLocale($user);
             $key = "{$locale}:{$dayType}:{$timeType}:{$timezone}:{$format}";
+
             if (!isset($cache[$key])) {
                 // Setting up the IntlDateFormatter is pretty expensive, so
                 // cache it since there aren't many variations of the


### PR DESCRIPTION
This will solve the problem in #3654 but I am not sure what the `$fromDb` is for. Is this needed? Why was it where in the first place?

What this change will do, is converting the timestamp we get from DB (queried in tickets.inc.php) in an UTC DateTime object instead of converting it to an unix timestamp and giving that to the IntlDateFormatter.

Please test this with other timezones!