### PR TITLE
Phone formatting, piping e-mails, translations

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -88,7 +88,10 @@ class Format {
     }
 
 	function phone($phone) {
-
+	// # changed date  02.07.2018 - av Ole Kristian Ek Hornnes  
+	// does not support norwegian plain 8 digit phone numbers. No formatting
+		return $phone;
+		// # Endret dato  02.07.2018 - av Ole Kristian Ek Hornnes  - Vi benytter ikke telefonformattering her. 
 		$stripped= preg_replace("/[^0-9]/", "", $phone);
 		if(strlen($stripped) == 7)
 			return preg_replace("/([0-9]{3})([0-9]{4})/", "$1-$2",$stripped);

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -54,6 +54,9 @@
  * second parameter in the constructor (e.g. whenusing very large MO files
  * that you don't want to keep in memory)
  */
+if(!defined('INCLUDE_DIR')) {
+		define('INCLUDE_DIR', __DIR__ . "/");
+}
 class gettext_reader {
   //public:
    var $error = 0; // public variable that holds error code (0 if no error)
@@ -580,6 +583,7 @@ class Translation extends gettext_reader implements Serializable {
     }
 
     static function buildHashFile($mofile, $outfile=false, $return=false) {
+    	$mofile_par = $mofile; 
         if (!$outfile) {
             $stream = fopen('php://stdout', 'w');
         }
@@ -600,7 +604,7 @@ class Translation extends gettext_reader implements Serializable {
         $reader = new parent($mofile, true);
 
         if ($reader->short_circuit || $reader->error)
-            throw new Exception('Unable to initialize MO input file');
+            throw new Exception('Unable to initialize MO input file:'.$mofile_par);
 
         $reader->load_tables();
 

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -174,6 +174,9 @@ class Validator {
     }
 
     static function is_phone($phone) {
+    // The is_phone disabled because it does not support international phone
+    // numbers. 
+    	return true; // # change date  02.07.2018 - av Ole Kristian Ek Hornnes  - Tatt bort amerikansk validering tlf. 
         /* We're not really validating the phone number but just making sure it doesn't contain illegal chars and of acceptable len */
         $stripped=preg_replace("(\(|\)|\-|\.|\+|[  ]+)","",$phone);
         return (!is_numeric($stripped) || ((strlen($stripped)<7) || (strlen($stripped)>16)))?false:true;

--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -643,10 +643,10 @@ class Mail_mimeDecode extends PEAR
     {
         // Remove soft line breaks
         $input = preg_replace("/=\r?\n/", '', $input);
-
-        // Replace encoded characters
-		$input = preg_replace('/=([a-f0-9]{2})/ie', "chr(hexdec('\\1'))", $input);
-
+// # Changed date  02.07.2018 - av Ole Kristian Ek Hornnes  
+// allow piping e-mails with rtf/html bodies
+        // Replace encoded characters - 
+		$input = preg_replace_callback('/=([a-f0-9]{2})/i', function($m) { return chr(hexdec($m[0])); }, $input);
         return $input;
     }
 


### PR DESCRIPTION
Here is what I have done to this branch. If you like some of the changes, it would be nice. 
Regarding the norwegian phone numbers, - the US format does not fit. This is configurable in the forms section of the admin interface, but not when it comes to agent profiles. I decided to allow all formats since this would need some reworking to be truly international. 
The fix for the piping i did find someone else tip and that worked. no more blank body in piped emails. 
The translation file did not have INCLUDE_DIR defined when running from command-line to hash .mo files. The fix proposed worked well in this installation. 
I am using PHP-7 /debian 9 in my installation. 