### PR TITLE
issue: CDATA Phone Contains

### DIFF
--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -10,13 +10,15 @@ $users = User::objects()
 
 if ($_REQUEST['query']) {
     $search = $_REQUEST['query'];
-    $users->filter(Q::any(array(
+    $filter = Q::any(array(
         'emails__address__contains' => $search,
         'name__contains' => $search,
         'org__name__contains' => $search,
-        'cdata__phone__contains' => $search,
-        // TODO: Add search for cdata
-    )));
+    ));
+    if (UserForm::getInstance()->getField('phone'))
+        $filter->add(array('cdata__phone__contains' => $search));
+
+    $users->filter($filter);
     $qs += array('query' => $_REQUEST['query']);
 }
 


### PR DESCRIPTION
This addresses an issue where people who do not have a phone field on the contact information form go to search for a User in the User Directory and the system crashes. This is due to the search query that always contains the phone field variable. This only adds the phone variable to the search query if the field actually exists.