### PR TITLE
issue: Language Pack Locale Mismatch

### DIFF
--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -183,16 +183,18 @@ if (!$lv) { ?>
         $p = $info['path'];
         if ($info['phar'])
             $p = 'phar://' . $p;
+        $manifest = (file_exists($p . '/MANIFEST.php')) ? (include $p . '/MANIFEST.php') : null;
 ?>
     <h3><strong><?php echo Internationalization::getLanguageDescription($info['code']); ?></strong>
-        &mdash; <?php echo $manifest['Language']; ?>
+        <?php if ($manifest) { ?>
+            &mdash; <?php echo $manifest['Language']; ?>
+        <?php } ?>
 <?php   if ($info['phar'])
             Plugin::showVerificationBadge($info['path']); ?>
         </h3>
         <div><?php echo sprintf('<code>%s</code> — %s', $info['code'],
                 str_replace(ROOT_DIR, '', $info['path'])); ?>
-<?php   if (file_exists($p . '/MANIFEST.php')) {
-            $manifest = (include $p . '/MANIFEST.php'); ?>
+<?php   if ($manifest) { ?>
             <br/> <?php echo __('Version'); ?>: <?php echo $manifest['Version'];
                 ?>, <?php echo sprintf(__('for version %s'),
                     'v'.($manifest['Phrases-Version'] ?: '1.9')); ?>


### PR DESCRIPTION
This addresses issue #4325 where the Language Pack Locales are mismatched.
The Locale for the first language is displayed on the second language,
etc. This updates the `$manifest` variable to be set before we display
data so the correct `MANIFEST` file is included and all language data is
displayed correctly.