### PR TITLE
issue: Section Break Hint

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3803,7 +3803,7 @@ class SectionBreakWidget extends Widget {
     function render($options=array()) {
         ?><div class="form-header section-break"><h3><?php
         echo Format::htmlchars($this->field->getLocal('label'));
-        ?></h3><em><?php echo Format::htmlchars($this->field->getLocal('hint'));
+        ?></h3><em><?php echo Format::display($this->field->getLocal('hint'));
         ?></em></div>
         <?php
     }


### PR DESCRIPTION
This addresses an issue where the Help Text for Section Break fields does
not display custom Redactor styling correctly. Instead of displaying the
properly formatted Redactor content with it's styling it displays the
entire html for the Redactor content. This was due to the format method
used for the Section Break Field's Help Text. This updates the method from
`Format::htmlchars()` to `Format::display()` which displays the properly
formatted content. The content is also sanitized by `Format::sanitize()`
before saving to the database to avoid any chance of XSS.