### PR TITLE
issue: Disabled & Private Help Topic

### DIFF
--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -418,8 +418,8 @@ implements TemplateVariable {
         $this->status_id = $vars['status_id'] ?: 0;
         $this->sla_id = $vars['sla_id'] ?: 0;
         $this->page_id = $vars['page_id'] ?: 0;
-        $this->isactive = !!$vars['isactive'];
-        $this->ispublic = !!$vars['ispublic'];
+        $this->isactive = $vars['isactive'];
+        $this->ispublic = $vars['ispublic'];
         $this->sequence_id = $vars['custom-numbers'] ? $vars['sequence_id'] : 0;
         $this->number_format = $vars['custom-numbers'] ? $vars['number_format'] : '';
         $this->flags = $vars['custom-numbers'] ? self::FLAG_CUSTOM_NUMBERS : 0;


### PR DESCRIPTION
This addresses issue #3538 where upon adding a new Help Topic that is
Disabled and Private/Internal the settings do not save. Instead the Help
Topic will be Active and Public always. This happens because the way we
assign them to variables is with "double not" operators `!!`. These return
true/false values which is not what we need. We need the actual integer
for the status and type. This removes the "double not" operators to assign
the correct integer value to the variables so that the correct status and
type is saved.