### PR TITLE
Fix for PHP7.0 warning on running Cron Job

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4329,7 +4329,7 @@ class AssignmentForm extends Form {
         return !$this->errors();
     }
 
-    function render($options) {
+    function render($staff=true, $title=false, $options=array()) {
 
         switch(strtolower($options['template'])) {
         case 'simple':
@@ -4459,7 +4459,7 @@ class TransferForm extends Form {
         return !$this->errors();
     }
 
-    function render($options) {
+    function render($staff=true, $title=false, $options=array()) {
 
         switch(strtolower($options['template'])) {
         case 'simple':


### PR DESCRIPTION
This pull is fixing the PHP warning on PHP7 when running cron.php
PHP Warning:  Declaration of AssignmentForm
PHP Warning:  Declaration of TransferForm

The 2 render functions is overwriting the Form Class render function, but with missing parameters.