### PR TITLE
issue: Canned Resp Select2 Width

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -193,7 +193,7 @@ var scp_prep = function() {
         }
      });
 
-    $('form select#cannedResp').select2({width: '300px'});
+    $('form select#cannedResp').select2({width: '350px'});
     $('form select#cannedResp').on('select2:opening', function (e) {
         var redactor = $('.richtext', $(this).closest('form')).data('redactor');
         if (redactor)


### PR DESCRIPTION
This enhances the Select2 canned response box by making it wider, showing more text in each line.