### PR TITLE
issue: Duplicate Page Requests

### DIFF
--- a/js/osticket.js
+++ b/js/osticket.js
@@ -45,6 +45,9 @@ $(document).ready(function(){
 
     $('form').submit(function() {
         $(window).unbind('beforeunload');
+        // Disable client-side Post Reply/Create Ticket buttons to help
+        // prevent duplicate POST
+        $(':submit', $(this)).attr('disabled', true);
         $('#overlay, #loading').show();
         return true;
        });

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -163,6 +163,9 @@ var scp_prep = function() {
 
     $('form.save, form:has(table.list)').submit(function() {
         $(window).unbind('beforeunload');
+        // Disable staff-side Post Reply/Open buttons to help prevent
+        // duplicate POST
+        $(':submit', $(this)).attr('disabled', true);
         $('#overlay, #loading').show();
         return true;
      });


### PR DESCRIPTION
This addresses an issue where clicking Open, Post Reply, etc. more than once whilst creating/responding to a ticket will generate duplicate requests. This causes duplicate responses to be sent out or duplicate tickets being created. This adds jQuery, on both Agent and User side, to disable the submit buttons when the "Loading" popup appears so you cannot click the button more than once.