### PR TITLE
issue: Deleted Field Thread Events

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1943,8 +1943,9 @@ class EditEvent extends ThreadEvent {
                 $fields[$F->id] = $F;
             }
             foreach ($data['fields'] as $id=>$f) {
-                $field = $fields[$id];
-                if ($mode == self::MODE_CLIENT && !$field->isVisibleToUsers())
+                if (!($field = $fields[$id]))
+                   continue;
+                if ($mode == self::MODE_CLIENT &&  !$field->isVisibleToUsers())
                     continue;
                 list($old, $new) = $f;
                 $impl = $field->getImpl($field);


### PR DESCRIPTION
This addresses an issue where deleting a field and all it's data will delete the form field record in the database causing all events containing the field to crash the ticket page.