### PR TITLE
oops: Fix randNumber()

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -52,12 +52,14 @@ class Misc {
     }
 
     /* Helper used to generate ticket IDs */
-    function randNumber($len=6,$start=false,$end=false) {
+    function randNumber($len=6) {
+        $number = '';
+        for ($i=0; $i<$len; $i++) {
+            $min = ($i == 0) ? 1 : 0;
+            $number .= mt_rand($min, 9);
+        }
 
-        $start=(!$len && $start)?$start:str_pad(1,$len,"0",STR_PAD_RIGHT);
-        $end=(!$len && $end)?$end:str_pad(9,$len,"9",STR_PAD_RIGHT);
-
-        return mt_rand($start,$end);
+        return (int) $number;
     }
 
     /* misc date helpers...this will go away once we move to php 5 */


### PR DESCRIPTION
This addresses an issue where the `randNumber()` function would crash on
32-Bit systems if the ticket format was set to a really high amount of
digits (eg. ###################). This is because the `max()` value that
was being passed to `mt_rand()` exceeded the `mt_getrandmax()` limit which
caused an error. This updates the function to generate a random number for
each digit to avoid the `mt_getrandmax()` limit.