### PR TITLE
Charset: Add generic transcode php_user_filter

### DIFF
--- a/include/class.charset.php
+++ b/include/class.charset.php
@@ -77,4 +77,32 @@ class Charset {
         return self::transcode($text, $charset, self::UTF8);
     }
 }
+
+class transcode_filter extends php_user_filter {
+  var $from;
+  var $to;
+
+  function filter($in, $out, &$consumed, $closing) {
+      while ($bucket = stream_bucket_make_writeable($in)) {
+        $bucket->data = Charset::transcode($bucket->data, $this->from,
+                $this->to);
+        $consumed += $bucket->datalen;
+        stream_bucket_append($out, $bucket);
+      }
+      return PSFS_PASS_ON;
+  }
+
+  function onCreate() {
+      switch ($this->filtername) {
+      case 'transcode.utf8-ascii':
+          $this->from ='utf-8';
+          $this->to = 'ISO-8859-1';
+          break;
+      default:
+          return false;
+      }
+      return true;
+  }
+}
+stream_filter_register('transcode.*', 'transcode_filter');
 ?>


### PR DESCRIPTION
This will be useful when converting content on the fly on write or read -allowing for support for output filter for file storage backend. 