### PR TITLE
canned: Canned Response Select2 Height

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2930,3 +2930,12 @@ a.attachment {
  */
 .select2-selection__rendered, .select2-search,
 .select2-search__field:not([placeholder='']){width: 100% !important;}
+/* Fix Canned Responses Select2 Height */
+#resp_sec .select2-results, #resp_sec .select2-results__choices {
+    height: auto;
+    max-height: 400px !important;
+}
+#select2-cannedResp-results {
+    height: auto;
+    max-height: 400px !important;
+}


### PR DESCRIPTION
This adds an enhancement to the Canned Response Select2 showing more options within the list. The length is automatic and is based on how many Canned Responses you have Enabled.

Limits:
- Height maxes out at 400px so it doesn’t run off the screen