### PR TITLE
issue: CLI Deploy Missing Bootstrap Fix

### DIFF
--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -210,7 +210,11 @@ class Unpacker extends Module {
         ), $pipes);
 
         fwrite($pipes[0], "<?php
-        include '{$this->source}/bootstrap.php';
+        if (file_exists('{$this->destination}/bootstrap.php'))
+            include '{$this->destination}/bootstrap.php';
+        else
+            include '{$this->source}/bootstrap.php';
+
         print INCLUDE_DIR;
         ");
         fclose($pipes[0]);


### PR DESCRIPTION
This addresses an issue introduced with #4332 where the deploy CLI breaks upon deploying to an existing location. This checks to see if there is a bootstrap file in the destination first and if so it uses that one if not uses the source.