### PR TITLE
Referral Assignment Issue:

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -314,7 +314,7 @@ implements Searchable {
     function refer($to) {
 
         if ($this->isReferred($to, true))
-            return true;
+            return false;
 
         $vars = array('thread_id' => $this->getId());
         switch (true) {


### PR DESCRIPTION
This commit fixes an issue where referrals were being considered successfully saved even if that referral already existed, resulting in multiple thread events for the same referral.

Instead, if we find that the thread is already referred to the referee, refer should return false so that an error message is displayed stating that we were unable to refer the ticket.