### PR TITLE
code tag typo's

### DIFF
--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -70,7 +70,7 @@ if ($user && $cfg->isAvatarsEnabled())
             )
         ); ?>
         <span style="max-width:400px" class="faded title truncate"><?php
-            echo $entry->title; ?></span>
+            echo $entry->title; ?>
         </span>
     </div>
     <div class="thread-body no-pjax">

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -468,7 +468,7 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
         <tr>
             <td width="200"><?php
 echo Format::htmlchars($label);
-            ?>:</th>
+            ?>:</td>
             <td><?php
 echo $v;
             ?></td>


### PR DESCRIPTION
This pull request fixes #4034 and #4035, both containing tag typos:

Line: 471 (/th should be /td)
https://github.com/osTicket/osTicket/blob/acac370761c17f1b9d25f0ff55a31ffd36e2d8ba/include/staff/ticket-view.inc.php#L468-L475

Line: 73 (unnecessary /span)
https://github.com/osTicket/osTicket/blob/acac370761c17f1b9d25f0ff55a31ffd36e2d8ba/include/staff/templates/thread-entry.tmpl.php#L72-L74

I apologise beforehand if this has been made in error, first time creating a pull request.