### PR TITLE
issue: Maxfilesize Comma Crash

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3932,7 +3932,7 @@ class FileUploadWidget extends Widget {
           allowedfiletypes: <?php echo JsonDataEncoder::encode(
             $mimetypes); ?>,
           maxfiles: <?php echo $config['max'] ?: 20; ?>,
-          maxfilesize: <?php echo $maxfilesize; ?>,
+          maxfilesize: <?php echo str_replace(',', '.', $maxfilesize); ?>,
           name: '<?php echo $name; ?>[]',
           files: <?php echo JsonDataEncoder::encode($files); ?>
         });});


### PR DESCRIPTION
This addresses an issue on the forums where having a comma in your number format (instead of periods) would crash the system if using a language pack other than English. (Fix suggested by @rspma on the forums.)