### PR TITLE
format: Mailto TLD Length

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -426,7 +426,7 @@ class Format {
                 // Scan for things that look like URLs
                 return preg_replace_callback(
                     '`(?<!>)(((f|ht)tp(s?)://|(?<!//)www\.)([-+~%/.\w]+)(?:[-?#+=&;%@.\w]*)?)'
-                   .'|(\b[_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,4})`',
+                   .'|(\b[_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,63})`',
                     function ($match) {
                         if ($match[1]) {
                             while (in_array(substr($match[1], -1),


### PR DESCRIPTION
This addresses an issue where the text formatter only allows 2-4
characters in email domain TLDs. This causes an issue if you have a TLD
with more than 4 characters, where the full email address will not be
converted into the link. This increases the allowed characters to 2-63
characters allowing all modern TLDs to be converted correctly. Why 63
chars? Have a look at the 2.3.4 Size Limts section here:
http://www.ietf.org/rfc/rfc1035.txt

**Before**
`<a href="mailto:user@domain.tech">user@domain.tech</a>nology`
<a href="mailto:user@domain.tech">user@domain.tech</a>nology

**After**
`<a href="mailto:user@domain.technology">user@domain.technology</a>`
<a href="mailto:user@domain.technology">user@domain.technology</a>