### PR TITLE
feature: add ticket closed notification

### DIFF
--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -545,6 +545,7 @@ class FA_SendEmail extends TriggerAction {
                 'required' => true,
                 'configuration' => array(
                     'size' => 80,
+                    'length' => 70,
                     'placeholder' => __('Subject')
                 ),
             )),

--- a/include/class.template.php
+++ b/include/class.template.php
@@ -84,6 +84,14 @@ class EmailTemplateGroup {
                 'ticket', 'signature', 'message', 'poster', 'recipient',
             ),
         ),
+        'ticket.close'=>array(
+            'group'=>'a.ticket.user',
+            'name'=>/* @trans */ 'Ticket Closed Notification',
+            'desc'=>/* @trans */ 'Notice sent to client on the closure of a ticket.',
+            'context' => array(
+                'ticket', 'signature', 'response', 'recipient',
+            ),
+        ),
         'ticket.alert'=>array(
             'group'=>'b.ticket.staff',
             'name'=>/* @trans */ 'New Ticket Alert',
@@ -323,6 +331,10 @@ class EmailTemplateGroup {
 
     function getReplyMsgTemplate() {
         return $this->getMsgTemplate('ticket.reply');
+    }
+
+    function getCloseMsgTemplate() {
+        return $this->getMsgTemplate('ticket.close');
     }
 
     function  getActivityNoticeMsgTemplate() {


### PR DESCRIPTION
feature: add ticket closed notification. taken from: https://gist.github.com/clonemeagain/8089055#file-list-of-changes-php-L28 and adapted to the new osticket's version. Please add even the SQL query written in the same url:

INSERT INTO ost_email_template (`id`, `tpl_id`, `code_name`, `subject`, `body`, `created`, `updated`) VALUES (NULL, 1, 'ticket.close', '[#%{ticket.number}] %{ticket.subject}', '%{ticket.name},
Our customer care team has closed the ticket, #%{ticket.number} on your behalf.
If you wish to provide additional comments or information regarding this issue, please don''t open a new ticket. You can update or view this ticket''s progress online here: %{ticket.client_link}.
%{signature}', NOW(), NOW());