### PR TITLE
use i18n to show open/closed status

### DIFF
--- a/include/staff/ticket-tasks.inc.php
+++ b/include/staff/ticket-tasks.inc.php
@@ -83,7 +83,7 @@ if ($count) { ?>
             $assigned=sprintf('<span class="Icon staffAssigned">%s</span>',
                     Format::truncate($task->staff->getName(),40));
 
-        $status = $task->isOpen() ? '<strong>open</strong>': 'closed';
+        $status = $task->isOpen() ? '<strong>'.__('Open').'</strong>': __('Closed');
 
         $title = Format::htmlchars(Format::truncate($task->getTitle(),40));
         $threadcount = $task->getThread() ?


### PR DESCRIPTION
The tasks assigned to a ticket doesn't use i18n to show there status in selected language pack.
![osticket-issue](https://user-images.githubusercontent.com/32037914/30595173-ba251548-9d50-11e7-8349-30fdd7bf7895.JPG)

