### PR TITLE
issue: Canned Response Margin

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2912,6 +2912,10 @@ select {
    -moz-border-radius: 4px;
 }
 
+#cannedResp {
+    margin-bottom: 10px;
+}
+
 a.attachment {
     padding-left: 1.2em;
     display: block;


### PR DESCRIPTION
This addresses an annoyance (for me) where the Response box is touching
the Canned Response dropdown. This adds a little space between them so
they get along better.