### PR TITLE
issue: TextThreadEntryBody Sanitize

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2191,7 +2191,7 @@ class TextThreadEntryBody extends ThreadEntryBody {
     }
 
     function getClean() {
-        return  Format::htmlchars(Format::stripEmptyLines(parent::getClean()), true);
+        return Format::htmlchars(Format::html_balance(Format::stripEmptyLines(parent::getClean())));
     }
 
     function prepend($what) {


### PR DESCRIPTION
This addresses an issue introduced with a3d896c where TextThreadEntryBodies
are not keeping their new line characters causing the email format to appear
wonky. This balances the entry and then htmlchars it to ensure no XSS.