### PR TITLE
[feature] Adds support for wildcard and regex match ip addresses for API keys. …

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -99,11 +99,23 @@ class API {
         return ($key && $ip && self::getIdByKey($key, $ip));
     }
 
+    function getAddrById($id) {
+        $sql='SELECT ipaddr FROM '.API_KEY_TABLE.' WHERE id='.db_input($id);
+
+        if(($res=db_query($sql)) && db_num_rows($res))
+                list($addr) = db_fetch_row($res);
+
+        return $addr;
+
+    }
+
     function getIdByKey($key, $ip='') {
 
         $sql='SELECT id FROM '.API_KEY_TABLE.' WHERE apikey='.db_input($key);
-        if($ip)
-            $sql.=' AND ipaddr='.db_input($ip);
+
+		#presumably api keys are unique anyway.  ip can be checked in php rather than mysql
+        #if($ip)
+        #    $sql.=' AND ipaddr='.db_input($ip);
 
         if(($res=db_query($sql)) && db_num_rows($res))
             list($id) = db_fetch_row($res);
@@ -121,8 +133,13 @@ class API {
 
     function save($id, $vars, &$errors) {
 
-        if(!$id && (!$vars['ipaddr'] || !Validator::is_ip($vars['ipaddr'])))
-            $errors['ipaddr'] = __('Valid IP is required');
+
+        if(!preg_match('/^hostname:(?:[\w\-\*]+\.?)+$/i', $vars['ipaddr']) &&
+	     	 !preg_match('/^(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)$/i',$vars['ipaddr']) &&
+             !preg_match('/^(?:hostname:)?regex:.+$',$vars['ipaddr']))&&
+	   	   (!$id && !$vars['ipaddr'])){
+            $errors['ipaddr'] = __('Valid IP/Hostname is required');
+	       }
 
         if($errors) return false;
 
@@ -175,9 +192,36 @@ class ApiController {
 
         if(!($key=$this->getApiKey()))
             return $this->exerr(401, __('Valid API key required'));
-        elseif (!$key->isActive() || $key->getIPAddr()!=$_SERVER['REMOTE_ADDR'])
+        elseif (!$key->isActive()) {
             return $this->exerr(401, __('API key not found/active or source IP not authorized'));
+		} else {
 
+	       $iporhname = API::getAddrById($key->id);
+
+			if(!preg_match('/^(hostname:)?(regex:)?(.+)$/i',$iporhname,$matches))
+				return $this->exerr(401, __('source not authorized. bad match pattern'));
+	
+			list($_,$is_hname_match,$is_regex_match,$match_addr) = $matches;
+			$is_wc_match = $is_regex_match ? false : (strpos($matches[3],"*") !== false);
+	
+			if ($is_hname_match && !$is_regex_match && !$is_wc_match)
+			{
+				$match_addr = gethostbyname($match_addr);
+				$is_hname_match = false;
+				$is_wc_match = true;
+			}
+
+			$remote_iporhost = $is_hname_match ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : $_SERVER['REMOTE_ADDR'];
+	
+			#wildcard/normal match
+			if ($is_wc_match  &&
+			    !preg_match("/^".str_replace(".","\.",str_replace("*",".+?",$match_addr))."$/i",$remote_iporhost)) {
+				return $this->exerr(401, __('source hostname not authorized (wc/nml)'));
+			#regex match
+			} elseif ( $is_regex_match && !preg_match($match_addr,$remote_iporhost)) {
+				return $this->exerr(401, __('source hostname not authorized (re)'));
+			}
+		}
         return $key;
     }
 

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -130,7 +130,7 @@ class API {
 
         if(!preg_match('/^hostname:(?:[\w\-\*]+\.?)+$/i', $vars['ipaddr']) &&
             !preg_match('/^(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)$/i',$vars['ipaddr']) &&
-             !preg_match('/^(?:hostname:)?regex:.+$/i',$vars['ipaddr']))&&
+             !preg_match('/^(?:hostname:)?regex:.+$/i',$vars['ipaddr'])&&
             (!$id && !$vars['ipaddr'])){
                 $errors['ipaddr'] = __('Valid IP/Hostname is required');
             }

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -130,7 +130,7 @@ class API {
 
         if(!preg_match('/^hostname:(?:[\w\-\*]+\.?)+$/i', $vars['ipaddr']) &&
             !preg_match('/^(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)$/i',$vars['ipaddr']) &&
-             !preg_match('/^(?:hostname:)?regex:.+$',$vars['ipaddr']))&&
+             !preg_match('/^(?:hostname:)?regex:.+$/i',$vars['ipaddr']))&&
             (!$id && !$vars['ipaddr'])){
                 $errors['ipaddr'] = __('Valid IP/Hostname is required');
             }

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -204,7 +204,7 @@ class ApiController {
             }
             
             if( $is_wc_match )
-                $match_addr = "/^".str_replace(".","\.",str_replace("*",".+?",$match_addr))."$/i";
+                $match_addr = "/^".str_replace("*",".+?",str_replace(".","\.",$match_addr))."$/i";
 
             $remote_iporhost = $is_hname_match ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : $_SERVER['REMOTE_ADDR'];
         
@@ -360,8 +360,8 @@ class ApiXmlDataParser extends XmlDataParser {
     function fixup($current) {
         global $cfg;
 
-		if($current['ticket'])
-			$current = $current['ticket'];
+        if($current['ticket'])
+            $current = $current['ticket'];
 
         if (!is_array($current))
             return $current;

--- a/include/i18n/en_US/help/tips/manage.api_keys.yaml
+++ b/include/i18n/en_US/help/tips/manage.api_keys.yaml
@@ -28,5 +28,11 @@ api_key:
 ip_addr:
     title: IP Address
     content: >
-        Client's network IP address. Each unique client IP address will
-        require separate API keys
+         Client's network IP address. Each unique client IP address will
+         require separate API keys. Allowed Formats:<br/>
+         <b>IP <i>( 1.2.3.4 )</i></b><br/>compares with source ip<br/>
+         <b>IP Wildcard <i>( 1.2.*.*  )</i></b><br/>wildcard compare with source ip<br/>
+         <b>IP Regex <i>( regex:/^123.\d{1,3}.789.0$/</i></b><br/>applies regex directly to source ip<br/>
+         <b>Hostname <i>( hostname:some.example.domain.com )</i></b><br/>dns look up domain, comapres with source ip<br/>
+         <b>Hostname Wildcard <i>( hostname:*.*.example.domain.com )</i></b><br/>reverse dns lookup on source ip wilcard compared with domain<br/>
+         <b>Hostname Regex <i>( hostname:regex:/\w+?\.example(\.domain)?\.com/i )</i></b><br/>reverse dns lookup on source ip, then regex applied to domain<br/>


### PR DESCRIPTION
…Also adds hostname options. Introduces "hostname:" and "regex:" syntax to the ipaddr field.

IP ( `1.2.3.4` )
compares with source ip

IP Wildcard ( `1.2.*.*` )
wildcard matched against source ip

IP Regex ( `regex:/^123.\d{1,3}.789.0$/` )
regex matched against source ip

Hostname ( `hostname:some.example.domain.com` )
dns look up domain, comapres with source ip ( this option works for dynamic dns setups )

Hostname Wildcard ( `hostname:*.*.example.domain.com` )
reverse dns lookup on source ip, wilcard matched against looked up domain

Hostname Regex ( `hostname:regex:/\w+?\.example(\.domain)?\.com/i` )
reverse dns lookup on source ip, then regex matched against looked up domain
[
![example](https://user-images.githubusercontent.com/5624991/29691162-5acc9fb0-892a-11e7-9452-13fdbcf571e3.png)
](url)