### PR TITLE
issue: mPDF SetAutoFont RTL

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -86,7 +86,7 @@ class Ticket2PDF extends mPDFWithLocalImages
             return;
         $html = ob_get_clean();
 
-        $this->SetAutoFont();
+        $this->SetAutoFont(AUTOFONT_RTL);
         $this->WriteHtml($html, 0, true, true);
     }
 }
@@ -116,7 +116,7 @@ class Task2PDF extends mPDFWithLocalImages {
         ob_start();
         include STAFFINC_DIR.'templates/task-print.tmpl.php';
         $html = ob_get_clean();
-        $this->SetAutoFont();
+        $this->SetAutoFont(AUTOFONT_RTL);
         $this->WriteHtml($html, 0, true, true);
 
     }


### PR DESCRIPTION
This addresses an issue where `SetAutoFont()` was making the Thai PDFs break. This adds the `AUTOFONT_RTL` flag to only autodetect RTL languages and nothing else.