### PR TITLE
deploy: Failed Bootstrap Inclusion

### DIFF
--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -210,7 +210,7 @@ class Unpacker extends Module {
         ), $pipes);
 
         fwrite($pipes[0], "<?php
-        include '{$this->destination}/bootstrap.php';
+        include '{$this->source}/bootstrap.php';
         print INCLUDE_DIR;
         ");
         fclose($pipes[0]);


### PR DESCRIPTION
This addresses issue #3741 where deploying osTicket from the command line
will throw a fatal error the first time ran. The error is caused by a
failed inclusion of the `bootstrap.php` file. This is because it’s trying
to include the file from the destination folder which doesn’t exist there
yet. This updates the deploy method to use the source bootstrap file
instead of the destination bootstrap file which already exists.