### PR TITLE
Minor fix: into DynamicFormField added missing "return" construct

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -887,7 +887,7 @@ class DynamicFormField extends VerySimpleModel {
             return $this->save();
 
         // Delete the field for realz
-        parent::delete();
+        return parent::delete();
 
     }
 


### PR DESCRIPTION
In the `delete()` function, there wasn't the _return_ construct  to propagate the result got from `parent::delete()`