### PR TITLE
oops: Selection Search Bug

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1822,7 +1822,9 @@ class SelectionField extends FormField {
 
     function getSearchQ($method, $value, $name=false) {
         $name = $name ?: $this->get('name');
-        $val = '"?'.implode('("|,|$)|"?', array_keys($value)).'("|,|$)';
+        $val = $value;
+        if ($value && is_array($value))
+            $val = '"?'.implode('("|,|$)|"?', array_keys($value)).'("|,|$)';
         switch ($method) {
         case '!includes':
             return Q::not(array("{$name}__regex" => $val));


### PR DESCRIPTION
This addresses an issue introduced with #4124 where searching for a Selection Field with the criteria "does not have a value" throws an `implode()` warning.