### PR TITLE
Fixed wrapping of plain-text ticket

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2209,7 +2209,7 @@ class TextThreadEntryBody extends ThreadEntryBody {
                 .Format::clickableurls($escaped).'</div>';
         case 'email':
             return '<div style="white-space:pre-wrap">'
-                .$escaped.'</div>';
+                .nl2br($escaped).'</div>';
         case 'pdf':
             return nl2br($escaped);
         default:


### PR DESCRIPTION
When plain-text e-mail ticket is received, notification send by e-mail
doesn't keep new lines and output is not consistent with the output on
ticket's web page.