### PR TITLE
Email Name Format

### DIFF
--- a/include/class.collaborator.php
+++ b/include/class.collaborator.php
@@ -41,7 +41,7 @@ implements EmailContact, ITicketUser {
         return Format::htmlchars($this->toString());
     }
     function toString() {
-        return sprintf('%s <%s>', $this->getName(), $this->getEmail());
+        return sprintf('"%s" <%s>', $this->getName(), $this->getEmail());
     }
 
     function getId() {

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -678,7 +678,7 @@ implements TemplateVariable {
                 $this->getDomain());
 
         if ($this->getName())
-            $this->address = sprintf('%s <%s>',
+            $this->address = sprintf('"%s" <%s>',
                     $this->getName(),
                     $this->email);
     }


### PR DESCRIPTION
This commit further corrects issues where emails were being sent out with names being improperly formatted if the name format is set as 'Last, First' or if it has special characters.