### PR TITLE
oops: Fix Task Print

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -268,7 +268,7 @@ if ($task->isOverdue())
                 <?php
                 foreach ($actions as $action) {?>
                 <span class="action-button <?php echo $action['class'] ?: ''; ?>">
-                    <a class="task-action"
+                    <a class="<?php echo ($action['class'] == 'no-pjax') ? '' : 'task-action'; ?>"
                         <?php
                         if ($action['dialog'])
                             echo sprintf("data-dialog-config='%s'", $action['dialog']);


### PR DESCRIPTION
This addresses issue #3782 where clicking Print on a Task gives you a blank
popup that hangs. This is because the Print button was being treated as a
Task action when it is actually not one. This adds a ternary operator to
give the proper Task actions the `task-action` class and gives the Print
button no class.