### PR TITLE
Fix for PHP7.0 warning on running Cron Job

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4329,7 +4329,7 @@ class AssignmentForm extends Form {
         return !$this->errors();
     }
 
-    function render($options) {
+    function render($staff=true, $title=false, $options=array()) {
 
         switch(strtolower($options['template'])) {
         case 'simple':
@@ -4459,7 +4459,7 @@ class TransferForm extends Form {
         return !$this->errors();
     }
 
-    function render($options) {
+    function render($staff=true, $title=false, $options=array()) {
 
         switch(strtolower($options['template'])) {
         case 'simple':


### PR DESCRIPTION
When running Cron Job on PHP7 it creates warning:
PHP Warning:  Declaration of AssignmentForm
PHP Warning:  Declaration of TransferForm
Related to issue :
https://github.com/osTicket/osTicket/issues/4126

Reason is render function from AssignForm and FransferForm is overriding render in Form Class, but don't have the same declaration.
This pull request fix this.