### PR TITLE
Retain Help Topics for Emails

### DIFF
--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -195,19 +195,6 @@ implements TemplateVariable, Searchable {
       return !!($this->flags & self::FLAG_ACTIVE);
     }
 
-    function clearInactiveTopic($topic_id) {
-      global $cfg;
-
-      $emails = Email::objects()->filter(array('topic_id'=>$topic_id))->values_flat('email_id');
-      if ($emails) {
-        foreach ($emails as $email_id) {
-          $email = Email::lookup($email_id[0]);
-          $email->topic_id = $cfg->getDefaultTopicId();
-          $email->save();
-        }
-      }
-    }
-
     function getStatus() {
       if($this->flags & self::FLAG_ACTIVE)
         return 'Active';

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -28,9 +28,6 @@ if($_POST){
             if(!$topic){
                 $errors['err']=sprintf(__('%s: Unknown or invalid'), __('help topic'));
             }elseif($topic->update($_POST,$errors)){
-              if ($_POST["status"] != __('Active'))
-                Topic::clearInactiveTopic($topic->getId());
-
                 $msg=sprintf(__('Successfully updated %s.'),
                     __('this help topic'));
             }elseif(!$errors['err']){
@@ -101,11 +98,8 @@ if($_POST){
                           $t->setFlag(Topic::FLAG_ACTIVE, false);
                           $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
                           FilterAction::setFilterFlag($filter_actions, 'topic', true);
-                          if($t->save()) {
+                          if($t->save())
                             $num++;
-                            //remove topic_id for emails using disabled topic
-                            Topic::clearInactiveTopic($t->getId());
-                          }
                         }
                         if ($num > 0) {
                             if($num==$count)
@@ -130,11 +124,8 @@ if($_POST){
                           $t->setFlag(Topic::FLAG_ACTIVE, false);
                           $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
                           FilterAction::setFilterFlag($filter_actions, 'topic', true);
-                          if($t->save()) {
+                          if($t->save())
                             $num++;
-                            //remove topic_id for emails using disabled topic
-                            Topic::clearInactiveTopic($t->getId());
-                          }
                         }
                         if ($num > 0) {
                             if($num==$count)


### PR DESCRIPTION
If a Help Topic is disabled or archived and it is also selected as the Help Topic for an Email, make sure we do not remove that Help Topic from the Email. Instead, if that email receives a Ticket, we should just assign the ticket to the Default Help Topic. If there is no Default Help Topic, the Ticket will not have a Help Topic at all.