### PR TITLE
Reset Button Fix:

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -291,7 +291,7 @@ $(function() {
         var reset = $('input[type=reset]', el.closest('form'));
         if (reset) {
             reset.click(function() {
-                var file = $('.file');
+                var file = $('.file', el.closest('form'));
                 if (file)
                     file.remove();
                 if (el.attr('data-draft-id'))


### PR DESCRIPTION
This commit makes sure that when the Reset button is hit, we only reset File Upload Field attachments for the specific form we're on.

Ex: Viewing a Ticket as an Agent and switching between 'Post Reply' and 'Post Internal Note' tabs. If you had an image in the Post Reply file upload field but switched to the Post Internal Note tab and hit Reset, only the text/attachments on the Post Internal Note tab would be cleared.

(Improves upon #4369)