### PR TITLE
Fix errors on staff pages (#4306)

### DIFF
--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -93,6 +93,8 @@ if(!$thisstaff->isAdmin()) {
 //Keep the session activity alive
 $thisstaff->refreshSession();
 
+global $ost, $cfg;
+
 /******* CSRF Protectin *************/
 // Enforce CSRF protection for POSTS
 if ($_POST  && !$ost->checkCSRFToken()) {


### PR DESCRIPTION
This fixes error #4306 

Adds required global declarations to scp/staff.inc.php to stop errors being logged upon agent login.