### PR TITLE
pages: User Login Page Translation

### DIFF
--- a/include/class.page.php
+++ b/include/class.page.php
@@ -57,7 +57,7 @@ class Page extends VerySimpleModel {
         return $this->name;
     }
     function getLocalName($lang=false) {
-        return $this->getLocal('name', $lang);
+        return $this->_getLocal('name', $lang);
     }
     function getNameAsSlug() {
         return urlencode(Format::slugify($this->name));

--- a/include/client/login.inc.php
+++ b/include/client/login.inc.php
@@ -8,7 +8,7 @@ $content = Page::lookupByType('banner-client');
 
 if ($content) {
     list($title, $body) = $ost->replaceTemplateVariables(
-        array($content->getName(), $content->getBody()));
+        array($content->getLocalName(), $content->getLocalBody()));
 } else {
     $title = __('Sign In');
     $body = __('To better serve you, we encourage our clients to register for an account and verify the email address we have on record.');


### PR DESCRIPTION
This addresses issue #3860 where if you add a translation to the Login
Page and view the page in the translated language, the translation does
not show. This adds the correct `getLocal` methods to get the translated
page.