### PR TITLE
cron: Delete Expired Sessions

### DIFF
--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -51,6 +51,11 @@ class Cron {
         AttachmentFile::deleteOrphans();
     }
 
+    function CleanExpiredSessions() {
+        require_once(INCLUDE_DIR.'class.ostsession.php');
+        DbSessionBackend::cleanup();
+    }
+
     function MaybeOptimizeTables() {
         // Once a week on a 5-minute cron
         $chance = rand(1,2000);
@@ -100,6 +105,7 @@ class Cron {
         self::MailFetcher();
         self::TicketMonitor();
         self::PurgeLogs();
+        self::CleanExpiredSessions();
         // Run file purging about every 10 cron runs
         if (mt_rand(1, 9) == 4)
             self::CleanOrphanedFiles();

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -158,6 +158,10 @@ abstract class SessionBackend {
         return $this->update($id, $i['touched'] ? session_encode() : $data);
     }
 
+    function cleanup() {
+        $this->gc(0);
+    }
+
     abstract function read($id);
     abstract function update($id, $data);
     abstract function destroy($id);
@@ -218,6 +222,10 @@ extends SessionBackend {
 
     function destroy($id){
         return SessionData::objects()->filter(['session_id' => $id])->delete();
+    }
+
+    function cleanup() {
+        self::gc(0);
     }
 
     function gc($maxlife){


### PR DESCRIPTION
This addresses an issue where expired sessions would not be removed from
the database. This caused the session table to fill up and create
unnecessary issues. This adds a cleanup method to remove all expired
sessions from the database when cron runs.