### PR TITLE
i18n: Fix getPrimaryLanguage() on non-object

### DIFF
--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -364,7 +364,7 @@ class Internationalization {
 
         return $lang = self::isLanguageInstalled($best_match_langcode)
             ? $best_match_langcode
-            : $cfg->getPrimaryLanguage();
+            : ($cfg ? $cfg->getPrimaryLanguage() : 'en_US');
     }
 
     static function getCurrentLanguage($user=false) {


### PR DESCRIPTION
This addresses issues #1964 & #3668 where $cfg might be null and cause a
non-object error. Check if $cfg is set, if not, return the default en_US
language.