### PR TITLE
status: Allow Reopen

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -221,7 +221,7 @@ implements RestrictedAccess, Threadable, Searchable {
 
     function isReopenable() {
         return ($this->getStatus()->isReopenable() && $this->getDept()->allowsReopen()
-        && ($this->getTopic() ? $this->getTopic()->allowsReopen() : null));
+        && ($this->getTopic() ? $this->getTopic()->allowsReopen() : true));
     }
 
     function isClosed() {


### PR DESCRIPTION
This addresses an issue introduced with `510046c5` where tickets with no Help Topic can not be reopened. This is due to a check on `isReopenable()` where it returns `null` instead of `true` if there is no help topic; therefore returning false and not allowing the ticket to be reopened.