### PR TITLE
issue: ChoiceField Template Variable

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1621,6 +1621,11 @@ class ChoiceField extends FormField {
         return (string) $value;
     }
 
+    function asVar($value, $id=false) {
+        $value = $this->to_php($value);
+        return $this->toString($this->getChoice($value));
+    }
+
     function whatChanged($before, $after) {
         $B = (array) $before;
         $A = (array) $after;


### PR DESCRIPTION
This addresses an issue on the forums where osTicket does not add the proper values to any custom choices field template variable. This adds an `asVar()` function to `class ChoiceField` so we can return the proper values for the template variables.