### PR TITLE
issue: Helpdesk Status Help Tip

### DIFF
--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -18,8 +18,7 @@ helpdesk_status:
     content: >
         If the status is changed to <span
         class="doc-desc-opt">Offline</span>, the client interface will be
-        disabled.  This does not however affect any normal Agent interaction
-        with the Agent Panel.
+        disabled.  Only Admins will be able to access the system.
 
 helpdesk_url:
     title: Helpdesk URL


### PR DESCRIPTION
This addresses an issue mentioned on the forums where the Helpdesk Status
setting’s Help Tip is wrong. It states that if the system is in Offline
mode then Agents can still interact with the system when in reality only
Admins can interact with the system. This updates the Help Tip to inform
the Agent that only Admins will be able to access the system.