### PR TITLE
issue: Default Help Topic Issue Summary

### DIFF
--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -26,7 +26,7 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
             $F = $F->instanciate();
             $F->isValidForClient();
         }
-        $forms[] = $F;
+        $forms[] = $F->getForm();
     }
 }
 


### PR DESCRIPTION
This addresses issue #4473 where users creating a ticket with the Help Topic preselected shows a validation error for the Issue Summary field. This is due to the new `getFormName()` function that creates new field form names based on the user’s/agent’s session. When the Help Topic is preselected, `_form` is not set for each field so the hashed name of the fields before ticket submit is different than after ticket submit.