### PR TITLE
tasks: Fix Task Updated Time

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1246,6 +1246,8 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                     $thisstaff);
         }
 
+        $this->updated = SqlFunction::NOW();
+
         if ($changes)
             $this->logEvent('edited', array('fields' => $changes));
 


### PR DESCRIPTION
This addresses an issue where updating a Task does not change the
`updated` column in the database. This adds a line to change the `update`
column when updating a Task.