### PR TITLE
change old wiki urls to new doc urls

### DIFF
--- a/include/i18n/en_US/templates/ticket/upgraded.yaml
+++ b/include/i18n/en_US/templates/ticket/upgraded.yaml
@@ -13,7 +13,7 @@ subject: osTicket Upgraded!
 message: |
     <p>
     osTicket upgraded successfully! Please refer to the Release Notes
-    (http://osticket.com/wiki/Release_Notes) for more information about
+    (https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes) for more information about
     changes and new features.
     </p><p>
     Be sure to join the <a href="http://osticket.com/forums">osTicket

--- a/include/upgrader/done.inc.php
+++ b/include/upgrader/done.inc.php
@@ -9,7 +9,7 @@ $_SESSION['ost_upgrader']=null;
         <div id="intro">
         <p><?php echo __('Congratulations! osTicket upgrade has been completed successfully.');?></p>
         <p><?php echo sprintf(__('Please refer to %s for more information about changes and/or new features.'),
-            sprintf('<a href="http://osticket.com/wiki/Release_Notes" target="_blank">%s</a>',
+            sprintf('<a href="https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes" target="_blank">%s</a>',
             __('Release Notes')
         ));?></p>
         </div>
@@ -26,7 +26,7 @@ $_SESSION['ost_upgrader']=null;
             <p><b><?php echo __('Post-upgrade');?></b>: <?php
             echo sprintf(__('You can now go to %s to enable the system and explore the new features. For complete and up-to-date release notes see the %s'),
                 sprintf('<a href="'. ROOT_PATH . 'scp/settings.php" target="_blank">%s</a>', __('Admin Panel')),
-                sprintf('<a href="http://osticket.com/wiki/Release_Notes" target="_blank">%s</a>', __('osTicket Wiki')));?></p>
+                sprintf('<a href="https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes" target="_blank">%s</a>', __('osTicket Docs')));?></p>
             <p><b><?php echo __('Stay up to date');?></b>: <?php echo __("It's important to keep your osTicket installation up to date. Get announcements, security updates and alerts delivered directly to you!");?>
             <?php echo sprintf(__('%1$s Get in the loop %2$s today and stay informed!'), '<a target="_blank" href="http://osticket.com/subscribe.php">', '</a>');?></p>
             <p><b><?php echo __('Commercial Support Available');?></b>: <?php echo sprintf(__('Get guidance and hands-on expertise to address unique challenges and make sure your osTicket runs smoothly, efficiently, and securely. %1$s Learn More! %2$s'), '<a target="_blank" href="http://osticket.com/support">','</a>');?></p>


### PR DESCRIPTION
fixes two urls in the code to point from the old /wiki to the same place in the new doc.osticket.com