### PR TITLE
issue: Private FAQs In Search Sidebar

### DIFF
--- a/include/client/kb-search.inc.php
+++ b/include/client/kb-search.inc.php
@@ -45,6 +45,7 @@ foreach (Topic::objects()
             <div class="header"><?php echo __('Categories'); ?></div>
 <?php
 foreach (Category::objects()
+    ->exclude(Q::any(array('ispublic'=>Category::VISIBILITY_PRIVATE)))
     ->annotate(array('faqs_count'=>SqlAggregate::count('faqs')))
     ->filter(array('faqs_count__gt'=>0))
     as $C) { ?>


### PR DESCRIPTION
This addresses and issue on the forums where upon searching for an FAQ,
Private FAQ Categories will appear in the sidebar. This updates the search
sidebar to exclude the Private FAQ Categories.