### PR TITLE
issue: Prevent Click Jacking

### DIFF
--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -6,6 +6,7 @@ $signin_url = ROOT_PATH . "login.php"
 $signout_url = ROOT_PATH . "logout.php?auth=".$ost->getLinkToken();
 
 header("Content-Type: text/html; charset=UTF-8");
+header("X-Frame-Options: SAMEORIGIN");
 if (($lang = Internationalization::getCurrentLanguage())) {
     $langs = array_unique(array($lang, $cfg->getPrimaryLanguage()));
     $langs = Internationalization::rfc1766($langs);

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -1,5 +1,6 @@
 <?php
 header("Content-Type: text/html; charset=UTF-8");
+header("X-Frame-Options: SAMEORIGIN");
 
 $title = ($ost && ($title=$ost->getPageTitle()))
     ? $title : ('osTicket :: '.__('Staff Control Panel'));

--- a/include/staff/login.header.php
+++ b/include/staff/login.header.php
@@ -1,5 +1,6 @@
 <?php
 defined('OSTSCPINC') or die('Invalid path');
+header("X-Frame-Options: SAMEORIGIN");
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">

--- a/setup/inc/header.inc.php
+++ b/setup/inc/header.inc.php
@@ -1,3 +1,4 @@
+<?php header("X-Frame-Options: SAMEORIGIN"); ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
     "http://www.w3.org/TR/html4/loose.dtd">
 <html <?php


### PR DESCRIPTION
This addresses a vulnerability where there was no `X-Frame-Options` header
which could potentially allow click jacking. This adds the
`X-Frame-Options: SAMEORIGIN` header so it will remove any chance of click
jacking. According to Mozilla Developer Docs:
```
SAMEORIGIN
The page can only be displayed in a frame on the same origin as the page
itself.
```