### PR TITLE
PHP 7.1 compatibility: session handler return var

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -190,7 +190,7 @@ extends SessionBackend {
         catch (OrmException $e) {
             return false;
         }
-        return $this->data->session_data;
+        return (string) $this->data->session_data;
     }
 
     function update($id, $data){
@@ -282,7 +282,7 @@ extends SessionBackend {
         // No session data on record -- new session
         $this->isnew = $data === false;
 
-        return $data;
+        return (string) $data;
     }
 
     function update($id, $data) {


### PR DESCRIPTION
Read handler needs to return a string in 7.1. So this pull adds explicit `(string)` casts to the success return on the custom handlers.

Compare with return value section here: http://php.net/manual/en/sessionhandlerinterface.read.php

Conveniently: Fixes login session errors when running on PHP 7.1.15-0ubuntu0.17.10.1
