### PR TITLE
Rest api added for open thread listing

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -24,6 +24,9 @@ require_once INCLUDE_DIR."class.dispatcher.php";
 
 $dispatcher = patterns('',
         url_post("^/tickets\.(?P<format>xml|json|email)$", array('api.tickets.php:TicketApiController','create')),
+        url_get("^/threads\.(?P<format>xml|json)$", array('api.threads.php:ThreadApiController','report')),
+        url_get("^/thread\.(?P<format>xml|json)/(?P<id>\d+)$", array('api.threads.php:ThreadApiController','get')),
+        url_get("^/thread\.(?P<format>xml|json)/(?P<id>\d+)/entries$", array('api.threads.php:ThreadApiController','getEntries')),
         url('^/tasks/', patterns('',
                 url_post("^cron$", array('api.cron.php:CronApiController', 'execute'))
          ))

--- a/include/api.threads.php
+++ b/include/api.threads.php
@@ -1,0 +1,91 @@
+<?php
+
+include_once INCLUDE_DIR.'class.api.php';
+include_once INCLUDE_DIR.'class.thread.php';
+
+class ThreadApiController extends ApiController {
+
+    function report($format) {
+
+        if(!($key=$this->requireApiKey()))
+            return $this->exerr(401, __('API key not authorized'));
+
+
+        # Parse request query string
+        $filter = array();
+        parse_str($_SERVER['QUERY_STRING'], $filter);
+        foreach ($filter as $key => $value) {
+            $filter[$key . "__exact"] = $value;
+            unset($filter[$key]);
+        }
+
+        try {
+            if (count($filter) == 0)
+                $tasks = Thread::objects()->values()->all();
+            else
+                $tasks = Thread::objects()->filter($filter)->values()->all();
+        } catch (InconsistentModelException $e) {
+            Http::response(400, $e->getMessage());
+            exit;
+        }
+        $encoder = null;
+        $contentType = null;
+        switch(strtolower($format)) {
+            case 'json':
+                $encoder = new JsonDataEncoder();
+                $contentType = 'application/json';
+                break;
+            default:
+                $this->exerr(415, __('Unsupported response format'));
+        }
+
+        Http::response(200,  $encoder->encode($tasks), $contentType);
+        exit;
+    }
+
+    function get($format, $id) {
+
+        if(!($key=$this->requireApiKey()))
+            return $this->exerr(401, __('API key not authorized'));
+
+        $thread = Thread::objects()->filter(array('id__exact' => $id ))->values()->one();
+
+        $encoder = null;
+        $contentType = null;
+        switch(strtolower($format)) {
+            case 'json':
+                $encoder = new JsonDataEncoder();
+                $contentType = 'application/json';
+                break;
+            default:
+                $this->exerr(415, __('Unsupported response format'));
+        }
+
+        Http::response(200,  $encoder->encode($thread), $contentType);
+        exit;
+    }
+
+   function getEntries($format, $id) {
+       if(!($key=$this->requireApiKey()))
+           return $this->exerr(401, __('API key not authorized'));
+
+       $entries = ThreadEntry::objects()->filter(array('thread_id__exact' => $id ))->values()->all();
+
+       $encoder = null;
+       $contentType = null;
+       switch(strtolower($format)) {
+           case 'json':
+               $encoder = new JsonDataEncoder();
+               $contentType = 'application/json';
+               break;
+           default:
+               $this->exerr(415, __('Unsupported response format'));
+       }
+
+       Http::response(200,  $encoder->encode($entries), $contentType);
+       exit;
+   }
+
+}
+
+?>


### PR DESCRIPTION
I added listing rest api for threads
GET /api/tasks.json
GET /api/thread.json/$id
GET /api/thread.json/$id/entries

I added dynamic search (using orm capabilities):
GET /api/threads.json?field1=value1&field2=value2

Example:
GET /api/threads.json?object_id=5