### PR TITLE
orgs: Remove Primary Contacts

### DIFF
--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -425,6 +425,12 @@ implements TemplateVariable {
                 $u->setPrimaryContact(array_search($u->id, $vars['contacts']) !== false);
                 $u->save();
             }
+        } else {
+            $members = $this->allMembers();
+            $members->update(array(
+                'status' => SqlExpression::bitand(
+                    new SqlField('status'), ~User::PRIMARY_ORG_CONTACT)
+                ));
         }
 
         return $this->save();


### PR DESCRIPTION
This addresses issue #3903 where you cannot remove Primary Contacts from
an Organization through the UI. This adds functionality to remove
collaborators from the select box.