### PR TITLE
Cleaned filter_action data on filter delete

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -355,6 +355,7 @@ class Filter {
         $sql='DELETE FROM '.FILTER_TABLE.' WHERE id='.db_input($id).' LIMIT 1';
         if(db_query($sql) && ($num=db_affected_rows())) {
             db_query('DELETE FROM '.FILTER_RULE_TABLE.' WHERE filter_id='.db_input($id));
+            db_query('DELETE FROM '.FILTER_ACTION_TABLE.' WHERE filter_id='.db_input($id));
         }
 
         return $num;


### PR DESCRIPTION
With this update, when a `Filter` is deleted are cleaned also **Filter Actions** associated to it. Otherwise are deleted only filter and relative Filter Rules.