### PR TITLE
Chunk long text body

### DIFF
--- a/include/class.thread_actions.php
+++ b/include/class.thread_actions.php
@@ -123,7 +123,7 @@ JS
         $old = $this->entry;
         $new = ThreadEntryBody::fromFormattedText($_POST['body'], $old->format);
 
-        if ($new->getClean() == $old->body)
+        if ($new->getClean() == $old->getBody())
             // No update was performed
             return $old;
 

--- a/include/staff/templates/thread-entry-edit.tmpl.php
+++ b/include/staff/templates/thread-entry-edit.tmpl.php
@@ -34,7 +34,8 @@
     class="large <?php
         if ($cfg->isRichTextEnabled() && $this->entry->format == 'html')
             echo 'richtext';
-    ?>"><?php echo htmlspecialchars(Format::viewableImages($this->entry->body));
+    ?>"><?php echo htmlspecialchars(Format::viewableImages(
+        (string) $this->entry->getBody()));
 ?></textarea>
 
 <?php if ($this->entry->type == 'R') { ?>


### PR DESCRIPTION
Store long thread entry body as an attachment if its length is more than max-length of a text field. 

This is necessary especially for emailed tickets which might contain excel document pasted into the body (inline attachment) of the email. We could increase the body field type to longtext - but that won't solve cases where the text is larger than the maximum packet size allowed by MySQL backend.

The technique implemented doesn't require any special flags - we simply set the entry body to `NULL` and the text is saved as an inline attachment for the entry. The attachment backends stores the file as it see fit - in the case of Database Backend, it already has a built-in chunking mechanism to go around max packet size allowed.