### PR TITLE
pages: Offline Page Images

### DIFF
--- a/offline.php
+++ b/offline.php
@@ -25,7 +25,7 @@ require(CLIENTINC_DIR.'header.inc.php');
 <div id="landing_page">
 <?php
 if(($page=$cfg->getOfflinePage())) {
-    echo $page->getBody();
+    echo $page->getBodyWithImages();
 } else {
     echo '<h1>'.__('Support Ticket System Offline').'</h1>';
 }


### PR DESCRIPTION
This addresses issue #3869 where images in the Offline Page are not
showing. The page was calling the `getBody()` method which does not
include attachments properly. This updates the method to
`getBodyWithImages()` which includes attachments.