### PR TITLE
null is as intended... making it so.

### DIFF
--- a/include/staff/templates/advanced-search.tmpl.php
+++ b/include/staff/templates/advanced-search.tmpl.php
@@ -100,7 +100,7 @@ foreach ($matches as $name => $fields) { ?>
 <div id="saved-searches" class="accordian" style="max-height:200px;overflow-y:auto;">
 <?php foreach (SavedSearch::forStaff($thisstaff) as $S) { ?>
     <dt class="saved-search">
-        <a href="#" class="load-search"><?php echo $S->title; ?>
+        <a href="#" class="load-search"><?php echo $S->title ?: "null"; ?>
         <i class="icon-chevron-down pull-right"></i>
         </a>
     </dt>


### PR DESCRIPTION
Current behavior:
adding an empty search inserts "null" in the name of the search ui, and saves as null.

New behavior:
nameless searches are called "null", which allows you to delete them and load them if needed.

https://github.com/osTicket/osTicket/issues/2787