### PR TITLE
Search All Tickets Setting

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -937,10 +937,14 @@ class CustomQueue extends VerySimpleModel {
         return $agent && $this->isPrivate() && $this->checkOwnership($agent);
     }
 
+    function isSaved() {
+        return true;
+    }
+
     function ignoreVisibilityConstraints(Staff $agent) {
-        // For saved searches (not queues), some staff can have a permission to
+        // For searches (not queues), some staff can have a permission to
         // see all records
-        return (!$this->isASubQueue()
+        return ($this->isASearch()
                 && $this->isOwner($agent)
                 && $agent->canSearchEverything());
     }
@@ -992,6 +996,10 @@ class CustomQueue extends VerySimpleModel {
 
     function isAQueue() {
         return $this->hasFlag(self::FLAG_QUEUE);
+    }
+
+    function isASearch() {
+        return !$this->isAQueue() || !$this->isSaved();
     }
 
     function isPrivate() {

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -912,6 +912,10 @@ extends SavedSearch {
         return false;
     }
 
+    function isOwner(Staff $staff) {
+        return $this->ht['staff_id'] == $staff->getId();
+    }
+
     function checkAccess($staff) {
         return true;
     }
@@ -921,6 +925,7 @@ extends SavedSearch {
     }
 
     function load($key) {
+        global $thisstaff;
 
         if (strpos($key, 'adhoc') === 0)
             list(, $key) = explode(',', $key, 2);
@@ -933,6 +938,7 @@ extends SavedSearch {
        $queue = new AdhocSearch(array(
                    'id' => "adhoc,$key",
                    'root' => 'T',
+                   'staff_id' => $thisstaff->getId(),
                    'title' => __('Advanced Search'),
                 ));
        $queue->config = $config;


### PR DESCRIPTION
If an Agent has the Miscellaneous setting checked to see all Tickets in search results, they should be able to see the search results of Tickets regardless of their access or if the search is saved or not. They should NOT, however, be able to view those Tickets.

This setting is set here:
Admin Panel | Agents | Choose an Agent | Permissions tab | Miscellaneous tab | Search (checkbox)