### PR TITLE
issue: Company Name Variable

### DIFF
--- a/include/class.company.php
+++ b/include/class.company.php
@@ -49,7 +49,12 @@ implements TemplateVariable {
     }
 
     function getInfo() {
-        return $this->getForm()->getClean();
+        // Loop through fields and return array of id=>value, name=>value
+        foreach ($this->getForm()->getFields() as $k=>$f) {
+            $info[$key] = $info[$f->get('name')] =
+                ($a=$f->getAnswer()) ? $a->getValue() : null;
+        }
+        return $info;
     }
 
     function getName() {


### PR DESCRIPTION
This addresses an issue where manually typing the User's email and name on the create ticket form causes the %{company.name} variable in the New Ticket Notice template to become the User's full name. This is due to `$this->getForm()->getClean()` which returns the incorrect values for the correct form fields.