### PR TITLE
upgrader: Flush Cache On Upgrade

### DIFF
--- a/include/class.upgrader.php
+++ b/include/class.upgrader.php
@@ -362,6 +362,10 @@ class StreamUpgrader extends SetupWizard {
         if(!($max_time = ini_get('max_execution_time')))
             $max_time = 300; //Apache/IIS defaults.
 
+        // Drop any model meta cache to ensure model changes do not cause
+        // crashes
+        ModelMeta::flushModelCache();
+
         // Apply up to five patches at a time
         foreach (array_slice($patches, 0, 5) as $patch) {
             //TODO: check time used vs. max execution - break if need be


### PR DESCRIPTION
This addresses an issue where the Upgrader will sometimes use an outdated
cached object and throw an error. This adds a the function to clear the
Model Cache every time the Upgrader runs an Upgrade Patch to get fresh
objects.