### PR TITLE
Adds auto-changing status feature

### DIFF
--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -28,10 +28,10 @@ class Cron {
     function TicketMonitor() {
         require_once(INCLUDE_DIR.'class.ticket.php');
         Ticket::checkOverdue(); //Make stale tickets overdue
+        Ticket::autoChangeStatus(); //Change status of tickets automatically
         // Cleanup any expired locks
         require_once(INCLUDE_DIR.'class.lock.php');
         Lock::cleanup();
-
     }
 
     function PurgeLogs() {


### PR DESCRIPTION
This feature enables an automatic status changing, from an open ticket, for any other status after a timer runs out.

![osticket_auto-changing-status](https://cloud.githubusercontent.com/assets/4013511/22938048/b31512ec-f2c1-11e6-844f-0b7b077471cd.png)
