### PR TITLE
oops: Fix Outdated Alerts Link

### DIFF
--- a/include/i18n/en_US/help/tips/staff.department.yaml
+++ b/include/i18n/en_US/help/tips/staff.department.yaml
@@ -67,7 +67,7 @@ group_membership:
         class="doc-desc-title">Alerts &amp; Notices</span>.
     links:
       - title: Configure Alerts &amp; Notices
-        href: /scp/settings.php?t=alerts
+        href: "/scp/settings.php?t=tickets#alerts"
 
 sandboxing:
     title: Ticket Assignment Restrictions


### PR DESCRIPTION
This addresses issue #3935 where Configure Alerts & Notices link in
Department settings is outdated. This adds the updated/correct link to
configure Alerts & Notices.