### PR TITLE
[bugfix] Issue with php7 and session write_close function

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -155,7 +155,8 @@ abstract class SessionBackend {
         // Last chance session update
         $i = new ArrayObject(array('touched' => false));
         Signal::send('session.close', null, $i);
-        return $this->update($id, $i['touched'] ? session_encode() : $data);
+        $this->update($id, $i['touched'] ? session_encode() : $data);
+        return TRUE;
     }
 
     abstract function read($id);


### PR DESCRIPTION
Also an issue with Dev-Next

PHP 7 spews these errors with debugging enabled:

```
localhost:8080/setup/install.php
[Mon Aug 21 12:05:32.742737 2017] [:error] [pid 15349] [client 10.0.2.2:41938] PHP Warning:  session_write_close(): Failed to write session data (user). Please verify that the current setting of session.save_path is correct (/var/lib/php/sessions) in /var/www/html/osticket/include/class.ostsession.php on line 38, referer: http://localhost:8080/setup/install.php
[Mon Aug 21 12:05:32.742870 2017] [:error] [pid 15349] [client 10.0.2.2:41938] PHP Stack trace:, referer: http://localhost:8080/setup/install.php
[Mon Aug 21 12:05:32.742985 2017] [:error] [pid 15349] [client 10.0.2.2:41938] PHP   1. {main}() /var/www/html/osticket/index.php:0, referer: http://localhost:8080/setup/install.php
[Mon Aug 21 12:05:32.743074 2017] [:error] [pid 15349] [client 10.0.2.2:41938] PHP   2. require() /var/www/html/osticket/index.php:16, referer: http://localhost:8080/setup/install.php
[Mon Aug 21 12:05:32.743149 2017] [:error] [pid 15349] [client 10.0.2.2:41938] PHP   3. osTicketSession->{closure:/var/www/html/osticket/include/class.ostsession.php:37-40}() /var/www/html/osticket/include/class.ostsession.php:0, referer: http://localhost:8080/setup/install.php
[Mon Aug 21 12:05:32.743234 2017] [:error] [pid 15349] [client 10.0.2.2:41938] PHP   4. session_write_close() /var/www/html/osticket/include/class.ostsession.php:38, referer: http://localhost:8080/setup/install.php
```

Seems related to this PHP bug: https://bugs.php.net/bug.php?id=71070

The patch simply changes the return value from the session write method from the void return type of the db->update method, to TRUE. 