### PR TITLE
Format the advanced search title so that it will not allow javascript

### DIFF
--- a/include/ajax.search.php
+++ b/include/ajax.search.php
@@ -136,7 +136,7 @@ class SearchAjaxAPI extends AjaxController {
 
         $search->config = JsonDataEncoder::encode($form->getState());
         if (isset($_POST['name']))
-            $search->title = $_POST['name'];
+            $search->title = Format::htmlchars($_POST['name']);
         elseif ($search->__new__)
             Http::response(400, 'A name is required');
         if (!$search->save()) {


### PR DESCRIPTION
This addresses issue #3766 where javascript can be injected into the title of an advanced search. 