### PR TITLE
Fix service & reponse times on dashboard

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -186,48 +186,48 @@ class OverviewReport {
             ));
 
         switch ($group) {
-        case 'dept':
-            $headers = array(__('Department'));
-            $header = function($row) { return Dept::getLocalNameById($row['dept_id'], $row['dept__name']); };
-            $pk = 'dept_id';
-            $stats = $stats
-                ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                ->values('dept__id', 'dept__name');
-            $times = $times
-                ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                ->values('dept__id');
-            break;
-        case 'topic':
-            $headers = array(__('Help Topic'));
-            $header = function($row) { return Topic::getLocalNameById($row['topic_id'], $row['topic__topic']); };
-            $pk = 'topic_id';
-            $stats = $stats
-                ->values('topic_id', 'topic__topic')
-                ->filter(array('topic_id__gt' => 0));
-            $times = $times
-                ->values('topic_id')
-                ->filter(array('topic_id__gt' => 0));
-            break;
-        case 'staff':
-            $headers = array(__('Agent'));
-            $header = function($row) { return new AgentsName(array(
-                'first' => $row['staff__firstname'], 'last' => $row['staff__lastname'])); };
-            $pk = 'staff_id';
-            $stats = $stats->values('staff_id', 'staff__firstname', 'staff__lastname');
-            $times = $times->values('staff_id');
-            $depts = $thisstaff->getManagedDepartments();
-            if ($thisstaff->hasPerm(ReportModel::PERM_AGENTS))
-                $depts = array_merge($depts, $thisstaff->getDepts());
-            $Q = Q::any(array(
-                'staff_id' => $thisstaff->getId(),
-            ));
-            if ($depts)
-                $Q->add(array('dept_id__in' => $depts));
-            $stats = $stats->filter(array('staff_id__gt'=>0))->filter($Q);
-            $times = $times->filter(array('staff_id__gt'=>0))->filter($Q);
-            break;
-        default:
-            # XXX: Die if $group not in $groups
+            case 'dept':
+                $headers = array(__('Department'));
+                $header = function($row) { return Dept::getLocalNameById($row['dept_id'], $row['dept__name']); };
+                $pk = 'dept_id';
+                $stats = $stats
+                    ->filter(array('dept_id__in' => $thisstaff->getDepts()))
+                    ->values('dept__id', 'dept__name');
+                $times = $times
+                    ->filter(array('dept_id__in' => $thisstaff->getDepts()))
+                    ->values('dept__id');
+                break;
+            case 'topic':
+                $headers = array(__('Help Topic'));
+                $header = function($row) { return Topic::getLocalNameById($row['topic_id'], $row['topic__topic']); };
+                $pk = 'topic_id';
+                $stats = $stats
+                    ->values('topic_id', 'topic__topic')
+                    ->filter(array('topic_id__gt' => 0));
+                $times = $times
+                    ->values('topic_id')
+                    ->filter(array('topic_id__gt' => 0));
+                break;
+            case 'staff':
+                $headers = array(__('Agent'));
+                $header = function($row) { return new AgentsName(array(
+                    'first' => $row['staff__firstname'], 'last' => $row['staff__lastname'])); };
+                $pk = 'staff_id';
+                $stats = $stats->values('staff_id', 'staff__firstname', 'staff__lastname');
+                $times = $times->values('staff_id');
+                $depts = $thisstaff->getManagedDepartments();
+                if ($thisstaff->hasPerm(ReportModel::PERM_AGENTS))
+                    $depts = array_merge($depts, $thisstaff->getDepts());
+                $Q = Q::any(array(
+                    'staff_id' => $thisstaff->getId(),
+                ));
+                if ($depts)
+                    $Q->add(array('dept_id__in' => $depts));
+                $stats = $stats->filter(array('staff_id__gt'=>0))->filter($Q);
+                $times = $times->filter(array('staff_id__gt'=>0))->filter($Q);
+                break;
+            default:
+                # XXX: Die if $group not in $groups
         }
 
         $timings = array();

