### PR TITLE
Added randomized backdrop setting

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -1394,11 +1394,23 @@ class OsticketConfig extends Config {
     }
 
     function getStaffLoginBackdropId() {
-        return $this->get("staff_backdrop_id", false);
+        $id = $this->get("staff_backdrop_id", false);
+
+        if (-1 == $id) {
+            $backdrops = iterator_to_array(AttachmentFile::allBackdrops());
+
+            $b  = array_rand($backdrops);
+            $id = $backdrops[$b]->getId();
+        }
+
+        return $id;
     }
     function getStaffLoginBackdrop() {
         $id = $this->getStaffLoginBackdropId();
         return ($id) ? AttachmentFile::lookup((int) $id) : null;
+    }
+    function isStaffLoginBackdropRandomized() {
+        return -1 == $this->get("staff_backdrop_id");
     }
 
     function isAuthRequiredForFiles() {

--- a/include/i18n/en_US/help/tips/settings.pages.yaml
+++ b/include/i18n/en_US/help/tips/settings.pages.yaml
@@ -75,3 +75,9 @@ upload_a_new_backdrop:
         data. Therefore, to speed load times, it is recommended that you keep your
         image relatively small (under a megabyte). Note also that the PHP
         max upload settings apply.
+
+randomize_background:
+    title: Randomize Backdrops
+    content: >
+        You may opt to randomize the backdrop. This will automatically select one
+        of your custom backdrops, every time you visit the staff portal.

--- a/include/staff/settings-pages.inc.php
+++ b/include/staff/settings-pages.inc.php
@@ -247,6 +247,18 @@ $pages = Page::getPages();
                                 ?>&nbsp;<i class="help-tip icon-question-sign" href="#upload_a_new_backdrop"></i></em>
                             </th>
                         </tr>
+                        <tr>
+                            <td>
+                               <input type="radio" name="selected-backdrop"
+                                      style="margin-left: 1em" value="-1" <?php
+                            $randomized = $ost->getConfig()->isStaffLoginBackdropRandomized();
+                            if ($randomized)
+                                echo 'checked="checked"'; ?>/>
+                            </td>
+                            <td>
+                                <?php echo __('Randomize Background'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#randomize_background"></i></em>
+                            </td>
+                        </tr>
                         <?php
                         $current = $ost->getConfig()->getStaffLoginBackdropId();
                         foreach (AttachmentFile::allBackdrops() as $logo) { ?>
@@ -255,7 +267,7 @@ $pages = Page::getPages();
                                 <input type="radio" name="selected-backdrop"
                                        style="margin-left: 1em" value="<?php
                             echo $logo->getId(); ?>" <?php
-                            if ($logo->getId() == $current)
+                            if ($logo->getId() == $current && !$randomized)
                                 echo 'checked="checked"'; ?>/>
                             </td>
                             <td>


### PR DESCRIPTION
A simple feature that will randomly choose the staff portal background from your custom images.

![untitled](https://user-images.githubusercontent.com/5936269/40766140-14658300-64e1-11e8-8529-b3e7ad6e3727.png)
