### PR TITLE
issue: jQuery Sortable Redactor

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -378,7 +378,8 @@ var scp_prep = function() {
            $('input[name^='+attr+']', ui.item.parent('tbody')).each(function(i, el) {
                $(el).val(i + 1 + offset);
            });
-       }
+       },
+       'cancel': ':input,button,div[contenteditable=true]'
    });
 
     // Scroll to a stop or top on scroll-up click


### PR DESCRIPTION
This addresses issue #4372 where any Redactor text box within jQuery sortable is not clickable. This is due to Redactor not being an actual input field, rather a div, so sortable doesn’t see it as an input.