### PR TITLE
issue: CLI Deploy Missing Bootstrap

### DIFF
--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -210,7 +210,7 @@ class Unpacker extends Module {
         ), $pipes);
 
         fwrite($pipes[0], "<?php
-        include '{$this->destination}/bootstrap.php';
+        include '{$this->source}/bootstrap.php';
         print INCLUDE_DIR;
         ");
         fclose($pipes[0]);


### PR DESCRIPTION
This addresses issue #4322 where deploying via CLI is missing
`bootstrap.php`. This is due to the `get_include_dir()` function that
tries to include a file from the destination which doesn’t exist yet,
causing a fatal error. This updates the function to use `$this->source`
instead of `$this->destination` to correctly find and include
`bootstrap.php`.