### PR TITLE
[php7:warn] 7.2 : fix  count() warning in class.translation.php

### DIFF
--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -672,7 +672,7 @@ class Translation extends gettext_reader implements Serializable {
         list($this->charset, $this->encode, $this->cache_translations)
             = unserialize($what);
         $this->short_circuit = ! $this->enable_cache
-            = 0 < count($this->cache_translations);
+            = 0 < is_array($this->cache_translations) && count($this->cache_translations);
     }
 }
 


### PR DESCRIPTION
this is a try at annoyng: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in .../upload/include/class.translation.php on line 674

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>