### PR TITLE
issue: Last Updated Sorting

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -345,7 +345,7 @@ case 'priority,updated':
     // Fall through for columns defined for `updated`
 case 'updated':
     $queue_columns['date']['heading'] = __('Last Updated');
-    $queue_columns['date']['sort'] = $sort_cols;
+    $queue_columns['date']['sort'] = 'updated';
     $queue_columns['date']['sort_col'] = $date_col = 'lastupdate';
     $tickets->order_by('lastupdate', $orm_dir);
     break;


### PR DESCRIPTION
This addresses issue #4058 where the Last Updated column header's sorting
does not function properly. It adds `sort=priority,updated` to the query
which breaks the sorting for the column. This updates the column's sorting
option to `updated` which should give you the proper sorting for the
header.