### PR TITLE
Email Name Format:

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -408,7 +408,7 @@ class Mailer {
         foreach ($recipients as $recipient) {
             switch (true) {
                 case $recipient instanceof EmailRecipient:
-                    $addr = sprintf('%s <%s>',
+                    $addr = sprintf('"%s" <%s>',
                             $recipient->getName(),
                             $recipient->getEmail());
                     switch ($recipient->getType()) {
@@ -425,12 +425,12 @@ class Mailer {
                     break;
                 case $recipient instanceof TicketOwner:
                 case $recipient instanceof Staff:
-                    $mime->addTo(sprintf('%s <%s>',
+                    $mime->addTo(sprintf('"%s" <%s>',
                                 $recipient->getName(),
                                 $recipient->getEmail()));
                     break;
                 case $recipient instanceof Collaborator:
-                    $mime->addCc(sprintf('%s <%s>',
+                    $mime->addCc(sprintf('"%s" <%s>',
                                 $recipient->getName(),
                                 $recipient->getEmail()));
                     break;


### PR DESCRIPTION
This commit addresses an issue where email alerts were not being properly sent out if the name format is set as 'Last, First' or if it has special characters. We now encode names with quotation marks to ensure that emails are sent out properly (escape possible commas).