### PR TITLE
pages: Newsletter Link

### DIFF
--- a/include/upgrader/done.inc.php
+++ b/include/upgrader/done.inc.php
@@ -28,7 +28,7 @@ $_SESSION['ost_upgrader']=null;
                 sprintf('<a href="'. ROOT_PATH . 'scp/settings.php" target="_blank">%s</a>', __('Admin Panel')),
                 sprintf('<a href="http://osticket.com/wiki/Release_Notes" target="_blank">%s</a>', __('osTicket Wiki')));?></p>
             <p><b><?php echo __('Stay up to date');?></b>: <?php echo __("It's important to keep your osTicket installation up to date. Get announcements, security updates and alerts delivered directly to you!");?>
-            <?php echo sprintf(__('%1$s Get in the loop %2$s today and stay informed!'), '<a target="_blank" href="http://osticket.com/subscribe.php">', '</a>');?></p>
+            <?php echo sprintf(__('%1$s Get in the loop %2$s today and stay informed!'), '<a target="_blank" href="http://osticket.com/newsletter">', '</a>');?></p>
             <p><b><?php echo __('Commercial Support Available');?></b>: <?php echo sprintf(__('Get guidance and hands-on expertise to address unique challenges and make sure your osTicket runs smoothly, efficiently, and securely. %1$s Learn More! %2$s'), '<a target="_blank" href="http://osticket.com/support">','</a>');?></p>
    </div>
    <div class="clear"></div>


### PR DESCRIPTION
This addresses an issue where the Installation Done page references an
incorrect link to sign up for the newsletter. This adds the correct link
to sign up for the newsletter.