### PR TITLE
Fixes issue with last_update ticket variable

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1878,7 +1878,7 @@ implements RestrictedAccess, Threadable {
                 return new FormattedDate($this->getCloseDate());
             break;
         case 'last_update':
-            return new FormattedDate($this->last_update);
+            return new FormattedDate($this->lastupdate);
         case 'user':
             return $this->getOwner();
         default:


### PR DESCRIPTION
I get an OrmException as field `last_update` doesn't exist, but `lastupdate` does, so it's likely just a typo. 

```
 /var/www/html/osticket/include/class.orm.php:382
Stack trace:
#0 /var/www/htm
l/osticket/include/class.orm.php(386): VerySimpleModel->get('last_update', NULL)

#1 /var/www/html/osticket/include/class.ticket.php(1881): VerySimpleModel->__g
et('last_update')
#2 /var/www/html/osticket/include/class.variable.php(89): Tic
ket->getVar('last_update', Object(VariableReplacer))
#3 /var/www/html/osticket/
include/class.variable.php(134): VariableReplacer->getVar(Object(Ticket), 'last_
update')
#4 /var/www/html/osticket/include/class.variable.php(168): VariableRep
lacer->_resolveVar('ticket.last_upd...')
#5 /var/www/html/osticket/include/clas
s.variable.php(115): VariableReplacer->_parse('Hi %{ticket.nam...')
#6 [interna
l function]: VariableReplacer->replaceVars('Hi %{ticket.nam...')
#7 /var/www/ht
ml/osticket/include/class.variable.php(113): array_map(Array, Array)
#8 /var/ww
w/html/osticket/include/class.osticket.php(147): VariableReplacer->replaceVars(A
rray)
#9 / in /var/www/html/osticket/include/class.orm.php on line 382, referer
: http://localhost:8080/scp/tickets.php?id=47
```

Removing that underscore, no error, works fine.