### PR TITLE
oops: Fix Incorrect dbtime() Conversion

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -108,14 +108,14 @@ class Misc {
         } else {
             // User time to UTC
             $time = self::user2gmtime($var);
+            // UTC to db time
+            $time = DateTime::createFromFormat('U', $time);
         }
 
         if (!isset($dbtz)) {
             $dbtz = new DateTimeZone($cfg->getDbTimezone());
         }
-        // UTC to db time
-        $D = DateTime::createFromFormat('U', $time);
-        return $time + $dbtz->getOffset($D);
+        return $time + $dbtz->getOffset($time);
     }
 
     /*Helper get GM time based on timezone offset*/


### PR DESCRIPTION
This addresses an issue where the `dbtime()` function returns the
incorrect time when calling it without a timestamp. When you call it
without a timestamp it creates the time with the `time()` function. The
`time()` function returns the time in Unix format. At the end of
`dbtime()` it converts the time into Unix format with
`DateTime::createFromFormat('U', $time)`. This is buggy when you pass an
already unix timestamp and will return the time in the timezone of +00:00
. This moves the lines around so that if the time is already Unix it will
not convert to Unix, resulting in the correct time.