### PR TITLE
Issue: manage.php file migrate fails when files have size=0

### DIFF
--- a/include/class.error.php
+++ b/include/class.error.php
@@ -25,12 +25,15 @@ class BaseError extends Exception {
         global $ost;
 
         parent::__construct(__($message));
-        $message = str_replace(ROOT_DIR, '(root)/', _S($message));
 
-        if ($ost && $ost->getConfig()->getLogLevel() == 3)
-            $message .= "\n\n" . $this->getBacktrace();
+        if ($ost) {
+            $message = str_replace(ROOT_DIR, '(root)/', _S($message));
 
-        $ost->logError($this->getTitle(), $message, static::$sendAlert);
+            if ($ost->getConfig()->getLogLevel() == 3)
+                $message .= "\n\n" . $this->getBacktrace();
+
+            $ost->logError($this->getTitle(), $message, static::$sendAlert);
+        }
     }
 
     function getTitle() {


### PR DESCRIPTION
This addresses issue #3517 where manage.php file migrate fails when files have size = 0. This is due to the BaseError constructor that call `logError()` on `$ost` without controls if this one is not null.