### PR TITLE
Ticket Sources

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -534,7 +534,8 @@ implements RestrictedAccess, Threadable, Searchable {
     }
 
     function getSource() {
-        return $this->source;
+        $sources = $this->getSources();
+        return $sources[$this->source] ?: $this->source;
     }
 
     function getIP() {
@@ -549,7 +550,7 @@ implements RestrictedAccess, Threadable, Searchable {
         global $cfg;
 
         return array(
-            'source'    => $this->getSource(),
+            'source'    => $this->source,
             'topicId'   => $this->getTopicId(),
             'slaId'     => $this->getSLAId(),
             'user_id'   => $this->getOwnerId(),
@@ -1028,7 +1029,7 @@ implements RestrictedAccess, Threadable, Searchable {
                         'id' => $fid,
                         'name' => 'source',
                         'label' => __('Ticket Source'),
-                        'default' => $this->getSource(),
+                        'default' => $this->source,
                         'choices' => Ticket::getSources()
                         ));
             break;


### PR DESCRIPTION
This commit ensures that we will always have the correct display of values for the Ticket Source regardless of if the key and value differ.
Ex: if we had a Ticket Source that contained a space in the value, the key would be camel cased in the database enum for source