### PR TITLE
subject max lenght changed from 30 to 70

### DIFF
--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -545,6 +545,7 @@ class FA_SendEmail extends TriggerAction {
                 'required' => true,
                 'configuration' => array(
                     'size' => 80,
+                    'length' => 70,
                     'placeholder' => __('Subject')
                 ),
             )),


### PR DESCRIPTION
The maximum lenght of the new email's subject was not specified, so it was default to 30 characters, that's too little. Changed to 70, as of recommended by rfc http://www.faqs.org/rfcs/rfc2822.html