### PR TITLE
Format untouched tickets in bold

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -559,7 +559,11 @@ return false;">
                     echo $base; ?>px; max-height: 1.2em"
                     class="<?php if ($flag) { ?>Icon <?php echo $flag; ?>Ticket <?php } ?>link truncate"
                     <?php if ($flag) { ?> title="<?php echo ucfirst($flag); ?> Ticket" <?php } ?>
-                    href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php echo $subject; ?></div>
+			href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php 
+			//Ticket subject displays bold if not transferred to department or agent
+			if($T['dept__name'] == $thisstaff->getDept() && $T['staff_id'] == "0") echo "<b>$subject</b>";
+			else echo $subject;
+			?></div>
 <?php               if ($T['attachment_count'])
                         echo '<i class="small icon-paperclip icon-flip-horizontal" data-toggle="tooltip" title="'
                             .$T['attachment_count'].'"></i>';


### PR DESCRIPTION
Formats ticket subjects in bold if not transferred to another department or agent yet. Helps when scanning homepage to see what tickets still need to be addressed.

![boldticketsubjects2](https://user-images.githubusercontent.com/5075161/27888016-b0e0522a-6198-11e7-9293-d74ced2f65db.jpg)
