### PR TITLE
View All Tickets for User

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -53,7 +53,7 @@ if (!$ticket) {
             && $_GET['a'] !== 'open'
     ) {
         $criteria = [
-            ['user__name', 'equal', $user->name],
+            ['user__emails__address', 'equal', $user->getDefaultEmailAddress()],
             ['user_id', 'equal', $user->id],
         ];
         if ($S = $_GET['status'])


### PR DESCRIPTION
When clicking 'All Tickets' for a User from within a Ticket, make sure we search using the User's email address instead of their Full Name in case we have users with the same name.