### PR TITLE
issue: Send Login Errors Still Sends

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -887,8 +887,9 @@ class StaffAuthStrikeBackend extends  AuthStrikeBackend {
                    ._S('Time').": ".date('M j, Y, g:i a T')."\n\n"
                    ._S('Attempts').": {$authsession['strikes']}\n"
                    ._S('Timeout').": ".sprintf(_N('%d minute', '%d minutes', $timeout), $timeout)."\n\n";
+            $admin_alert = ($cfg->alertONLoginError() == 1) ? TRUE : FALSE;
             $ost->logWarning(sprintf(_S('Excessive login attempts (%s)'),$username),
-                    $alert, $cfg->alertONLoginError());
+                    $alert, $admin_alert);
             return new AccessDenied(__('Forgot your login info? Contact Admin.'));
         //Log every other third failed login attempt as a warning.
         } elseif($authsession['strikes']%3==0) {
@@ -947,14 +948,15 @@ class UserAuthStrikeBackend extends  AuthStrikeBackend {
                     _S('IP').": {$_SERVER['REMOTE_ADDR']}\n".
                     _S('Time').": ".date('M j, Y, g:i a T')."\n\n".
                     _S('Attempts').": {$authsession['strikes']}";
-            $ost->logError(_S('Excessive login attempts (user)'), $alert, ($cfg->alertONLoginError()));
+            $admin_alert = ($cfg->alertONLoginError() == 1 ? TRUE : FALSE);
+            $ost->logError(_S('Excessive login attempts (user)'), $alert, $admin_alert);
             return new AccessDenied(__('Access denied'));
         } elseif($authsession['strikes']%3==0) { //Log every third failed login attempt as a warning.
             $alert=_S('Username').": {$username}\n".
                     _S('IP').": {$_SERVER['REMOTE_ADDR']}\n".
                     _S('Time').": ".date('M j, Y, g:i a T')."\n\n".
                     _S('Attempts').": {$authsession['strikes']}";
-            $ost->logWarning(_S('Failed login attempt (user)'), $alert);
+            $ost->logWarning(_S('Failed login attempt (user)'), $alert, false);
         }
 
     }


### PR DESCRIPTION
This addresses issue #4073 where Disabling the 'Excessive failed login
attempts' option in the Ticket Alert settings will still send the Admin
Excessive failed login alerts. This is due to the method that checks if
the setting is Enabled returns `0` or `1` not `TRUE` or `FALSE`. So this
updates the section of code to return `FALSE` for `0` and `TRUE` for `1`
so that it properly disables/enables the alerts.