### PR TITLE
issue: Auto-Assignment Log

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1791,8 +1791,8 @@ class ThreadEvents extends InstrumentedList {
             }
             // XXX: Use $user here
             elseif ($thisclient) {
-                if ($thisclient->hasAccount)
-                    $username = $thisclient->getAccount()->getUserName();
+                if ($thisclient->hasAccount())
+                    $username = $thisclient->getFullName();
                 if (!$username)
                     $username = $thisclient->getEmail();
             }


### PR DESCRIPTION
This addresses an issue on the Forums where the Auto-Assignment Thread
Event (configurable via Help Topic) uses the Email of the User rather than
the User’s Name. This adds the correct function to retrieve the User’s
Name if the User has an Account.