### PR TITLE
issue: Featured FAQs On Disable

### DIFF
--- a/include/client/templates/sidebar.tmpl.php
+++ b/include/client/templates/sidebar.tmpl.php
@@ -19,8 +19,9 @@ $BUTTONS = isset($BUTTONS) ? $BUTTONS : true;
         </div>
 <?php } ?>
         <div class="content"><?php
-    $faqs = FAQ::getFeatured()->select_related('category')->limit(5);
-    if ($faqs->all()) { ?>
+    if ($cfg->isKnowledgebaseEnabled()
+        && ($faqs = FAQ::getFeatured()->select_related('category')->limit(5))
+        && $faqs->all()) { ?>
             <section><div class="header"><?php echo __('Featured Questions'); ?></div>
 <?php   foreach ($faqs as $F) { ?>
             <div><a href="<?php echo ROOT_PATH; ?>kb/faq.php?id=<?php


### PR DESCRIPTION
This addresses an issue where the client portal shows Featured FAQs on the sidebar even though the Knowledgebase is Disabled.