### PR TITLE
mailer: EmailAddress Object as Array

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -434,6 +434,9 @@ class Mailer {
                                 $recipient->getName(),
                                 $recipient->getEmail()));
                     break;
+                case $recipient instanceof EmailAddress:
+                    $mime->addTo($recipient->getAddress());
+                    break;
                 default:
                     // Assuming email address.
                     $mime->addTo($recipient);


### PR DESCRIPTION
This address issue #4366 where sending a User a password reset email throws a fatal error of "object of type EmailAddress cannot be used as an array". This adds a switch case for EmailAddress to get the User's email address as a string not an object.