### PR TITLE
Feature: canned response rendered using select2

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -193,6 +193,8 @@ var scp_prep = function() {
         }
      });
 
+    $('form select#cannedResp').select2({width: '300px'});
+
     $('form select#cannedResp').change(function() {
 
         var fObj = $(this).closest('form');


### PR DESCRIPTION
This feature adds the ability to search for the _canned response_ by title in the post reply form.

![search-canned-response](https://user-images.githubusercontent.com/30795814/40991246-71fbb078-68f3-11e8-8f1e-3920b5c70051.png)
