### PR TITLE
oops: Fix System Timezone Variable

### DIFF
--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -115,7 +115,11 @@ function db_version() {
 }
 
 function db_timezone() {
-    return db_get_variable('system_time_zone', 'global');
+    $timezone = db_get_variable('time_zone', 'global');
+    if ($timezone == 'SYSTEM')
+        $timezone = db_get_variable('system_time_zone', 'global');
+
+    return $timezone;
 }
 
 function db_get_variable($variable, $type='session') {


### PR DESCRIPTION
This addresses an issue where people are getting the incorrect time on tickets even though they have all the timezones set correctly. The current MySQL variable the system uses to determine the timezone is `system_time_zone`. This variable is set by the server and sometimes cannot be updated properly (or cannot be updated at all). 

This changes the variable from `system_time_zone` to `time_zone` so if in the event the system returns the incorrect time and they can't update the server timezone properly, they can just change the `@@global.time_zone` and `@@session.time_zone` MySQL variables and should get the correct time.