### PR TITLE
Syntax Errors Hotfix

### DIFF
--- a/include/ajax.tasks.php
+++ b/include/ajax.tasks.php
@@ -689,7 +689,7 @@ class TasksAjaxAPI extends AjaxController {
                 $errors['err'] = $info['error'] = $m;
             else
                 $info['warn'] = sprintf(__('Are you sure you want to change status of %s?'),
-                        sprintf(__('this task'));
+                        __('this task'));
             break;
         default:
             Http::response(404, __('Unknown status'));

--- a/include/staff/templates/task-preview.tmpl.php
+++ b/include/staff/templates/task-preview.tmpl.php
@@ -2,7 +2,7 @@
 $error=$msg=$warn=null;
 
 if (!$task->checkStaffPerm($thisstaff))
-     $warn.= __('You do not have access to %s'), __('this task');
+     $warn.= sprintf(__('You do not have access to %s'), __('this task'));
 elseif ($task->isOverdue())
     $warn.='&nbsp;<span class="Icon overdueTicket">'.__('Marked overdue!').'</span>';
 


### PR DESCRIPTION
Fixes syntax error introduced with commit 71a6b2a0 & 6e0ddf2e