### PR TITLE
fixes JS error on Ajax GET from scp/search

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3543,7 +3543,7 @@ class DatetimePickerWidget extends Widget {
                     showButtonPanel: true,
                     buttonImage: './images/cal.png',
                     showOn:'both',
-                    dateFormat: $.translate_format('<?php echo $cfg->getDateFormat(true); ?>')
+                    dateFormat: $.translate_format(<?php echo json_encode($cfg->getDateFormat(true)); ?>)
                 });
             });
         </script>


### PR DESCRIPTION
The previous code causes JS error `SyntaxError: missing ) after argument list` when `'` is included in i18n date format string. (for example, ja_JP language pack is affected.)