### PR TITLE
xss: Prevent Shared XSS Attachments

### DIFF
--- a/file.php
+++ b/file.php
@@ -39,6 +39,18 @@ if ($cfg->isAuthRequiredForFiles() && !$thisclient) {
             require 'secure.inc.php';
         }
     }
+} elseif ($cfg->isAuthRequiredForFiles() && $thisclient) {
+    // If the file is a ticket attachment, only let Users associated with the
+    // ticket view the file. Helps prevent shared XSS attachments.
+    $attachment = $file->attachments->findFirst();
+    if (($thread = $attachment->getObject()->getThread()) && $thread->getObjectType() == 'T') {
+        $recipients = $thread->getObject()->getRecipients();
+        foreach($recipients as $r) {
+            $allowed[] = $r->getEmail();
+        }
+        if (!in_array($thisclient->getEmail(), $allowed))
+            return Http::response(401, __('Unauthorized: You do not have permission to view this file.'));
+    }
 }
 
 // Validate session access hash - we want to make sure the link is FRESH!


### PR DESCRIPTION
This addresses an issue where a User can upload an XSS infected
attachment to a ticket, share the file link with another person, and the
person will be able to view/download the attachment. This adds a check to
see if the attachment is apart of a ticket and if it is then only Users
associated with the ticket can view the attachment. You have to enable
the setting ‘Login Required to view attachments’ for this to work.