### PR TITLE
login: Fix CSRF fail, add shake effect on authentication fail

### DIFF
--- a/scp/css/login.css
+++ b/scp/css/login.css
@@ -353,3 +353,6 @@ input[type=password] {
     padding: 5px;
     font-size: 0.75em;
 }
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
It's possible I'm the only user annoyed by this issue. Everyday when I come into work and start working on tickets, I click somewhere in the interface and am presented with the login screen. After authenticating, I'm presented with the CSRF failure message and receive a database error email for DB Error 1062 (Duplicate entry '[blah]' for key 'PRIMARY').

This fixes an issue where the current session data is not retrieved from the database, because it is expired. However, the session-id is not reset either. Therefore, the session data with the new CSRF token is not updated in the database and the user may have trouble logging in. (This is where the db error email comes from).

This problem manifests itself as a session expires. If a user clicks somewhere in the software and their session is now expired, a redirect to the login page is triggered. However, the CSRF token sent in the login page is not saved in the database. So when the user logs in, they are greeted with the CSRF failure message.

This issue is addressed by retrieving the session data from the database, but clearing the content if it is expired. Therefore, the session data appears to the software as invalid and is properly reset and saved to the database, thereby avoiding the errors.

This also changes the staff authentication process to use AJAX to authenticate (with a failsafe of using traditional page requests). If the authentication fails on the server because of CSRF problems, the page is refreshed in the browser fetching a new CSRF token. If the authentication fails because of password issues, the login box shakes and the user can retry. As before, the `forgot password` link shows up after the first failure. Upon success, a redirect is issued into the staff control panel.

This should not affect external authentication plugins such as LDAP or OAUTH, but I have not yet tested them.