### PR TITLE
issue: Organization User List Pages Link

### DIFF
--- a/include/staff/templates/users.tmpl.php
+++ b/include/staff/templates/users.tmpl.php
@@ -36,7 +36,10 @@ $pageNav=new Pagenate($total,$page,PAGE_LIMIT);
 $qstr = '&amp;'. Http::build_query($qs);
 $qs += array('sort' => $_REQUEST['sort'], 'order' => $_REQUEST['order']);
 
-$pageNav->setURL('users.php', $qs);
+if (strpos($_SERVER['REQUEST_URI'], 'orgs.php') !== false)
+    $pageNav->setURL('orgs.php?id='.$org->getId().'&amp;', $qs);
+else
+    $pageNav->setURL('users.php', $qs);
 //Ok..lets roll...create the actual query
 $qstr .= '&amp;order='.($order=='DESC' ? 'ASC' : 'DESC');
 


### PR DESCRIPTION
This addresses an issue where clicking on Page 2 or above in an
Organization’s Users tab will bring you out of the User tab and put you in
the User Directory. This was caused by the setUrl() method as it only set
the URL to the User Directory. This adds a check to see if the Agent is
within the Organization tab and if so it’ll set the correct URL.