### PR TITLE
issue: Australian Timezones

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -95,6 +95,17 @@ class Misc {
             return $timestamp - $tz->getOffset($date);
         }
 
+        // Parse and remove the timezone from the datetime string to avoid
+        // fatal errors on DateTime::__construct()
+        $parsed = date_parse($timestamp);
+        $timestamp = date('Y-m-d H:i:s', mktime(
+                $parsed['hour'],
+                $parsed['minute'],
+                $parsed['second'],
+                $parsed['month'],
+                $parsed['day'],
+                $parsed['year']
+            ));
         $date = new DateTime($timestamp ?: 'now', $tz);
         return $date ? $date->getTimestamp() : $timestamp;
     }


### PR DESCRIPTION
This addresses an issue where Australian timezones (specifically `AEST`) will throw a fatal error when creating a task. This is due to the way we create the time in the backend where DateTime class "cannot find `AEST` in the database".