### PR TITLE
issue: IE Select2 Target

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -195,7 +195,7 @@ var scp_prep = function() {
 
     $('form select#cannedResp').select2({width: '300px'});
     $('form select#cannedResp').on('select2:opening', function (e) {
-        var redactor = $('.richtext', e.target.closest('form')).data('redactor');
+        var redactor = $('.richtext', $(this).closest('form')).data('redactor');
         if (redactor)
             redactor.selection.save();
     });


### PR DESCRIPTION
This addresses an issue where Microsoft IE 11 apparently does not like `event.target` syntax in javascript and breaks the Canned Response Select2.