### PR TITLE
Feature Request Agent access restriction to agent directory

### DIFF
--- a/include/class.nav.php
+++ b/include/class.nav.php
@@ -165,7 +165,10 @@ class StaffNav {
                     break;
                 case 'dashboard':
                     $subnav[]=array('desc'=>__('Dashboard'),'href'=>'dashboard.php','iconclass'=>'logs');
-                    $subnav[]=array('desc'=>__('Agent Directory'),'href'=>'directory.php','iconclass'=>'teams');
+					if($staff) {
+						if ($staff->hasPerm(User::PERM_SDIRECTORY, false))
+							$subnav[]=array('desc'=>__('Agent Directory'),'href'=>'directory.php','iconclass'=>'teams');
+					}
                     $subnav[]=array('desc'=>__('My Profile'),'href'=>'profile.php','iconclass'=>'users');
                     break;
                 case 'users':

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1480,6 +1480,7 @@ extends AbstractForm {
             Organization::PERM_EDIT,
             Organization::PERM_DELETE,
             FAQ::PERM_MANAGE,
+			User::PERM_SDIRECTORY,
         );
         return $clean;
     }

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -82,6 +82,7 @@ class UserModel extends VerySimpleModel {
     const PERM_DELETE =     'user.delete';
     const PERM_MANAGE =     'user.manage';
     const PERM_DIRECTORY =  'user.dir';
+	const PERM_SDIRECTORY =  'staff.dir';
 
     static protected $perms = array(
         self::PERM_CREATE => array(
@@ -107,6 +108,11 @@ class UserModel extends VerySimpleModel {
         self::PERM_DIRECTORY => array(
             'title' => /* @trans */ 'User Directory',
             'desc' => /* @trans */ 'Ability to access the user directory',
+            'primary' => true,
+        ),
+		self::PERM_SDIRECTORY => array(
+            'title' => /* @trans */ 'Staff Directory',
+            'desc' => /* @trans */ 'Ability to access the staff directory',
             'primary' => true,
         ),
     );

--- a/include/staff/staff.inc.php
+++ b/include/staff/staff.inc.php
@@ -19,6 +19,7 @@ if ($_REQUEST['a']=='add'){
             Organization::PERM_EDIT,
             Organization::PERM_DELETE,
             FAQ::PERM_MANAGE,
+			User::PERM_SDIRECTORY,
         ));
     }
     $title=__('Add New Agent');


### PR DESCRIPTION
### Description

It started with issue #4003 
The Ability of restricting Agent access to certain department or team directory, since in my case i granted access to agents from different factories that need to provide some feedback about current tickets involving them. I dont want them to have access to all my company directory. 

I got them separated by teams in a single department so i can asign to them as "Factory", every team is a different factory, so also i dont want them to have access to other factory contacts. 

### Steps to Reproduce

1. Create Agent and asign to department
2. Give the created agent limited access to department. 
3. Give/revoke permission Users    Staff Directory — Ability to access the staff directory 
 
![image](https://user-images.githubusercontent.com/32772585/31572702-5f735f72-b071-11e7-94eb-6af537c6daa5.png)

4. login as Newly created agent 
5. select Dashboard and Agent Directory(if not selected Agent Directory will not be shown) 
![image](https://user-images.githubusercontent.com/32772585/31572716-a72379c4-b071-11e7-9cfa-3e40f0dba270.png)

### Versions

Admin panel -> Dashboard -> Information which also additionally gives you information about you server.

osTicket Version | v1.10.1 (9ae093d) —  Up to date
-- | --
Web Server Software | Apache/2.4.23 (Win64) PHP/5.6.25
MySQL Version | 5.7.14
PHP Version | 5.6.25
