### PR TITLE
Revert "issue: Orphaned File Query Rewrite"

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -636,17 +636,20 @@ class AttachmentFile extends VerySimpleModel {
      * canned-response, or faq point to any more.
      */
     static function deleteOrphans() {
-        $sql = "SELECT `id` FROM ".FILE_TABLE.
-            " A1 WHERE (A1.ft = 'T' AND A1.created < NOW() - INTERVAL 1 DAY)".
-            " AND NOT EXISTS (SELECT id FROM ".ATTACHMENT_TABLE.
-            " A2 WHERE A1.`id` = A2.`file_id`)";
 
-        if (($res=db_query($sql)) && db_num_rows($res)) {
-            while (list($id) = db_fetch_row($res)) {
-                if ($f = static::lookup((int) $id))
-                    if (!$f->delete())
-                        break;
-            }
+        // XXX: Allow plugins to define filetypes which do not represent
+        //      files attached to tickets or other things in the attachment
+        //      table and are not logos
+        $files = static::objects()
+            ->filter(array(
+                'attachments__object_id__isnull' => true,
+                'ft' => 'T',
+                'created__lt' => SqlFunction::NOW()->minus(SqlInterval::DAY(1)),
+            ));
+
+        foreach ($files as $f) {
+            if (!$f->delete())
+                break;
         }
 
         return true;


### PR DESCRIPTION
An index was added to the v1.11 branch to support the ORM query. Because the index cannot be applied to v1.10, the query was rewritten for the 1.10.x branch to provide better performance without changes to the database. When 1.10.x was merged into 1.11.x the rewritten SQL accidentally showed up. This reverts that merge to use the original ORM query.