### PR TITLE
issue: Httponly Cookies

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -53,7 +53,7 @@ class osTicketSession {
             list($domain) = explode(':', $_SERVER['HTTP_HOST']);
 
         session_set_cookie_params($ttl, ROOT_PATH, $domain,
-            osTicket::is_https());
+            osTicket::is_https(), true);
 
         if (!defined('SESSION_BACKEND'))
             define('SESSION_BACKEND', 'db');


### PR DESCRIPTION
This addresses issue #4015 where osTicket’s cookies aren’t HttpOnly by
default. The HttpOnly flag helps prevent client scripts accessing the
cookie. This updates the method that sets the cookie params to include
the HttpOnly flag.