### PR TITLE
Filter Action Send an Email Issue

### DIFF
--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -561,8 +561,9 @@ class FA_SendEmail extends TriggerAction {
     }
 
     function getConfigurationOptions() {
-        $choices = array('' => __('Default System Email'));
-        $choices += Email::getAddresses();
+        global $cfg;
+
+        $choices = Email::getAddresses();
 
         return array(
             'recipients' => new TextboxField(array(
@@ -608,7 +609,7 @@ class FA_SendEmail extends TriggerAction {
             'from' => new ChoiceField(array(
                 'label' => __('From Email'),
                 'choices' => $choices,
-                'default' => '',
+                'default' => $cfg->getDefaultEmail()->getId(),
             )),
         );
     }


### PR DESCRIPTION
This commit fixes an issue we had with adding a Filter Action to Send an Email. We had an option at the top for 'Default System Email', however, it did not have the Email ID or address for the system email and would throw an error if chosen. Now, we just retrieve the emails with their IDs and values with the Default System Email being the initial value selected in the list of options.