### PR TITLE
Fixes Datetime variable output in email templates.

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1774,7 +1774,7 @@ class DatetimeField extends FormField {
 
     function asVar($value, $id=false) {
         if (!$value) return null;
-        return new FormattedDate((int) $value, 'UTC', false, false);
+        return new FormattedDate(strtotime($value), 'UTC', false, false);
     }
     function asVarType() {
         return 'FormattedDate';


### PR DESCRIPTION
For some reason when VariableReplacer is called on Ticket Form Template Tariables that are DateTime's, the FormattedDate constructor was converting the timestamp from "2017 Mar 17 00:10" format, through an `(int)` cast into just "2017", which wasn't bad enough to fail, so it happily worked, however the FormattedDate constructor expects a timestamp (GMT?) integeter, so the cast removes an error, it breaks the Variable.

The proposed patch simply converts the string into a timestamp via strtotime, which, in my tests, seems to fix the variable replacement issue.

Phew. that took some digging.

See original thread here: http://osticket.com/forum/discussion/90854/custom-form-with-date-time-field-gives-a-problem-when-using-as-variable-in-email#latest