### PR TITLE
Avoid bare linefeeds in outgoing mails (SMTP)

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -566,6 +566,10 @@ class Mailer {
         $mail = mail::factory('mail', $args);
         // Ensure the To: header is properly encoded.
         $to = $headers['To'];
+        
+        // Avoid bare linefeeds
+        $body = str_replace("\n", "\r\n", $body);
+        
         $result = $mail->send($to, $headers, $body);
         if(!PEAR::isError($result))
             return $messageId;


### PR DESCRIPTION
Some mail servers didn't accept osTicket mails.

Environment: Windows IIS Server, PHP 5.6

Bare LFs: [http://cr.yp.to/docs/smtplf.html](http://cr.yp.to/docs/smtplf.html)

Without Workaround:
![image002](https://cloud.githubusercontent.com/assets/15348012/26735511/7d11cd10-47c2-11e7-9651-d90af9f7ed6e.png)
 
With this Workaround:
![image003](https://cloud.githubusercontent.com/assets/15348012/26735499/74c88a72-47c2-11e7-8569-7380ac291f7a.jpg) 