### PR TITLE
issue: CSRF In users.inc.php URL

### DIFF
--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -312,6 +312,11 @@ $(function() {
         goBaby($(this).attr('href').substr(1));
         return false;
     });
+
+    // Remove CSRF Token From GET Request
+    document.querySelector("form[action='users.php']").onsubmit = function() {
+        document.getElementsByName("__CSRFToken__")[0].remove();
+    };
 });
 </script>
 


### PR DESCRIPTION
This addresses an issue where the CSRF Token is displayed in the URL
when you preform a search in the Users Tab. This removes the token from the
request which removes it from the URL.