### PR TITLE
issue: Ticket Filter Does Not Match Regex

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -251,7 +251,7 @@ class Filter {
             'starts'    => array('stripos', 0),
             'ends'      => array('iendsWith', true),
             'match'     => array('pregMatchB', 1),
-            'not_match' => array('pregMatchB', null, 0),
+            'not_match' => array('pregMatchB', null, 1),
         );
 
         $match = false;


### PR DESCRIPTION
This addresses an issue reported on the forums where the ticket filter Rule option of "Does Not Match Regex" isn’t working properly; instead it works in reverse.