### PR TITLE
oops: User Phone Search

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -77,6 +77,7 @@ class UsersAjaxAPI extends AjaxController {
                     'emails__address__contains' => $q,
                     'name__contains' => $q,
                     'org__name__contains' => $q,
+                    'cdata__phone__contains' => $q,
                 )));
             }
 

--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -14,6 +14,7 @@ if ($_REQUEST['query']) {
         'emails__address__contains' => $search,
         'name__contains' => $search,
         'org__name__contains' => $search,
+        'cdata__phone__contains' => $search,
         // TODO: Add search for cdata
     )));
     $qs += array('query' => $_REQUEST['query']);


### PR DESCRIPTION
This addresses issue #3815 where searching by User's phone number doesn't
work in v1.10. This adds phone number search capabilities for the User
Directory and User Search popup in v1.10.