### PR TITLE
forms: User Form Field Editability

### DIFF
--- a/include/client/edit.inc.php
+++ b/include/client/edit.inc.php
@@ -16,7 +16,7 @@ if(!defined('OSTCLIENTINC') || !$thisclient || !$ticket || !$ticket->checkUserAc
     <tbody id="dynamic-form">
     <?php if ($forms)
         foreach ($forms as $form) {
-            $form->render(false);
+            $form->render(false, false, $options);
     } ?>
     </tbody>
 </table>

--- a/include/client/templates/dynamic-form.tmpl.php
+++ b/include/client/templates/dynamic-form.tmpl.php
@@ -18,6 +18,10 @@
             if (!$field->isVisibleToUsers() && !$field->isRequiredForUsers())
                 continue;
         }
+        elseif (isset($options['mode']) && $options['mode'] == 'edit') {
+            if (!$field->isEditableToUsers())
+                continue;
+        }
         elseif (!$field->isVisibleToUsers() && !$field->isEditableToUsers()) {
             continue;
         }

--- a/tickets.php
+++ b/tickets.php
@@ -122,6 +122,7 @@ $nav->setActiveNav('tickets');
 if($ticket && $ticket->checkUserAccess($thisclient)) {
     if (isset($_REQUEST['a']) && $_REQUEST['a'] == 'edit'
             && $ticket->hasClientEditableFields()) {
+        $options['mode'] = 'edit';
         $inc = 'edit.inc.php';
         if (!$forms) $forms=DynamicFormEntry::forTicket($ticket->getId());
         // Auto add new fields to the entries
@@ -136,6 +137,7 @@ if($ticket && $ticket->checkUserAccess($thisclient)) {
     $inc='tickets.inc.php';
 } else {
     $nav->setActiveNav('new');
+    $options['mode'] = 'create';
     $inc='open.inc.php';
 }
 include(CLIENTINC_DIR.'header.inc.php');


### PR DESCRIPTION
This addresses issue #3724 where setting a form field to be non-editable by
a Users does not work. The User will still be able to edit the field when
they edit a ticket. This corrects the check on form field permissions to not
allow a User to edit the field if it’s not enabled.