### PR TITLE
Agent Default Queue:

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -93,7 +93,7 @@ if (!$ticket) {
 
     $queue_key = sprintf('::Q:%s', ObjectModel::OBJECT_TYPE_TICKET);
     $queue_id = $queue_id ?: @$_GET['queue'] ?: $_SESSION[$queue_key]
-        ?: $cfg->getDefaultTicketQueueId();
+        ?: $thisstaff->getDefaultTicketQueueId() ?: $cfg->getDefaultTicketQueueId();
 
     // Recover advanced search, if requested
     if (isset($_SESSION['advsearch'])


### PR DESCRIPTION
This commit addresses an issue where the Agent could set a Default Ticket Queue in their profile, but the System Default queue would be shown instead.