### PR TITLE
issue: Newly Added Queues

### DIFF
--- a/scp/queues.php
+++ b/scp/queues.php
@@ -42,7 +42,6 @@ if ($_POST) {
 
     case 'create':
         $queue = CustomQueue::create(array(
-            'flags' => CustomQueue::FLAG_PUBLIC,
             'staff_id' => 0,
             'title' => $_POST['queue-name'],
             'root' => $_POST['root'] ?: 'T'


### PR DESCRIPTION
This addresses an issue where newly added queues in the Admin Panel do not show up in the list of queues nor in the ticket view. This is due to the function that does not set any additional flags on queues if one already exists.