### PR TITLE
issue: accepted the status name as parameter value in setStatus

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1171,8 +1171,11 @@ implements RestrictedAccess, Threadable {
         if ($thisstaff && !($role = $thisstaff->getRole($this->getDeptId())))
             return false;
 
-        if ($status && is_numeric($status))
-            $status = TicketStatus::lookup($status);
+        if ($status)
+            if (is_numeric($status)) {
+                $status = TicketStatus::lookup($status);
+            } else if (is_string($status))
+                $status = TicketStatus::lookup(array('name' => $status));
 
         if (!$status || !$status instanceof TicketStatus)
             return false;


### PR DESCRIPTION
In Ticket class, added in the `setStatus` function the ability to receive the status name in the `$status` parameter.
This change helps for problem reported in comment [#r40874460](https://github.com/osTicket/osTicket/pull/2152#r40874460).