### PR TITLE
issue: User Registration Form

### DIFF
--- a/account.php
+++ b/account.php
@@ -77,6 +77,10 @@ elseif ($_POST) {
             '</strong></a>'));
         $errors['err'] = __('Unable to register account. See messages below');
     }
+    elseif (!$addr)
+        $errors['email'] = sprintf(__('%s is a required field'), $user_form->getField('email')->getLocal('label'));
+    elseif (!$user_form->getField('name')->getClean())
+        $errors['name'] = sprintf(__('%s is a required field'), $user_form->getField('name')->getLocal('label'));
     // Users created from ClientCreateRequest
     elseif (isset($_POST['backend']) && !($user = User::fromVars($user_form->getClean())))
         $errors['err'] = __('Unable to create local account. See messages below');


### PR DESCRIPTION
This addresses issue #4043 where the User registration form does not
validate whether or not the required fields have data. This adds checks
for data in the Email field and Name field. If there is no data it will
not let you create an account.