### PR TITLE
issue: Old Attachment Names

### DIFF
--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -108,15 +108,23 @@ extends InstrumentedList {
      */
     function keepOnlyFileIds($ids, $inline=false, $lang=false) {
         if (!$ids) $ids = array();
-        $new = array_fill_keys($ids, 1);
+        $new = array_flip($ids);
         foreach ($this as $A) {
             if (!isset($new[$A->file_id]) && $A->lang == $lang && $A->inline == $inline)
                 // Not in the $ids list, delete
                 $this->remove($A);
             unset($new[$A->file_id]);
         }
-        // Everything remaining in $new is truly new
-        $this->upload(array_keys($new), $inline, $lang);
+        $attachments = array();
+        // Format $new for upload() with new name
+        foreach ($new as $id=>$name) {
+            $attachments[] = array(
+                    'id' => $id,
+                    'name' => $name
+                );
+        }
+        // Everything remaining in $attachments is truly new
+        $this->upload($attachments, $inline, $lang);
     }
 
     function upload($files, $inline=false, $lang=false) {


### PR DESCRIPTION
This addresses an issue where uploading a file you’ve uploaded before but renamed is not saving the new name in the Attachment table.