### PR TITLE
tasks: Due Date Template Variable

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1014,7 +1014,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         case 'create_date':
             return new FormattedDate($this->getCreateDate());
          case 'due_date':
-            if ($due = $this->getEstDueDate())
+            if ($due = $this->getDueDate())
                 return new FormattedDate($due);
             break;
         case 'close_date':


### PR DESCRIPTION
This addresses issue #3864 where the Task due date template variable
throws an undefined method error. The variable referenced a non-existing
method, this updates the reference to the correct method.