### PR TITLE
oops: Fix New Ticket Help Topic SLA

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3321,10 +3321,8 @@ implements RestrictedAccess, Threadable {
             elseif (!isset($vars['teamId']) && $topic->getTeamId())
                 $vars['teamId'] = $topic->getTeamId();
 
-            //set default sla.
-            if (isset($vars['slaId']))
-                $vars['slaId'] = $vars['slaId'] ?: $cfg->getDefaultSLAId();
-            elseif ($topic && $topic->getSLAId())
+            // Help topic SLA.
+            if (!$vars['slaId'] && $topic->getSLAId())
                 $vars['slaId'] = $topic->getSLAId();
         }
 


### PR DESCRIPTION
This addresses issue #3648 where creating a ticket as an agent and
selecting a Help Topic that has an SLA plan associated with it gives the ticket the
system default SLA instead. This adds a check for the Help Topic SLA plan
and adds it to the ticket if there is one. If not then it will add whatever
SLA plan the agent selected or the system default.