### PR TITLE
issue: User Password Reset

### DIFF
--- a/pwreset.php
+++ b/pwreset.php
@@ -73,12 +73,8 @@ elseif ($_GET['token']) {
     else
         Http::redirect('index.php');
 }
-elseif ($cfg->allowPasswordReset()) {
-    $banner = __('Enter your username or email address below');
-}
 else {
-    $_SESSION['_staff']['auth']['msg']=__('Password resets are disabled');
-    return header('Location: index.php');
+    $banner = __('Enter your username or email address below');
 }
 
 $nav = new UserNav();


### PR DESCRIPTION
This addresses issue #4030 where if the Allow Password Reset setting for
Agents is disabled it will also affect Users. That means Users will not be
able to reset their password. This updates the User’s password reset page
to ignore that setting so that User’s will still be able to reset their
password.