### PR TITLE
oops: Fix Default Dept. Private Error

### DIFF
--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -93,6 +93,7 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info);
                 <input type="radio" name="ispublic" value="0" <?php echo !$info['ispublic']?'checked="checked"':''; ?>><strong><?php echo __('Private');?></strong> <?php echo mb_convert_case(__('(internal)'), MB_CASE_TITLE);?>
                 </label>
                 &nbsp;<i class="help-tip icon-question-sign" href="#type"></i>
+                &nbsp;<span class="error"><?php echo $errors['ispublic']; ?></span>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
This addresses issue #3934 where setting the Default Department to
Private will throw “Fix errors below” error without showing the specific
error below. This adds the error class to the field so the system will
show what to fix.