### PR TITLE
Fix: stuck on "loading...." when closing a TASK within a ticket

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -666,7 +666,10 @@ $(function() {
             }
         })
         .done(function() { })
-        .fail(function() { });
+        .fail(function() { })
+        .always(function() {
+            $('#overlay, #loading').hide();
+        });
      });
     <?php
     if ($ticket) { ?>


### PR DESCRIPTION
This addresses issue #3468 where page is stuck on "loading...." when posting a reply or note at a TASK within a ticket.
_#overlay_ and _#loading_ were shown after the form submission and were no longer hidden.