### PR TITLE
issue: Custom File Upload Dropping

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3974,7 +3974,10 @@ class FileUploadWidget extends Widget {
         // Files already attached to the field are allowed
         foreach ($this->field->getFiles() as $F) {
             // FIXME: This will need special porting in v1.10
-            $allowed[$F->id] = 1;
+            if ($F instanceof Attachment)
+                $allowed[$F->getFileId()] = 1;
+            else
+                $allowed[$F->id] = 1;
         }
 
         // New files uploaded in this session are allowed


### PR DESCRIPTION
This addresses issue #4155 where editing a ticket using a different session causes custom file uploads to drop from the ticket.