### PR TITLE
sessions: Clear On Password Set/Reset

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -396,7 +396,7 @@ class ClientAccount extends UserAccount {
         global $cfg;
 
         // FIXME: Updates by agents should go through UserAccount::update()
-        global $thisstaff;
+        global $thisstaff, $thisclient;
         if ($thisstaff)
             return parent::update($vars, $errors);
 
@@ -454,6 +454,8 @@ class ClientAccount extends UserAccount {
             Signal::send('auth.pwchange', $this->getUser(), $info);
             $this->cancelResetTokens();
             $this->clearStatus(UserAccountStatus::REQUIRE_PASSWD_RESET);
+            // Clean sessions
+            Signal::send('auth.clean', $this->getUser(), $thisclient);
         }
 
         return $this->save();

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -217,6 +217,8 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
     }
 
     function setPassword($new, $current=false) {
+        global $thisstaff;
+
         // Allow the backend to update the password. This is the preferred
         // method as it allows for integration with password policies and
         // also allows for remotely updating the password where possible and
@@ -240,6 +242,9 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $this->change_passwd = 0;
         $this->cancelResetTokens();
         $this->passwdreset = SqlFunction::NOW();
+
+        // Clean sessions
+        Signal::send('auth.clean', $this, $thisstaff);
 
         return $rv;
     }

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1033,6 +1033,8 @@ class UserAccount extends VerySimpleModel {
 
     function setPassword($new) {
         $this->set('passwd', Passwd::hash($new));
+        // Clean sessions
+        Signal::send('auth.clean', $this->getUser());
     }
 
     protected function sendUnlockEmail($template) {


### PR DESCRIPTION
This adds a Signal to clean Agent and User sessions upon setting/resetting their password. If an Agent/User resets their own password and has multiple sessions open it will log them out of every session except the one they’re on.