### PR TITLE
Fix crash editing thread entry with inline image

### DIFF
--- a/include/class.thread_actions.php
+++ b/include/class.thread_actions.php
@@ -165,7 +165,9 @@ JS
         }
 
         // Move the attachments to the new entry
-        $old->attachments->update(array(
+        $old->attachments->filter(array(
+            'inline' => false,
+        ))->update(array(
             'object_id' => $entry->id
         ));
 


### PR DESCRIPTION
This fixes an InconsistentModelException error when editing thread entries with inline images. The fix assumes that inline images are re-attached when a new ThreadEntry is created and the body is copied from the previous entry. Only the non-inline attachments need to be moved in the update query.

Fixes #3787