--- a/include/class.report.php
+++ b/include/class.report.php
@@ -188,7 +188,7 @@ class OverviewReport {
         switch ($group) {
             case 'dept':
                 $headers = array(__('Department'));
-                $header = function($row) { return Dept::getLocalNameById($row['dept_id'], $row['dept__name']); };
+                $header_value = function($row) { return Dept::getLocalNameById($row['dept_id'], $row['dept__name']); };
                 $pk = 'dept_id';
                 $stats = $stats
                     ->filter(array('dept_id__in' => $thisstaff->getDepts()))
@@ -199,7 +199,7 @@ class OverviewReport {
                 break;
             case 'topic':
                 $headers = array(__('Help Topic'));
-                $header = function($row) { return Topic::getLocalNameById($row['topic_id'], $row['topic__topic']); };
+                $header_value = function($row) { return Topic::getLocalNameById($row['topic_id'], $row['topic__topic']); };
                 $pk = 'topic_id';
                 $stats = $stats
                     ->values('topic_id', 'topic__topic')
@@ -210,7 +210,7 @@ class OverviewReport {
                 break;
             case 'staff':
                 $headers = array(__('Agent'));
-                $header = function($row) { return new AgentsName(array(
+                $header_value = function($row) { return new AgentsName(array(
                     'first' => $row['staff__firstname'], 'last' => $row['staff__lastname'])); };
                 $pk = 'staff_id';
                 $stats = $stats->values('staff_id', 'staff__firstname', 'staff__lastname');
@@ -234,23 +234,25 @@ class OverviewReport {
                 );
         }
 
+        // Sort the timings into an array keyed by the primary key (department / topic / staff id)
         $timings = array();
-        foreach ($times as $T) {
-            $timings[$T[$pk]] = $T;
+        foreach ($times as $time_row) {
+            $timings[$time_row[$pk]] = $time_row;
         }
+        unset($times);
 
         $rows = array();
-        foreach ($stats as $R) {
-            $T = $timings[$R[$pk]];
+        foreach ($stats as $stats_row) {
+            $times = $timings[$stats_row[$pk]];
             $rows[] = array(
-                $header($R),
-                $R['Opened'],
-                $R['Assigned'],
-                $R['Overdue'],
-                $R['Closed'],
-                $R['Reopened'],
-                number_format($T['ServiceTime'], 1),
-                number_format($T['ResponseTime'], 1),
+                $header_value($stats_row), // Name column ("Department" / "Team" etc)
+                $stats_row['Opened'],
+                $stats_row['Assigned'],
+                $stats_row['Overdue'],
+                $stats_row['Closed'],
+                $stats_row['Reopened'],
+                number_format($times['ServiceTime'], 1),
+                number_format($times['ResponseTime'], 1),
             );
         }
 

--- a/include/class.report.php
+++ b/include/class.report.php
@@ -192,10 +192,10 @@ class OverviewReport {
                 $pk = 'dept_id';
                 $stats = $stats
                     ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                    ->values('dept__id', 'dept__name');
+                    ->values('dept_id', 'dept__name');
                 $times = $times
                     ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                    ->values('dept__id');
+                    ->values('dept_id');
                 break;
             case 'topic':
                 $headers = array(__('Help Topic'));
@@ -227,7 +227,11 @@ class OverviewReport {
                 $times = $times->filter(array('staff_id__gt'=>0))->filter($Q);
                 break;
             default:
-                # XXX: Die if $group not in $groups
+                // Return empty data if invalid group was given.
+                return array(
+                    "columns" => array(),
+                    "data" => array()
+                );
         }
 
         $timings = array();

--- a/include/class.report.php
+++ b/include/class.report.php
@@ -238,14 +238,32 @@ class OverviewReport {
         $rows = array();
         foreach ($stats as $R) {
             $T = $timings[$R[$pk]];
-            $rows[] = array($header($R), $R['Opened'], $R['Assigned'],
-                $R['Overdue'], $R['Closed'], $R['Reopened'],
+            $rows[] = array(
+                $header($R),
+                $R['Opened'],
+                $R['Assigned'],
+                $R['Overdue'],
+                $R['Closed'],
+                $R['Reopened'],
                 number_format($T['ServiceTime'], 1),
-                number_format($T['ResponseTime'], 1));
+                number_format($T['ResponseTime'], 1),
+            );
         }
-        return array("columns" => array_merge($headers,
-                        array(__('Opened'),__('Assigned'),__('Overdue'),__('Closed'),__('Reopened'),
-                              __('Service Time'),__('Response Time'))),
-                     "data" => $rows);
+
+        return array(
+            "columns" => array_merge(
+                $headers,
+                array(
+                    __('Opened'),
+                    __('Assigned'),
+                    __('Overdue'),
+                    __('Closed'),
+                    __('Reopened'),
+                    __('Service Time'),
+                    __('Response Time'),
+                )
+            ),
+            "data" => $rows,
+        );
     }
 }


### PR DESCRIPTION
Currently the agent dashboard statistics are showing the same service and response time for every department.

**Before:**
<img width="1103" alt="screen shot 2017-03-09 at 13 54 05" src="https://cloud.githubusercontent.com/assets/251159/23754587/717db02a-04d5-11e7-801f-2cea7b7ca108.png">

This is happening because in `class.report.php` it is trying to look up the times for the department by the `dept_id` key. But in the query the id is actually `dept__id` (2 underscores). I changed dept__id back to dept_id.

I also cleaned up the code a bit as it was initially hard to understand due to how compact it was.

**After:**
<img width="1078" alt="screen shot 2017-03-09 at 14 09 45" src="https://cloud.githubusercontent.com/assets/251159/23755019/f9c97378-04d6-11e7-8e56-e282b55a79aa.png">


