### PR TITLE
Fixes uncaught Fatal error with class.search.php

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -776,7 +776,7 @@ class SavedSearch extends VerySimpleModel {
                     continue;
                 }
                 $id = $info[2];
-                if (is_numeric($id) && ($field = DynamicFormField::lookup($id))) {
+                if (is_numeric($id) && ($field = DynamicFormField::lookup($id)) && is_object($field->form)) {
                     $impl = $field->getImpl();
                     $impl->set('label', sprintf('%s / %s',
                         $field->form->getLocal('title'), $field->getLocal('label')


### PR DESCRIPTION
```
[Fri Jun 09 17:21:31.272057 2017] [proxy_fcgi:error] [pid 27722] [client me:39054] AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught Error: Call to a member function getLocal() on null in /var/www/osticket/include/class.search.php:782\n
Stack trace:\n
#0 /var/www/osticket/include/class.search.php(700): SavedSearch->getCurrentSearchFields(Array)\n
#1 /var/www/osticket/include/class.search.php(687): SavedSearch->getForm(Array)\n
#2 /var/www/osticket/include/class.search.php(692): SavedSearch->loadFromState(Array)\n
#3 /var/www/osticket/scp/tickets.php(419): SavedSearch->getFormFromSession('advsearch')\n
#4 /var/www/osticket/scp/index.php(17): require('/var/www/os...')\n
#5 {main}\n  thrown in /var/www/osticket/include/class.search.php on line 782\n'
```

Must have left it logged in for a while, when I came back, blank, 500's.. that was the only error logged, adding the ```is_object``` check for the form seemed to fix it. I don't even remember saving an advanced search.. weird.