### PR TITLE
issue: Priority Field Template Variable

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2273,6 +2273,10 @@ class PriorityField extends ChoiceField {
         return ($value instanceof Priority) ? array($value->getId()) : null;
     }
 
+    function asVar($value, $id=false) {
+        return $this->to_php($value, $id);
+    }
+
     function getConfigurationOptions() {
         $choices = $this->getChoices();
         $choices[''] = __('System Default');


### PR DESCRIPTION
This addresses an issue with PriorityField Template Variables introduced with #4359 where the priority variable will appear as "Array" instead of the actual value. This adds an `asVar()` function to `class PriorityField` to get the appropriate data.