### PR TITLE
issue: AJAX Reflected XSS

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -15,6 +15,9 @@ class DynamicFormsAjaxAPI extends AjaxController {
     }
 
     function getFormsForHelpTopic($topic_id, $client=false) {
+        if (!$_SERVER['HTTP_REFERER'])
+            Http::response(403, 'Forbidden.');
+
         if (!($topic = Topic::lookup($topic_id)))
             Http::response(404, 'No such help topic');
 


### PR DESCRIPTION
This addresses an issue where you can exploit XSS in the help-topic AJAX
request. This adds a check for a refferal URL and if none it will return
a 403 Forbidden Response.