### PR TITLE
issue: Ticket Lock On Disable

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -419,6 +419,11 @@ class OsticketConfig extends Config {
         return $this->get('enable_avatars');
     }
 
+    function isTicketLockEnabled() {
+        return (($this->getTicketLockMode() != Lock::MODE_DISABLED)
+                && $this->getLockTime());
+    }
+
     function getClientTimeout() {
         return $this->getClientSessionTimeout();
     }

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -90,7 +90,7 @@ if($_POST && !$errors):
                 if(!$vars['response'])
                     $errors['response']=__('Response required');
 
-                if ($cfg->getLockTime()) {
+                if ($cfg->isTicketLockEnabled()) {
                     if (!$lock) {
                         $errors['err'] = sprintf('%s %s', __('This action requires a lock.'), __('Please try again!'));
                     }
@@ -147,7 +147,7 @@ if($_POST && !$errors):
                 $vars['cannedattachments'] ?: array(), $attachments);
             $vars['note'] = ThreadEntryBody::clean($vars['note']);
 
-            if ($cfg->getLockTime()) {
+            if ($cfg->isTicketLockEnabled()) {
                 if (!$lock) {
                     $errors['err'] = sprintf('%s %s', __('This action requires a lock.'), __('Please try again!'));
                 }


### PR DESCRIPTION
This addresses an issue where disabling Ticket Locks but setting a time
for the Lock Timeout will always throw a "lock required" error. This adds
a check to see if locks are enabled AND there is a time set. If locks are
disabled it will not throw the error.