### PR TITLE
issue: Existing User Registration

### DIFF
--- a/account.php
+++ b/account.php
@@ -81,7 +81,7 @@ elseif ($_POST) {
     elseif (!$user_form->getField('name')->getClean())
         $errors['name'] = sprintf(__('%s is a required field'), $user_form->getField('name')->getLocal('label'));
     // Registration for existing users
-    elseif ($addr && !($user = User::lookupByEmail($addr)))
+    elseif ($addr && ($user = User::lookupByEmail($addr)) && !$user->updateInfo($_POST, $errors))
       $errors['err'] = __('Unable to register account. See messages below');
     // Users created from ClientCreateRequest
     elseif (isset($_POST['backend']) && !($user = User::fromVars($user_form->getClean())))


### PR DESCRIPTION
This addresses an issue where registering as a non-existing user fails to register nor create an account. This is due to a check added in `824e92` that fails if there is no User model found for the address provided.