### PR TITLE
issue: Saved Searches Flags

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1293,7 +1293,8 @@ class CustomQueue extends VerySimpleModel {
 
         $queue = new static($vars);
         $queue->created = SqlFunction::NOW();
-        $queue->setFlag(self::FLAG_QUEUE);
+        if (!isset($vars['flags']))
+            $queue->setFlag(self::FLAG_QUEUE);
 
         return $queue;
     }


### PR DESCRIPTION
This addresses an issue where class Queue sets SavedSearches flags to `FLAG_QUEUE` causing the SavedSearches to become Primary Queues.