### PR TITLE
issue: Information Page Performance

### DIFF
--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -154,7 +154,17 @@ if (!$lv) { ?>
         echo sprintf('%.2f MiB', $space); ?></td>
     <tr><td><?php echo __('Space for Attachments'); ?></td>
         <td><?php
-        $sql = 'SELECT SUM(LENGTH(filedata)) / 1048576 FROM '.FILE_CHUNK_TABLE;
+        $sql = 'SELECT
+                    (DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024
+                FROM
+                    information_schema.TABLES
+                WHERE
+                    TABLE_SCHEMA = "'.DBNAME.'"
+                AND
+                    TABLE_NAME = "'.FILE_CHUNK_TABLE.'"
+                ORDER BY
+                    (DATA_LENGTH + INDEX_LENGTH)
+                DESC';
         $space = db_result(db_query($sql));
         echo sprintf('%.2f MiB', $space); ?></td></tr>
     <tr><td><?php echo __('Timezone'); ?></td>


### PR DESCRIPTION
This addresses an issue on the forums where the query to determine the
size of the `file_chunk` table is making the page load really slow for
people with large tables. This updates the query to improve the
performance of the page load time.