### PR TITLE
issue: Deleted Field Thread Events (template)

### DIFF
--- a/include/staff/templates/thread-event.tmpl.php
+++ b/include/staff/templates/thread-event.tmpl.php
@@ -1,8 +1,10 @@
+<?php if ($desc = $event->getDescription(ThreadEvent::MODE_STAFF)) { ?>
 <div class="thread-event <?php if ($event->uid) echo 'action'; ?>">
         <span class="type-icon">
           <i class="faded icon-<?php echo $event->getIcon(); ?>"></i>
         </span>
         <span class="faded description">
-            <?php echo $event->getDescription(ThreadEvent::MODE_STAFF); ?>
+            <?php echo $desc; ?>
         </span>
 </div>
+<?php } ?>


### PR DESCRIPTION
This addresses an issue introduced with `9ab2317` where the icon for the event still shows even though we continued and didn’t return the event description.