### PR TITLE
Set Session Cookie to HttpOnly

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -38,6 +38,9 @@ class osTicketSession {
 
         // Set session cleanup time to match TTL
         ini_set('session.gc_maxlifetime', $ttl);
+        
+        // Set session to HttpOnly to prevent cookie hijacking attacks
+        ini_set('session.cookie_httponly', 'true');
 
         if (OsticketConfig::getDBVersion())
             return session_start();


### PR DESCRIPTION
Proposing that the OsTicket session cookie be set to HttpOnly to mediate a cross-site scripting vulnerability. The details are outlined here: https://msdn.microsoft.com/en-us/library/ms533046.aspx
I have been testing this change locally and it have not noticed any issues.