### PR TITLE
cron: Optimize Lock Table

### DIFF
--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -56,7 +56,7 @@ class Cron {
         $chance = rand(1,2000);
         switch ($chance) {
         case 42:
-            @db_query('OPTIMIZE TABLE '.LOCK_TABLE);
+            @db_query('OPTIMIZE TABLE `'.LOCK_TABLE.'`');
             break;
         case 242:
             @db_query('OPTIMIZE TABLE '.SYSLOG_TABLE);


### PR DESCRIPTION
This addresses the MySQL syntax error regarding the lock table. On older
osTicket databases we didn’t enforce having a prefix on the db tables.
This means the lock table name would be 'lock' instead of 'ost_lock'. Cron
runs an `OPTIMIZE TABLE` query on the lock table and if it has no prefix
the query reads `OPTIMIZE TABLE lock;`. This is an issue because 'lock' is
a MySQL Reserved Word and will throw an error. All you have to do is
escape the table name with back ticks and MySQL won’t throw an error.