### PR TITLE
xss: Prevent XSS via AJAX

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -22,7 +22,7 @@ class DynamicFormsAjaxAPI extends AjaxController {
             if (!is_array($_SESSION[':form-data']))
                 $_SESSION[':form-data'] = array();
             $_SESSION[':form-data'] = array_merge($_SESSION[':form-data'],
-                    Format::htmlchars($_GET));
+                    Format::htmlchars($_GET, true));
         }
 
         foreach ($topic->getForms() as $form) {

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -316,7 +316,7 @@ class Format {
             'balance' => $options['balance'],
             'comment' => 1, //Remove html comments (OUTLOOK LOVE THEM)
             'tidy' => -1,
-            'deny_attribute' => 'id',
+            'deny_attribute' => 'id,onmouseover,alert',
             'schemes' => 'href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, telnet; *:file, http, https; src: cid, http, https, data',
             'hook_tag' => function($e, $a=0) { return Format::__html_cleanup($e, $a); },
             'elements' => '*+iframe',
@@ -349,7 +349,7 @@ class Format {
         static $phpversion = null;
 
         if (is_array($var))
-            return array_map(array('Format', 'htmlchars'), $var);
+            return array_map(array('Format', 'htmlchars'), $var, array_fill(0, count($var), $sanitize));
 
         if ($sanitize)
             $var = Format::sanitize($var);


### PR DESCRIPTION
This addresses a vulnerability where a User can perform XSS via an AJAX
request. This removes any `onmouseover` and `alert` events from the
requests.