### PR TITLE
issue: Outlook _MailEndCompose

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -306,8 +306,9 @@ class Format {
                   ':<!DOCTYPE[^>]+>:',          # <!DOCTYPE ... >
                   ':<\?[^>]+>:',                # <?xml version="1.0" ... >
                   ':<html[^>]+:i',              # drop html attributes
+                  ':<(a|span) (name|style)="(mso-bookmark\:)?_MailEndCompose">(.+)?<\/(a|span)>:', # Drop _MailEndCompose
             ),
-            array('', '', '', '', '<html'),
+            array('', '', '', '', '<html', '$4'),
             $html);
 
         // HtmLawed specific config only


### PR DESCRIPTION
This addresses an issue where Outlook adds weird (and seemingly random)
_MailEndCompose tags to the email body which turns unwanted content into
links. This adds the _MailEndCompose tag to Format::sanitize() so it
will be removed from the email body.