### PR TITLE
issue: Session form-data Files

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4401,12 +4401,12 @@ class FileUploadWidget extends Widget {
         );
         $maxfilesize = ($config['size'] ?: 1048576) / 1048576;
         $files = array();
-        $new = array_fill_keys($this->field->getClean(), 1);
+        $new = array_flip($this->field->getClean());
 
         //get file ids stored in session when creating tickets/tasks from thread
         if (!$new && is_array($_SESSION[':form-data'])
                   && array_key_exists($this->field->get('name'), $_SESSION[':form-data']))
-          $new = array_fill_keys($_SESSION[':form-data'][$this->field->get('name')], 1);
+          $new = $_SESSION[':form-data'][$this->field->get('name')];
 
         foreach ($attachments as $a) {
             unset($new[$a->file_id]);
@@ -4493,7 +4493,7 @@ class FileUploadWidget extends Widget {
         // Files attached to threads where we are creating tasks/tickets are allowed
         if (isset($_SESSION[':form-data'][$this->field->get('name')])) {
           foreach ($_SESSION[':form-data'][$this->field->get('name')] as $key => $value)
-            $allowed[$value] = 1;
+            $allowed[$key] = $value;
         }
 
         // Canned attachments initiated by this session

--- a/include/class.thread_actions.php
+++ b/include/class.thread_actions.php
@@ -524,7 +524,7 @@ JS
               unset($_SESSION[':form-data'][$k]);
               foreach ($this->entry->getAttachments() as $a)
                   if (!$a->inline && $a->file) {
-                    $_SESSION[':form-data'][$k][] = $a->file->getId();
+                    $_SESSION[':form-data'][$k][$a->file->getId()] = $a->getFilename();
                   }
         }
 

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -30,7 +30,7 @@ if (!$user && $_GET['tid'] && ($entry = ThreadEntry::lookup($_GET['tid']))) {
          unset($_SESSION[':form-data'][$k]);
         foreach ($entry->getAttachments() as $a) {
           if (!$a->inline && $a->file) {
-            $_SESSION[':form-data'][$k][] = $a->file->getId();
+            $_SESSION[':form-data'][$k][$a->file->getId()] = $a->getFilename();
           }
         }
      }


### PR DESCRIPTION
This addresses an issue where `$_SESSION[':form-data']` files are not including the new filenames.