### PR TITLE
issue: Help Topic SLA

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3321,6 +3321,10 @@ implements RestrictedAccess, Threadable {
             elseif (!isset($vars['teamId']) && $topic->getTeamId())
                 $vars['teamId'] = $topic->getTeamId();
 
+            // Unset slaId if 0 to use the Help Topic SLA or Default SLA
+            if ($vars['slaId'] == 0)
+                unset($vars['slaId']);
+
             //set default sla.
             if (isset($vars['slaId']))
                 $vars['slaId'] = $vars['slaId'] ?: $cfg->getDefaultSLAId();


### PR DESCRIPTION
This addresses issue #3979 where the system uses the default SLA plan if
you don’t choose one in the creation process, even though the selected
Help Topic has one explicitly set. This is due to the method that checks
for an SLA plan selection upon ticket creation. The method uses `isset()`
to determine whether or not the agent selected an SLA Plan. If you don’t
select an SLA plan the `slaId` will return `0` which, even though equals
nothing, is still set. If the `slaId` is set then it will use that SLA
plan or the default one. Since `0` is not an SLA plan, it will use the
default SLA. So this adds a check beforehand to see if `slaId` is `0`. If
so it will unset `slaId` and use either the Help Topic SLA or the default
SLA.