### PR TITLE
Change Date Created into Date Closed

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -41,8 +41,8 @@ $queue_columns = array(
             ),
         'date' => array(
             'width' => '14.6%',
-            'heading' => __('Date Created'),
-            'sort_col' => 'created',
+            'heading' => __('Date Closed'),
+            'sort_col' => 'closed',
             ),
         'subject' => array(
             'width' => '29.8%',


### PR DESCRIPTION
### Description

In Closed Tickets tab, we can view all closed tickets with date when it was closed. When i apply the filter by ticket number it changed into Date Created from Date Closed but it reflects the date closed.

### Steps to Reproduce

1. Click the closed tab tickets
2. Click Sort to Number

**Expected behavior:** When i apply the sorting by ticket number, will show the date closed.

**Actual behavior:** When i apply the sorting by ticket number, it shows Date Created but reflecting the date closed.

### Versions

v1.10
Windows Server
Google Chrome Version 58.0.3029.110

![before filter](https://user-images.githubusercontent.com/16589622/31528161-5c613222-b004-11e7-9ac0-41b184691daf.jpg)
![first code](https://user-images.githubusercontent.com/16589622/31528171-6f66b6bc-b004-11e7-9e38-937b13c5fed6.jpg)
![after filter](https://user-images.githubusercontent.com/16589622/31528218-bb5cd7c2-b004-11e7-97c4-9a531c6ea5ef.jpg)
![must change](https://user-images.githubusercontent.com/16589622/31528224-c251d352-b004-11e7-8ad0-3dc696c8a59d.jpg)
![view status](https://user-images.githubusercontent.com/16589622/31528227-c4f57fdc-b004-11e7-975e-8cce073aa52a.jpg)
