### PR TITLE
issue: Clone Method Called On NonObject

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2029,7 +2029,7 @@ class DatetimeField extends FormField {
         $config = $this->getConfiguration();
         $value = is_int($value)
             ? DateTime::createFromFormat('U', !$config['gmt'] ? Misc::gmtime($value) : $value) ?: $value
-            : $value;
+            : (is_object($value) ? $value : new DateTime($value));
         switch ($method) {
         case 'equal':
             $l = clone $value;


### PR DESCRIPTION
This addresses an issue reported on the Forums where searching for
something by date will throw a PHP fatal error. (eg. Closed Date -> on ->
10/11/2017) This is due to the date value that was chosen is not a
DateTime object. The code that determines the method to search by (has a
value, before, on, etc.) for DateTime fields will sometimes clone the date
value. In order to clone the date value it has to be an object. This
updates the method that sets the date value to always return a DateTime
object for the date value.