### PR TITLE
issue: FAQ & Canned Attachments Dropping

### DIFF
--- a/scp/canned.php
+++ b/scp/canned.php
@@ -37,6 +37,13 @@ $canned_form = new SimpleForm(array(
    )),
 ));
 
+// Set fields' attachments so exsting files stay put
+if ($canned
+    && $canned->attachments
+    && ($attachments = $canned_form->getField('attachments'))) {
+     $attachments->setAttachments($canned->attachments);
+}
+
 if ($_POST) {
     switch(strtolower($_POST['do'])) {
         case 'update':

--- a/scp/faq.php
+++ b/scp/faq.php
@@ -48,6 +48,21 @@ if ($langs = $cfg->getSecondaryLanguages()) {
 
 $faq_form = new SimpleForm($form_fields, $_POST);
 
+// Set fields' attachments so exsting files stay put
+if ($faq
+    && $faq->getAttachments()->window(array('inline' => false))
+    && ($common_attachments = $faq_form->getField('attachments'))) {
+     // Common attachments
+     $common_attachments->setAttachments($faq->getAttachments()->window(array('inline' => false)));
+}
+if ($langs && $faq) {
+    // Multi-lingual system
+    foreach ($langs as $lang) {
+        $attachments = $faq_form->getField('attachments.'.$lang);
+        $attachments->setAttachments($faq->getAttachments($lang)->window(array('inline' => false)));
+    }
+}
+
 if ($_POST) {
     $errors=array();
     // General attachments
@@ -124,21 +139,6 @@ if ($_POST) {
         default:
             $errors['err']=__('Unknown action');
 
-    }
-}
-else {
-    // Not a POST — load database-backed attachments to attachment fields
-    if ($langs && $faq) {
-        // Multi-lingual system
-        foreach ($langs as $lang) {
-            $attachments = $faq_form->getField('attachments.'.$lang);
-            $attachments->setAttachments($faq->getAttachments($lang)->window(array('inline' => false)));
-        }
-    }
-    if ($faq) {
-        // Common attachments
-        $attachments = $faq_form->getField('attachments');
-        $attachments->setAttachments($faq->getAttachments()->window(array('inline' => false)));
     }
 }
 


### PR DESCRIPTION
This addresses an issue where FAQ & Canned Response attachments are dropping when another agent edits the FAQ or Canned Response.