### PR TITLE
tests: Git Conflict Markers

### DIFF
--- a/setup/test/tests/test.git-conflicts.php
+++ b/setup/test/tests/test.git-conflicts.php
@@ -1,0 +1,27 @@
+<?php
+require_once "class.test.php";
+
+class GitConflicts extends Test {
+    var $name = "Git Conflicts Checks";
+
+    function testFindGitConflicts() {
+        $regex = '/^[\t ]*?<{3,} ?HEAD[\t ]*?|^[\t ]*?>{3,}[\t ]*?/m';
+        foreach ($this->getAllScripts('*') as $s) {
+            $matches = array();
+            $content = file_get_contents($s);
+            if (preg_match_all($regex,
+                    $content, $matches,
+                    PREG_OFFSET_CAPTURE) > 0) {
+                foreach ($matches[0] as $match) {
+                    $this->fail(
+                        $s,
+                        $this->line_number_for_offset($content, $match[1]),
+                        trim($match[0]));
+                }
+            }
+            else $this->pass();
+        }
+    }
+}
+return 'GitConflicts';
+?>


### PR DESCRIPTION
This adds a test for Git Conflict Markers to prevent committing unfinished
merge conflicts. This will find any `<<<<<<< HEAD`/`>>>>>>>` markers
and will fail out with the line of code, filename and line number.