### PR TITLE
orm: queryset: Fix circular reference error

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -1606,15 +1606,22 @@ extends CachedResultSet {
 
 class ModelInstanceManager
 implements IteratorAggregate {
-    var $queryset;
     var $model;
     var $map;
+    var $resource;
+    var $annnotations;
+    var $defer;
 
     static $objectCache = array();
 
     function __construct(QuerySet $queryset) {
-        $this->queryset = $queryset;
         $this->model = $queryset->model;
+        $this->resource = $queryset->getQuery();
+        $cache = !$queryset->hasOption(QuerySet::OPT_NOCACHE);
+        $this->resource->setBuffered($cache);
+        $this->map = $this->resource->getMap();
+        $this->annotations = $queryset->annotations;
+        $this->defer = $queryset->defer;
     }
 
     function cache($model) {
@@ -1669,7 +1676,7 @@ implements IteratorAggregate {
                 return null;
             }
         }
-        $annotations = $this->queryset->annotations;
+        $annotations = $this->annotations;
         $extras = array();
         // For annotations, drop them from the $fields list and add them to
         // an $extras list. The fields passed to the root model should only
@@ -1688,7 +1695,7 @@ implements IteratorAggregate {
             // Construct and cache the object
             $m = $modelClass::$meta->newInstance($fields);
             // XXX: defer may refer to fields not in this model
-            $m->__deferred__ = $this->queryset->defer;
+            $m->__deferred__ = $this->defer;
             $m->__onload();
             if ($cache)
                 $this->cache($m);
@@ -1758,10 +1765,6 @@ implements IteratorAggregate {
     }
 
     function getIterator() {
-        $this->resource = $this->queryset->getQuery();
-        $this->map = $this->resource->getMap();
-        $cache = !$this->queryset->hasOption(QuerySet::OPT_NOCACHE);
-        $this->resource->setBuffered($cache);
         $func = ($this->map) ? 'getRow' : 'getArray';
         $func = array($this->resource, $func);
 


### PR DESCRIPTION
In my further development of the ORM, I found this bug. It's a circular reference between the ModelInstanceManager and the QuerySet instances. It prevents the query statement and database resources from being cleaned up automatically when the query leaves scope (ie. function exits) and there are still records to be fetched from the database (for instance, if only the first record of a recordset with multiple rows was fetched).

This fixes an error where the ModelInstanceManager maintained a reference to the QuerySet instance, and the QuerySet instance managed a reference to the ModelInstanceManager instance (if it's the iterator for the query). Because of the circular reference, if the iterator is not exhausted, then the resource is not closed and the query remains open. This wastes memory and prevents some other queries from running after such a situation happens.

This addresses the issue by removing the circular reference between the QuerySet and the ModelInstanceManager.