### PR TITLE
Custom Queues Merged for 1.11

### DIFF
--- a/include/ajax.search.php
+++ b/include/ajax.search.php
@@ -366,7 +366,7 @@ class SearchAjaxAPI extends AjaxController {
         $field_name = $_GET['field'];
         $id = $_GET['id'];
         $object_id = $_GET['object_id'];
-        $condition = new QueueColumnCondition();
+        $condition = new QueueColumnCondition(array());
         include STAFFINC_DIR . 'templates/queue-column-condition.tmpl.php';
     }
 

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -1282,7 +1282,7 @@ implements CustomListItem, TemplateVariable, Searchable {
             'state' => new TicketStateChoiceField(array(
                 'label' => __('State'),
             )),
-            'name' => new TextBoxField(array(
+            'id' => new TicketStatusChoiceField(array(
                 'label' => __('Status Name'),
             )),
         );

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1408,6 +1408,8 @@ class TicketStatusChoiceField extends SelectionField {
 
     function getSearchQ($method, $value, $name=false) {
         $name = $name ?: $this->get('name');
+        if (!$value)
+            return false;
         switch ($method) {
         case '!includes':
             return Q::not(array("{$name}__in" => array_keys($value)));

--- a/include/staff/queue.inc.php
+++ b/include/staff/queue.inc.php
@@ -346,6 +346,8 @@ if ($queue->getConditions()) {
   foreach ($queue->getConditions() as $i=>$condition) {
      $id = QueueColumnCondition::getUid();
      list($label, $field) = $condition->getField();
+     if (!$field || !$label)
+        continue;
      $field_name = $condition->getFieldName();
      $object_id = $queue->id;
      include STAFFINC_DIR . 'templates/queue-column-condition.tmpl.php';

--- a/include/staff/templates/queue-column.tmpl.php
+++ b/include/staff/templates/queue-column.tmpl.php
@@ -122,6 +122,8 @@ if ($column->getConditions(false)) {
   foreach ($column->getConditions() as $i=>$condition) {
      $id = QueueColumnCondition::getUid();
      list($label, $field) = $condition->getField();
+     if (!$label || !$field)
+        continue;
      $field_name = $condition->getFieldName();
      $object_id = $column->getId();
      include STAFFINC_DIR . 'templates/queue-column-condition.tmpl.php';

--- a/include/staff/templates/queue-columns.tmpl.php
+++ b/include/staff/templates/queue-columns.tmpl.php
@@ -1,12 +1,13 @@
 <div style="overflow-y: auto; height:auto; max-height: 350px;">
 <table class="table">
 <?php
+$hidden_cols = $queue->inheritColumns() || count($queue->columns) === 0;
 if ($queue->parent) { ?>
   <tbody>
     <tr>
       <td colspan="3">
         <input type="checkbox" name="inherit-columns" <?php
-          if ($queue->inheritColumns()) echo 'checked="checked"'; ?>
+          if ($hidden_cols) echo 'checked="checked"'; ?>
           onchange="javascript:$(this).closest('table').find('.if-not-inherited').toggle(!$(this).prop('checked'));" />
         <?php echo __('Inherit columns from the parent queue'); ?>
         <br /><br />

--- a/include/staff/templates/queue-navigation.tmpl.php
+++ b/include/staff/templates/queue-navigation.tmpl.php
@@ -4,6 +4,7 @@
 // $q - <CustomQueue> object for this navigation entry
 // $selected - <bool> true if this queue is currently active
 // $child_selected - <bool> true if the selected queue is a descendent
+$childs = $children;
 $this_queue = $q;
 $selected = (!isset($_REQUEST['a'])  && $_REQUEST['queue'] == $this_queue->getId());
 ?>
@@ -28,8 +29,21 @@ $selected = (!isset($_REQUEST['a'])  && $_REQUEST['queue'] == $this_queue->getId
       </li>
 
       <!-- Start Dropdown and child queues -->
-      <?php foreach ($this_queue->getPublicChildren() as $q) {
-          include 'queue-subnavigation.tmpl.php';
+      <?php foreach ($childs as $_) {
+          list($q, $children) = $_;
+          if (!$q->isPrivate())
+              include 'queue-subnavigation.tmpl.php';
+      }
+      $first_child = true;
+      foreach ($childs as $_) {
+        list($q, $children) = $_;
+        if (!$q->isPrivate())
+            continue;
+        if ($first_child) {
+            $first_child = false;
+            echo '<li class="personalQ"></li>';
+        }
+        include 'queue-subnavigation.tmpl.php';
       } ?>
       <!-- Personal Queues -->
       <?php

--- a/include/staff/templates/queue-savedsearches-nav.tmpl.php
+++ b/include/staff/templates/queue-savedsearches-nav.tmpl.php
@@ -18,11 +18,13 @@
       <!-- Start Dropdown and child queues -->
       <?php foreach ($searches->findAll(array(
             'staff_id' => $thisstaff->getId(),
+            'parent_id' => 0,
             Q::not(array(
                 'flags__hasbit' => CustomQueue::FLAG_PUBLIC
             ))
       )) as $q) {
-        include 'queue-subnavigation.tmpl.php';
+        if ($q->checkAccess($thisstaff))
+            include 'queue-subnavigation.tmpl.php';
       } ?>
      <?php
      if (isset($_SESSION['advsearch'])) { ?>

--- a/include/staff/templates/queue-subnavigation.tmpl.php
+++ b/include/staff/templates/queue-subnavigation.tmpl.php
@@ -1,10 +1,9 @@
 <?php
 // Calling conventions
 // $q - <CustomQueue> object for this navigation entry
+// $children - <Array<CustomQueue>> all direct children of this queue
 $queue = $q;
-$children = !$queue instanceof SavedSearch ? $queue->getPublicChildren() : array();
-$subq_searches = !$queue instanceof SavedSearch ? $queue->getMyChildren() : array();
-$hasChildren = count($children) + count($subq_searches) > 0;
+$hasChildren = count($children) > 0;
 $selected = $_REQUEST['queue'] == $q->getId();
 global $thisstaff;
 ?>
@@ -27,24 +26,30 @@ global $thisstaff;
     </a>
 
     <?php
-    $closure_include = function($q) use ($thisstaff, $ost, $cfg) {
+    $closure_include = function($q, $children) {
         global $thisstaff, $ost, $cfg;
         include __FILE__;
     };
     if ($hasChildren) { ?>
     <ul class="subMenuQ">
     <?php
-    foreach ($children as $q)
-        $closure_include($q);
+    foreach ($children as $_) {
+        list($q, $childs) = $_;
+        if (!$q->isPrivate())
+          $closure_include($q, $childs);
+    }
 
     // Include personal sub-queues
     $first_child = true;
-    foreach ($subq_searches as $q) {
-      if ($first_child) {
+    foreach ($children as $_) {
+      list($q, $childs) = $_;
+      if ($q->isPrivate()) {
+        if ($first_child) {
           $first_child = false;
           echo '<li class="personalQ"></li>';
+        }
+        $closure_include($q, $childs);
       }
-      $closure_include($q);
     } ?>
     </ul>
 <?php

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -445,19 +445,14 @@ $nav->setTabActive('tickets');
 $nav->addSubNavInfo('jb-overflowmenu', 'customQ_nav');
 
 // Fetch ticket queues organized by root and sub-queues
-$queues = SavedQueue::queues()
-    ->filter(Q::any(array(
-        'flags__hasbit' => CustomQueue::FLAG_PUBLIC,
-        'staff_id' => $thisstaff->getId(),
-    )))
-    ->exclude(['flags__hasbit' => CustomQueue::FLAG_DISABLED])
-    ->getIterator();
+$queues = CustomQueue::getHierarchicalQueues($thisstaff);
 
 // Start with all the top-level (container) queues
-foreach ($queues->findAll(array('parent_id' => 0))
-as $q) {
-    $nav->addSubMenu(function() use ($q, $queue) {
-        $selected = false;
+foreach ($queues as $_) {
+    list($q, $children) = $_;
+    if ($q->isPrivate())
+        continue;
+    $nav->addSubMenu(function() use ($q, $queue, $children) {
         // A queue is selected if it is the one being displayed. It is
         // "child" selected if its ID is in the path of the one selected
         $child_selected = $queue


### PR DESCRIPTION
So I'm abandoning my previous pull request in favor of a new one. Since custom queues are making their official debut in v1.11 (yay!), I've taken the liberty to start finding the differences between my branch and the upstream branch. This pull request is the start of the conversation to tie up all the loose ends and merge the two ideas.

I think I've got most everything. A couple of the commits showed differences, but the merge conflicts were too extreme for me to figure out. I'll try another couple approaches to make sure we've got everything, but I think this is the most of it.

The only major enhancement here is the concept of creating team-based queues, where the members of a team can share a common queue. 

This also includes a database usage fix to reduce the queries needed to render the queue system by like 90% (From O(n) to O(1) where n is the number of queues visible to a staff member).

### Possibly Outstanding
- [x] Add container queues with no criteria and default sub-queues. This will replace the current "Show assigned tickets on open queue" setting and friends. When the container queue is clicked, the default sub-queue will be shown instead
- [ ] Add description (queue page title) field
- [ ] Add icon selection to custom queue management page
- [ ] Retire CDATA usage and feature
- [ ] Delete custom column (definition)
- [ ] Delete custom sort criteria (definition)
- [ ] Personal queue columns don't need to be translatable
- [ ] Make queue titles translatable