### PR TITLE
issue: Files - deleteOrphans()

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -635,7 +635,7 @@ class AttachmentFile extends VerySimpleModel {
             ->filter(array(
                 'attachments__object_id__isnull' => true,
                 'ft' => 'T',
-                'created__gt' => new DateTime('now -1 day'),
+                'created__lt' => SqlFunction::NOW()->minus(SqlInterval::DAY(1)),
             ));
 
         foreach ($files as $f) {


### PR DESCRIPTION
This addresses the issue where files were being deleted before being sent
out in Agent responses. This was due to a bug in the query that gets the
orphaned files. This query was getting files created within the last 24
hours not after the last 24 hours. The query also had another bug that
would use the time from PHP instead of MySQL which could cause issues.
This updates the query as per @greezybacon's suggestions to delete
orphaned files that were created more than 24 hours ago.