### PR TITLE
issue: Ticket Edit Internal Note

### DIFF
--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -154,7 +154,7 @@ if ($_POST)
     <tbody>
         <tr>
             <th colspan="2">
-                <em><strong><?php echo __('Internal Note');?></strong>: <?php echo __('Reason for editing the ticket (required)');?> <font class="error">&nbsp;<?php echo $errors['note'];?></font></em>
+                <em><strong><?php echo __('Internal Note');?></strong>: <?php echo __('Reason for editing the ticket (optional)');?> <font class="error">&nbsp;<?php echo $errors['note'];?></font></em>
             </th>
         </tr>
         <tr>


### PR DESCRIPTION
This addresses issue #4028 where upon editing a ticket the Internal Note’s
Instructions states that it is required in order to save the changes to
the ticket. In reality this is not the case; the Internal Note is
optional. So this updates the Instructions and changes the word 'required'
to 'optional'.