### PR TITLE
Fix lookup of database time zone

### DIFF
--- a/include/class.timezone.php
+++ b/include/class.timezone.php
@@ -165,6 +165,7 @@ class DbTimezone {
     function get_from_database() {
         // Attempt to fetch timezone direct from the database
         $TZ = db_timezone();
+        $utc_offset_seconds = db_timezone_offset();
 
         // Translate ambiguous 'GMT' timezone
         if ($TZ === 'GMT') {
@@ -176,7 +177,7 @@ class DbTimezone {
         // Forbid timezone abbreviations like 'CDT'
         elseif ($TZ !== 'UTC' && strpos($TZ, '/') === false) {
             // Attempt to lookup based on the abbreviation
-            if (!($TZ = timezone_name_from_abbr($TZ)))
+            if (!($TZ = timezone_name_from_abbr($TZ, $utc_offset_seconds)))
                 // Abbreviation doesn't point to anything valid
                 return false;
         }

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -118,6 +118,20 @@ function db_timezone() {
     return db_get_variable('system_time_zone', 'global');
 }
 
+/**
+ * Returns the database server's offset from UTC in seconds.
+ *
+ * @return int|null
+ */
+function db_timezone_offset() {
+    $res = db_query('SELECT TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP, NOW());');
+    if ($row = db_fetch_row($res)) {
+        return (int)$row[0];
+    }
+
+    return null;
+}
+
 function db_get_variable($variable, $type='session') {
     $sql =sprintf('SELECT @@%s.%s', $type, $variable);
     return db_result(db_query($sql));


### PR DESCRIPTION
Fixes https://github.com/osTicket/osTicket/issues/3583 and https://github.com/osTicket/osTicket/issues/3654

**The problem:**

Times on ticket entries, and calculations of response times are broken.

In our case we are using Asia/Shanghai, so CST (China Standard Time) is the timezone on the MySQL sever. However `timezone_name_from_abbr` returns America/Chicago as it interprets CST as Central Standard Time. This can be seen on the Dashboard > Information page as:

> Timezone	CST (Interpreted as America/Chicago)

**The fix:**

`timezone_name_from_abbr` supports a second parameter which is a timezone offset in seconds, to aid selecting the correct timezone. This PR selects the current timezone offset in seconds to pass to  `timezone_name_from_abbr`. This results in the correct Asia/Shanghai timezone being returned.

More info: http://php.net/manual/en/function.timezone-name-from-abbr.php

The System information page now shows:

> Timezone	CST (Interpreted as Asia/Chongqing)

Asia/Chongqing is equivalent to Asia/Shanghai, so it's all good.

**Notes:**

This will be okay with DST, as by default (omitting the third parameter to `timezone_name_from_abbr)` it will take into account wether DST is currently in effect or not. So passing an offset of -6 hours for MST will work during daylight savings, and -7 will work at other times.

