### PR TITLE
format: Add Fullscreen to Embedded Videos

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -321,7 +321,7 @@ class Format {
             'hook_tag' => function($e, $a=0) { return Format::__html_cleanup($e, $a); },
             'elements' => '*+iframe',
             'spec' =>
-            'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo)\.com/`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : ''),
+            'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo)\.com/`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : '').',allowfullscreen',
         );
 
         return Format::html($html, $config);


### PR DESCRIPTION
This addresses an issue where there is no fullscreen option for embedded
videos. This adds the allowfullscreen parameter to the formatter for
iframe tags.