### PR TITLE
Feature: Show urls on custom field texts.

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -470,7 +470,18 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
 echo Format::htmlchars($label);
             ?>:</th>
             <td><?php
-echo $v;
+        // Show urls on custom fields.
+        // The Regular Expression filter
+               $reg_exUrl = "/(http|https|ftp|ftps)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(\/\S*)?/";
+
+               // Check if there is a url in the text
+               if(preg_match($reg_exUrl, $v, $url)) {
+                    // make the urls hyper links
+                    echo preg_replace($reg_exUrl, '<a href="'.$url[0].'" rel="nofollow">'.$url[0].'</a>', $v);
+               } else {
+                    // if no urls in the text just return the text
+                    echo $v;
+                }
             ?></td>
         </tr>
 <?php } ?>


### PR DESCRIPTION
Using regex, show urls inside custom field contents. Pretty useful for when you have a lot of locations and must use maps to redirect your agents.