### PR TITLE
collab: @localhost Mailer Error

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1660,6 +1660,9 @@ implements RestrictedAccess, Threadable, Searchable {
                 unset($recipients[$key]);
          }
 
+        if (!count($recipients))
+            return true;
+
         //see if the ticket user is a recipient
         if ($owner->getEmail()->address != $poster->getEmail()->address && !in_array($owner->getEmail()->address, $skip))
           $owner_recip = $owner->getEmail()->address;


### PR DESCRIPTION
This addresses issue #4370 where Users responding to tickets via Client Portal triggers a “Failed to add recipient: @localhost” Mailer Error in the osTicket Logs. This is due to the `notifyCollaborators()` function that lacks a check for an empty mailing list.