### PR TITLE
i18n: FAQ Local Questions & Answers

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -79,6 +79,9 @@ class FAQ extends VerySimpleModel {
     function getTeaser() {
         return Format::truncate(Format::striptags($this->answer), 150);
     }
+    function getLocalTeaser() {
+        return Format::truncate(Format::striptags($this->getLocalAnswer()), 150);
+    }
     function getSearchableAnswer() {
         return ThreadEntryBody::fromFormattedText($this->answer, 'html')
             ->getSearchable();

--- a/include/client/faq-category.inc.php
+++ b/include/client/faq-category.inc.php
@@ -29,7 +29,7 @@ foreach ($faqs as $F) {
         $attachments=$F->has_attachments?'<span class="Icon file"></span>':'';
         echo sprintf('
             <li><a href="faq.php?id=%d" >%s &nbsp;%s</a></li>',
-            $F->getId(),Format::htmlchars($F->question), $attachments);
+            $F->getId(),Format::htmlchars($F->getLocalQuestion()), $attachments);
     }
     echo '  </ol>
          </div>';

--- a/index.php
+++ b/index.php
@@ -61,14 +61,14 @@ if ($cats->all()) { ?>
     <div class="featured-category front-page">
         <i class="icon-folder-open icon-2x"></i>
         <div class="category-name">
-            <?php echo $C->getName(); ?>
+            <?php echo $C->getLocalName(); ?>
         </div>
 <?php foreach ($C->getTopArticles() as $F) { ?>
         <div class="article-headline">
             <div class="article-title"><a href="<?php echo ROOT_PATH;
                 ?>kb/faq.php?id=<?php echo $F->getId(); ?>"><?php
-                echo $F->getQuestion(); ?></a></div>
-            <div class="article-teaser"><?php echo $F->getTeaser(); ?></div>
+                echo $F->getLocalQuestion(); ?></a></div>
+            <div class="article-teaser"><?php echo $F->getLocalTeaser(); ?></div>
         </div>
 <?php } ?>
     </div>


### PR DESCRIPTION
This addresses two issues, with the first being the Featured FAQs on the
client portal are not translated when selecting another language. The
other issue is when you click the FAQ Category to see all FAQs the FAQ
names are not translated. This adds the correct `getLocal*` functions to
the FAQ templates to get the correctly translated Questions & Answers.
This also adds a new function called `getLocalTeaser` which will return
the truncated, translated FAQ answer.