### PR TITLE
oops: Fix Serbian Flag Icon

### DIFF
--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -115,7 +115,7 @@ if (($all_langs = Internationalization::getConfiguredSystemLanguages())
         list($lang, $locale) = explode('_', $code);
         $qs['lang'] = $code;
 ?>
-        <a class="flag flag-<?php echo strtolower($locale ?: $info['flag'] ?: $lang); ?>"
+        <a class="flag flag-<?php echo strtolower($info['flag'] ?: $locale ?: $lang); ?>"
             href="?<?php echo http_build_query($qs);
             ?>" title="<?php echo Internationalization::getLanguageDescription($code); ?>">&nbsp;</a>
 <?php }


### PR DESCRIPTION
This addresses issue #3952 where the Serbian language did not have a flag
icon. This icon has to be seen in order for the users to change the
language. The reason the flag wasn’t shown was due to the incorrect class
name for the language link. This updates the class naming section to add
the correct part of the language name to the class.

**Example:**
- Before `class="flag flag-cs"`.
- After `class="flag flag-rs"`.