### PR TITLE
issue: Client Side Thread Entries

### DIFF
--- a/include/client/templates/thread-entries.tmpl.php
+++ b/include/client/templates/thread-entries.tmpl.php
@@ -34,7 +34,9 @@ if (count($entries)) {
                 $events->next();
                 $event = $events->current();
             }
+            ?><div id="thread-entry-<?php echo $entry->getId(); ?>"><?php
             include 'thread-entry.tmpl.php';
+            ?></div><?php
         }
         $i++;
     }


### PR DESCRIPTION
This addresses an issue where the client side thread entries are all grouped within the same div. This pushes all grouped entries to one side of the page making them illegible.