### PR TITLE
forms: Render Instructions

### DIFF
--- a/scp/forms.php
+++ b/scp/forms.php
@@ -8,6 +8,7 @@ if($_REQUEST['id'] && !($form=DynamicForm::lookup($_REQUEST['id'])))
 
 if($_POST) {
     $_POST = Format::htmlchars($_POST, true);
+    $_POST['instructions'] = Format::htmldecode($_POST['instructions']);
     $fields = array('title', 'notes', 'instructions');
     $required = array('title');
     $max_sort = 0;


### PR DESCRIPTION
This addresses issue #4493 where the system renders form instructions as plain text instead of HTML. The data is saved in the db as encoded HTML and upon pulling the data we do not decode it back to HTML for rendering.