### PR TITLE
Setting - Require Help Topic to Close:

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -198,6 +198,7 @@ class OsticketConfig extends Config {
         'client_name_format' => 'original', # As entered
         'auto_claim_tickets'=>  true,
         'collaborator_ticket_visibility' =>  true,
+        'require_topic_to_close' =>  false,
         'system_language' =>    'en_US',
         'default_storage_bk' => 'D',
         'message_autoresponder_collabs' => true,
@@ -924,6 +925,10 @@ class OsticketConfig extends Config {
         return $this->get('collaborator_ticket_visibility');
     }
 
+    function requireTopicToClose() {
+        return $this->get('require_topic_to_close');
+    }
+
     function getDefaultTicketQueueId() {
         return $this->get('default_ticket_queue');
     }
@@ -1277,6 +1282,7 @@ class OsticketConfig extends Config {
             'enable_captcha'=>isset($vars['enable_captcha'])?1:0,
             'auto_claim_tickets'=>isset($vars['auto_claim_tickets'])?1:0,
             'collaborator_ticket_visibility'=>isset($vars['collaborator_ticket_visibility'])?1:0,
+            'require_topic_to_close'=>isset($vars['require_topic_to_close'])?1:0,
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -229,6 +229,7 @@ implements RestrictedAccess, Threadable, Searchable {
     }
 
     function isCloseable() {
+        global $cfg;
 
         if ($this->isClosed())
             return true;
@@ -242,6 +243,10 @@ implements RestrictedAccess, Threadable, Searchable {
         } elseif (($num=$this->getNumOpenTasks())) {
             $warning = sprintf(__('%1$s has %2$d open tasks and cannot be closed'),
                     __('This ticket'), $num);
+        } elseif ($cfg->requireTopicToClose() && !$this->getTopicId()) {
+            $warning = sprintf(
+                    __( '%1$s is missing a %2$s and cannot be closed'),
+                    __('This ticket'), __('Help Topic'), '');
         }
 
         return $warning ?: true;

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -68,6 +68,7 @@ core:
     assigned_alert_team_members: 0
     auto_claim_tickets: 1
     collaborator_ticket_visibility: 1
+    require_topic_to_close: 0
     show_related_tickets: 1
     show_assigned_tickets: 1
     show_answered_tickets: 0

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -103,6 +103,11 @@ collaborator_ticket_visibility:
         If Disabled, Users will only be able to see their own Tickets
         when signing into the Web Portal.
 
+require_topic_to_close:
+    title: Require Help Topic to Close
+    content: >
+        If Enabled, a Ticket must have a Help Topic in order to be Closed by an Agent
+
 assigned_tickets:
     title: Assigned Tickets
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -214,6 +214,13 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td><?php echo __('Require Help Topic to Close'); ?>:</td>
+            <td>
+                <input type="checkbox" name="require_topic_to_close" <?php echo $config['require_topic_to_close']?'checked="checked"':''; ?>>
+                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#require_topic_to_close"></i>
+            </td>
+        </tr>
+        <tr>
             <th colspan="2">
                 <em><b><?php echo __('Attachments');?></b>:  <?php echo __('Size and maximum uploads setting mainly apply to web tickets.');?></em>
             </th>

--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -105,7 +105,14 @@ if ($_POST)
                     }
                     ?>
                 </select>
+
                 <?php
+                if (!$info['topicId'] && $cfg->requireTopicToClose()) {
+                ?><i class="icon-warning-sign help-tip warning"
+                    data-title="<?php echo __('Required to close ticket'); ?>"
+                    data-content="<?php echo __('Data is required in this field in order to close the related ticket'); ?>"
+                ></i><?php
+                }
                 if($warn) { ?>
                     &nbsp;<font class="error"><b>*</b>&nbsp;<?php echo $warn; ?></font>
                 <?php } ?>


### PR DESCRIPTION
This commit adds an Admin setting that requires a Ticket to have a Help Topic before it can be closed. It can be set by going to:

Admin Panel | Settings | Tickets | Require Help Topic to Close

If enabled, Tickets will have a warning banner across the bottom of the page, a warning banner when trying to change the Ticket status to Closed, and a warning flag beside the field when editing the Ticket.

By default, this setting is NOT enabled.