### PR TITLE
Open Task Shows "Reopen" Option

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -146,7 +146,7 @@ if ($task->isOverdue())
                 <ul>
 
                     <?php
-                    if ($task->isOpen()) { ?>
+                    if ($task->isClosed()) { ?>
                     <li>
                         <a class="no-pjax task-action"
                             href="#tasks/<?php echo $task->getId(); ?>/reopen"><i


### PR DESCRIPTION
An open task on a ticket gives the user the option to "Reopen". A closed task gives the user the option to "Close". Changing isOpen() to isClosed() fixes the logic.