### PR TITLE
Issue: SQL Error Unknown column '__relevance__' in 'order clause'

### DIFF
--- a/include/ajax.orgs.php
+++ b/include/ajax.orgs.php
@@ -32,7 +32,7 @@ class OrgsAjaxAPI extends AjaxController {
         $q = $_REQUEST['q'];
         $limit = isset($_REQUEST['limit']) ? (int) $_REQUEST['limit']:25;
 
-        if (strlen($q) < 3)
+        if (strlen(Format::searchable($q)) < 3)
             return $this->encode(array());
 
         $orgs = Organization::objects()

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -51,7 +51,7 @@ class TicketsAjaxAPI extends AjaxController {
 
         $q = $_REQUEST['q'];
 
-        if (strlen($q) < 3)
+        if (strlen(Format::searchable($q)) < 3)
             return $this->encode(array());
 
         global $ost;

--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -39,7 +39,7 @@ class UsersAjaxAPI extends AjaxController {
         $emails=array();
         $matches = array();
 
-        if (strlen($q) < 3)
+        if (strlen(Format::searchable($q)) < 3)
             return $this->encode(array());
 
         if (!$type || !strcasecmp($type, 'remote')) {


### PR DESCRIPTION
This addresses issue #2655:
some research (e.g. searching for 3 or more whitespaces) raise the error `Unknown column '__relevance__' in 'order clause'`