### PR TITLE
forms: Disabled By Help Topic Users

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -155,8 +155,12 @@ class DynamicForm extends VerySimpleModel {
         $inst = DynamicFormEntry::create(
             array('form_id'=>$this->get('id'), 'sort'=>$sort)
         );
+
         if ($data)
             $inst->setSource($data);
+
+        $inst->_fields = $this->_fields ?: null;
+
         return $inst;
     }
 


### PR DESCRIPTION
This addresses issue #4470 where Users creating tickets via Client Portal and failing to fill out a required field makes disabled fields by Help Topic appear on the page. When the disabled fields appear they allow Users to populate and save data that they were not meant to submit.