### PR TITLE
Fix compile error in task clam

### DIFF
--- a/include/ajax.tasks.php
+++ b/include/ajax.tasks.php
@@ -689,7 +689,7 @@ class TasksAjaxAPI extends AjaxController {
                 $errors['err'] = $info['error'] = $m;
             else
                 $info['warn'] = sprintf(__('Are you sure you want to change status of %s?'),
-                        sprintf(__('this task'));
+                        sprintf(__('this task')));
             break;
         default:
             Http::response(404, __('Unknown status'));


### PR DESCRIPTION
This is a PR for a fix for the error causing the task claim call to fail with a blank popup.

![image](https://cloud.githubusercontent.com/assets/6013514/23525650/f095353a-ff6d-11e6-9f6a-3e4a2ed41e5d.png)
