### PR TITLE
issue: Image CID Attributes

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -308,8 +308,9 @@ class Format {
                   ':<html[^>]+:i',              # drop html attributes
                   ':<(a|span) (name|style)="(mso-bookmark\:)?_MailEndCompose">(.+)?<\/(a|span)>:', # Drop _MailEndCompose
                   ':<div dir=(3D)?"ltr">(.*?)<\/div>(.*):is', # drop Gmail "ltr" attributes
+                  ':data-cid="[^"]*":',         # drop image cid attributes
             ),
-            array('', '', '', '', '<html', '$4', '$2 $3'),
+            array('', '', '', '', '<html', '$4', '$2 $3', ''),
             $html);
 
         // HtmLawed specific config only


### PR DESCRIPTION
This addresses an issue where images in email signatures containing a `data-cid` attribute will either crash the ticket page or not show the image in the signature in IE.