### PR TITLE
issue: Disable Canned Responses On New Ticket

### DIFF
--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -300,7 +300,7 @@ if ($_POST)
         <tr>
             <td colspan=2>
             <?php
-            if(($cannedResponses=Canned::getCannedResponses())) {
+            if($cfg->isCannedResponseEnabled() && ($cannedResponses=Canned::getCannedResponses())) {
                 ?>
                 <div style="margin-top:0.3em;margin-bottom:0.5em">
                     <?php echo __('Canned Response');?>:&nbsp;


### PR DESCRIPTION
This addresses issue #3971 where disabling the Canned Response feature does
not disable the Canned Responses dropdown on the New Ticket page for
Agents. This adds a check to see if the Canned Response feature is
enabled. If so the dropdown will appear. If not the dropdown will not
appear.