### PR TITLE
Only allow image attachments to be opened in the browser window

### DIFF
--- a/include/class.http.php
+++ b/include/class.http.php
@@ -106,7 +106,7 @@ class Http {
     }
 
     function download($filename, $type, $data=null, $disposition='attachment') {
-        if (strpos($type, 'image/') !== 0)
+        if (strpos($type, 'image/') !== 0 || preg_match('/image\/.*\+.*/', $type))
           $disposition='attachment';
 
         header('Pragma: private');

--- a/include/class.http.php
+++ b/include/class.http.php
@@ -106,6 +106,9 @@ class Http {
     }
 
     function download($filename, $type, $data=null, $disposition='attachment') {
+        if (strpos($type, 'image/') !== 0)
+          $disposition='attachment';
+
         header('Pragma: private');
         header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
         header('Cache-Control: private', false);


### PR DESCRIPTION
When opening attachments, we should only allow image files to be opened in the browser window. This prevents possible xss attacks where malicious code could be executed if an attachment were opened in the browser window. This was tested in Chrome, Safari, and Firefox.