### PR TITLE
Ensure ['HTTPS'] exists

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -145,7 +145,8 @@ class Misc {
     function currentURL() {
 
         $str = 'http';
-        if ($_SERVER['HTTPS'] == 'on') {
+        if (isset($_SERVER['HTTPS'])
+            && strtolower($_SERVER['HTTPS']) == 'on') {
             $str .='s';
         }
         $str .= '://';


### PR DESCRIPTION
Hi,
I've tried to use osTicket on my local Windows 10 machine, PHP 5..6.26, Apache 2.4 as web server.
My $_SERVER array did not have 'HTTPS' key and the app would stop. So I've included a check if that key exists.