### PR TITLE
issue: Check Missing Required Fields

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -310,7 +310,7 @@ implements RestrictedAccess, Threadable {
             return true;
 
         $warning = null;
-        if ($this->getMissingRequiredFields()) {
+        if (self::getMissingRequiredFields($this)) {
             $warning = sprintf(
                     __( '%1$s is missing data on %2$s one or more required fields %3$s and cannot be closed'),
                     __('This ticket'),
@@ -965,17 +965,31 @@ implements RestrictedAccess, Threadable {
         }
     }
 
-    function getMissingRequiredFields() {
+    static function getMissingRequiredFields($ticket) {
+        // Check for fields disabled by Help Topic
+        $disabled = array();
+        foreach ($ticket->entries as $entry) {
+            $extra = JsonDataParser::decode($entry->extra);
+            if (!empty($extra['disable']))
+                $disabled[] = $extra['disable'];
+        }
+        $disabled = !empty($disabled) ? call_user_func_array('array_merge', $disabled) : NULL;
 
-        return $this->getDynamicFields(array(
+        $criteria = array(
                     'answers__field__flags__hasbit' => DynamicFormField::FLAG_ENABLED,
                     'answers__field__flags__hasbit' => DynamicFormField::FLAG_CLOSE_REQUIRED,
                     'answers__value__isnull' => true,
-                    ));
+                    );
+
+        // If there are disabled fields then exclude them
+        if ($disabled)
+            array_push($criteria, Q::not(array('answers__field__id__in' => $disabled)));
+
+        return $ticket->getDynamicFields($criteria, $ticket);
     }
 
     function getMissingRequiredField() {
-        $fields = $this->getMissingRequiredFields();
+        $fields = self::getMissingRequiredFields($this);
         return $fields ? $fields[0] : null;
     }
 

--- a/include/staff/templates/status-options.tmpl.php
+++ b/include/staff/templates/status-options.tmpl.php
@@ -15,7 +15,7 @@ $actions= array(
 
 $states = array('open');
 if ($thisstaff->getRole($ticket ? $ticket->getDeptId() : null)->hasPerm(TicketModel::PERM_CLOSE)
-        && (!$ticket || !$ticket->getMissingRequiredFields()))
+        && (!$ticket || !Ticket::getMissingRequiredFields($ticket)))
     $states = array_merge($states, array('closed'));
 
 $statusId = $ticket ? $ticket->getStatusId() : 0;


### PR DESCRIPTION
This addresses an issue where an integrity field that’s disabled by a Help
Topic will still prevent the closing of a ticket. This is due to the check
for integrity fields on a ticket that have no data. The check includes the
fields that are disabled by Help Topic. This updates the check to
correctly exclude the disabled fields so that the ticket can be closed.