### PR TITLE
issue: File Upload Bypass

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -381,9 +381,15 @@ class DynamicFormsAjaxAPI extends AjaxController {
     }
 
     function attach() {
+        global $thisstaff;
+
+        $config = DynamicFormField::objects()
+            ->filter(array('type__contains'=>'thread'))
+            ->first()->getConfiguration();
         $field = new FileUploadField();
+        $field->_config = $config;
         return JsonDataEncoder::encode(
-            array('id'=>$field->ajaxUpload())
+            array('id'=>$field->ajaxUpload($thisstaff ? true : false))
         );
     }
 

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2837,7 +2837,7 @@ class FileUploadField extends FormField {
 
         // Check MIME type - file ext. shouldn't be solely trusted.
         if ($type && $config['__mimetypes']
-                && in_array($type, $config['__mimetypes']))
+                && in_array($type, $config['__mimetypes'], true))
             return true;
 
         // Return true if all file types are allowed (.*)


### PR DESCRIPTION
This addresses an issue where someone can bypass the file restrictions on
the file upload field in the Client Portal. This adds the allowed
extensions and file types to the field options so that User’s cannot
upload anything other than the allowed file types.