### PR TITLE
issue: User Import No Email

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -452,7 +452,7 @@ implements TemplateVariable {
             db_autocommit(false);
             $records = $importer->importCsv(UserForm::getUserForm()->getFields(), $defaults);
             foreach ($records as $data) {
-                if (!isset($data['email']) || !isset($data['name']))
+                if (!Validator::is_email($data['email']) || empty($data['name']))
                     throw new ImportError('Both `name` and `email` fields are required');
                 if (!($user = static::fromVars($data, true, true)))
                     throw new ImportError(sprintf(__('Unable to import user: %s'),


### PR DESCRIPTION
This addresses issue #4329 where you can import a User with no email
address via CSV file. Once the User is added and you try to update them
with an email address it fails due to no default email. This updates the
check for email address from `!isset()` to `empty()` which will correctly
check for empty string.