### PR TITLE
Allowing translation of copyrights in footers

### DIFF
--- a/include/client/footer.inc.php
+++ b/include/client/footer.inc.php
@@ -1,7 +1,7 @@
         </div>
     </div>
     <div id="footer">
-        <p>Copyright &copy; <?php echo date('Y'); ?> <?php echo (string) $ost->company ?: 'osTicket.com'; ?> - All rights reserved.</p>
+        <p><?php echo __('Copyright &copy;'); ?> <?php echo date('Y'); ?> <?php echo (string) $ost->company ?: 'osTicket.com'; ?> - <?php echo __('All rights reserved.'); ?></p>
         <a id="poweredBy" href="http://osticket.com" target="_blank"><?php echo __('Helpdesk software - powered by osTicket'); ?></a>
     </div>
 <div id="overlay"></div>

--- a/include/staff/footer.inc.php
+++ b/include/staff/footer.inc.php
@@ -2,7 +2,7 @@
 </div>
 <?php if (!isset($_SERVER['HTTP_X_PJAX'])) { ?>
     <div id="footer">
-        Copyright &copy; 2006-<?php echo date('Y'); ?>&nbsp;<?php echo (string) $ost->company ?: 'osTicket.com'; ?>&nbsp;All Rights Reserved.
+        <?php echo __('Copyright &copy;') ?> 2006-<?php echo date('Y'); ?>&nbsp;<?php echo (string) $ost->company ?: 'osTicket.com'; ?>&nbsp;<?php echo __('All Rights Reserved.'); ?>
     </div>
 <?php
 if(is_object($thisstaff) && $thisstaff->isStaff()) { ?>


### PR DESCRIPTION
This will allow translation of copyright notices in footers of client and agent pages.