### PR TITLE
Address Security Issues On #4331

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -1110,6 +1110,8 @@ class OsticketConfig extends Config {
         $f['default_timezone']=array('type'=>'string',   'required'=>1, 'error'=>__('Default Timezone is required'));
         $f['system_language']=array('type'=>'string',   'required'=>1, 'error'=>__('A primary system language is required'));
 
+        $vars = Format::htmlchars($vars, true);
+
         // Make sure the selected backend is valid
         $storagebk = null;
         if (isset($vars['default_storage_bk'])) {

--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -620,6 +620,21 @@ implements TemplateVariable {
         if ($vars['pid'] && !($p = static::lookup($vars['pid'])))
             $errors['pid'] = __('Department selection is required');
 
+        if ($vars['sla_id'] && !SLA::lookup($vars['sla_id']))
+            $errors['sla_id'] = __('Invalid SLA');
+
+        if ($vars['manager_id'] && !Staff::lookup($vars['manager_id']))
+            $errors['manager_id'] = __('Unknown Staff');
+
+        if ($vars['email_id'] && !Email::lookup($vars['email_id']))
+            $errors['email_id'] = __('Unknown System Email');
+
+        if ($vars['tpl_id'] && !EmailTemplateGroup::lookup($vars['tpl_id']))
+            $errors['tpl_id'] = __('Unknown Template Set');
+
+        if ($vars['autoresp_email_id'] && !Email::lookup($vars['autoresp_email_id']))
+            $errors['autoresp_email_id'] = __('Unkown System Email');
+
         // Format access update as [array(dept_id, role_id, alerts?)]
         $access = array();
         if (isset($vars['members'])) {
@@ -634,17 +649,17 @@ implements TemplateVariable {
             return false;
 
         $this->pid = $vars['pid'] ?: null;
-        $this->ispublic = isset($vars['ispublic'])?$vars['ispublic']:0;
-        $this->email_id = isset($vars['email_id'])?$vars['email_id']:0;
-        $this->tpl_id = isset($vars['tpl_id'])?$vars['tpl_id']:0;
-        $this->sla_id = isset($vars['sla_id'])?$vars['sla_id']:0;
-        $this->autoresp_email_id = isset($vars['autoresp_email_id'])?$vars['autoresp_email_id']:0;
+        $this->ispublic = isset($vars['ispublic']) ? (int) $vars['ispublic'] : 0;
+        $this->email_id = isset($vars['email_id']) ? (int) $vars['email_id'] : 0;
+        $this->tpl_id = isset($vars['tpl_id']) ? (int) $vars['tpl_id'] : 0;
+        $this->sla_id = isset($vars['sla_id']) ? (int) $vars['sla_id'] : 0;
+        $this->autoresp_email_id = isset($vars['autoresp_email_id']) ? (int) $vars['autoresp_email_id'] : 0;
         $this->manager_id = $vars['manager_id'] ?: 0;
         $this->name = Format::striptags($vars['name']);
         $this->signature = Format::sanitize($vars['signature']);
         $this->group_membership = $vars['group_membership'];
-        $this->ticket_auto_response = isset($vars['ticket_auto_response'])?$vars['ticket_auto_response']:1;
-        $this->message_auto_response = isset($vars['message_auto_response'])?$vars['message_auto_response']:1;
+        $this->ticket_auto_response = isset($vars['ticket_auto_response']) ? (int) $vars['ticket_auto_response'] : 1;
+        $this->message_auto_response = isset($vars['message_auto_response']) ? (int) $vars['message_auto_response'] : 1;
         $this->flags = 0;
         $this->setFlag(self::FLAG_ASSIGN_MEMBERS_ONLY, isset($vars['assign_members_only']));
         $this->setFlag(self::FLAG_DISABLE_AUTO_CLAIM, isset($vars['disable_auto_claim']));

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -349,8 +349,13 @@ class Format {
     function htmlchars($var, $sanitize = false) {
         static $phpversion = null;
 
-        if (is_array($var))
-            return array_map(array('Format', 'htmlchars'), $var);
+        if (is_array($var)) {
+            $result = array();
+            foreach ($var as $k => $v)
+                $result[$k] = self::htmlchars($v, $sanitize);
+
+            return $result;
+        }
 
         if ($sanitize)
             $var = Format::sanitize($var);

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2191,7 +2191,7 @@ class TextThreadEntryBody extends ThreadEntryBody {
     }
 
     function getClean() {
-        return  Format::stripEmptyLines(parent::getClean());
+        return  Format::htmlchars(Format::stripEmptyLines(parent::getClean()), true);
     }
 
     function prepend($what) {

--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -67,6 +67,7 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info);
                     ?>><?php echo $name; ?></option>
 <?php } ?>
                 </select>
+                &nbsp;<span class="error"><?php echo $errors['pid']; ?></span>
             </td>
         </tr>
         <tr>

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -20,7 +20,7 @@ if($topic && $_REQUEST['a']!='add') {
     $qs += array('a' => $_REQUEST['a']);
     $forms = TicketForm::objects();
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 
 <h2><?php echo $title; ?>

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -253,7 +253,10 @@ elseif ($_SESSION[$queue_sort_key][0] == 'relevance') {
 }
 
 if (isset($_GET['sort'])) {
-    $_SESSION[$queue_sort_key] = array($_GET['sort'], $_GET['dir']);
+    $_SESSION[$queue_sort_key] = array(
+            Format::htmlchars($_GET['sort']),
+            Format::htmlchars($_GET['dir'])
+        );
 }
 elseif (!isset($_SESSION[$queue_sort_key])) {
     $_SESSION[$queue_sort_key] = array($queue_sort_options[0], 0);

--- a/scp/forms.php
+++ b/scp/forms.php
@@ -7,6 +7,7 @@ if($_REQUEST['id'] && !($form=DynamicForm::lookup($_REQUEST['id'])))
     $errors['err']=sprintf(__('%s: Unknown or invalid ID.'), __('custom form'));
 
 if($_POST) {
+    $_POST = Format::htmlchars($_POST, true);
     $fields = array('title', 'notes', 'instructions');
     $required = array('title');
     $max_sort = 0;


### PR DESCRIPTION
It may be possible to steal or manipulate customer session and cookies, which might be used to impersonate a legitimate user, allowing the hacker to view or alter user records, and to perform transactions as that user. Sanitation of hazardous characters was not performed correctly on user
input.

osTicket did not properly sanitize array values in `Format::htmlchars()`. Some values in the Admin Interface were not properly sanitized and returned to the response.