### PR TITLE
Changed password suggestion about the minimum length

### DIFF
--- a/include/i18n/en_US/help/tips/install.yaml
+++ b/include/i18n/en_US/help/tips/install.yaml
@@ -54,7 +54,7 @@ username:
 password:
     title: Password
     content: |
-        <p>Admin's password.  Must be five (5) characters or more.</p>
+        <p>Admin's password.  Must be six (6) characters or more.</p>
 
 password2:
     title: Confirm Password

--- a/setup/tips.php
+++ b/setup/tips.php
@@ -32,7 +32,7 @@ require_once('setup.inc.php');
 </div>
 <div id="t7">
 <b><?php echo __('Password');?></b>
-<p><?php echo __("Admin's password.  Must be five (5) characters or more.");?></p>
+<p><?php echo __("Admin's password.  Must be six (6) characters or more.");?></p>
 </div>
 <div id="t8">
 <b><?php echo __('Confirm Password');?></b>


### PR DESCRIPTION
In the installation page, changed the password hint according to the minimum length constraint (6 characters instead of 5)