### PR TITLE
queues: Column Conditions Overwrite

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -2248,7 +2248,7 @@ extends VerySimpleModel {
             if ($include_queue && ($q = $this->getQueue())
                 && ($q_conds = $q->getConditions())
             ) {
-                $this->_conditions = array_merge($this->_conditions, $q_conds);
+                $this->_conditions = array_merge($q_conds, $this->_conditions);
             }
         }
         return $this->_conditions;


### PR DESCRIPTION
This addresses an issue where Column Conditions are not overwriting the Row Conditions. This changes the order of `array_merge()` to make Column Conditions overwrite the Row Conditions.