### PR TITLE
Task Assigned Team Issue:

### DIFF
--- a/include/staff/ticket-tasks.inc.php
+++ b/include/staff/ticket-tasks.inc.php
@@ -79,9 +79,13 @@ if ($count) { ?>
         $id = $task->getId();
         $access = $task->checkStaffPerm($thisstaff);
         $assigned='';
-        if ($task->staff)
-            $assigned=sprintf('<span class="Icon staffAssigned">%s</span>',
-                    Format::truncate($task->staff->getName(),40));
+        if ($task->staff || $task->team) {
+            $assigneeType = $task->staff ? 'staff' : 'team';
+            $icon = $assigneeType == 'staff' ? 'staffAssigned' : 'teamAssigned';
+            $assigned=sprintf('<span class="Icon %s">%s</span>',
+                    $icon,
+                    Format::truncate($task->getAssigned(),40));
+        }
 
         $status = $task->isOpen() ? '<strong>open</strong>': 'closed';
 


### PR DESCRIPTION
This addresses an issue where it appeared as though tasks could not be assigned to teams if an agent in the team was not a part of the task's department. The assigment was actually taking place, however, it was not showing up in the Assignee column. Now the form will correctly display the column