### PR TITLE
CVE-2017-14396

### DIFF
--- a/file.php
+++ b/file.php
@@ -21,7 +21,7 @@ require_once(INCLUDE_DIR.'class.file.php');
 if (!$_GET['key']
     || !$_GET['signature']
     || !$_GET['expires']
-    || !($file = AttachmentFile::lookup($_GET['key']))
+    || !($file = AttachmentFile::lookupByHash($_GET['key']))
 ) {
     Http::response(404, __('Unknown or invalid file'));
 }

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2601,7 +2601,7 @@ class MySqlCompiler extends SqlCompiler {
     }
 
     function quote($what) {
-        return "`$what`";
+        return sprintf("`%s`", str_replace("`", "``", $what));
     }
 
     /**


### PR DESCRIPTION
This commit addresses an SQL injection vulnerability in ORM lookup function.

* ORM implementation failed to properly quote field names, used in SQL
statements, that might originate from unsanitized user input.

* AttachmentFile lookup allowed for key based SQL injection by blindly delegating non-string lookup to ORM.