### PR TITLE
Form Attachment Issues

### DIFF
--- a/include/ajax.tasks.php
+++ b/include/ajax.tasks.php
@@ -84,8 +84,10 @@ class TasksAjaxAPI extends AjaxController {
     function add($tid=0, $vars=array()) {
         global $thisstaff;
 
-        if ($tid)
-          $originalTask = Task::lookup($tid);
+        if ($tid) {
+            $vars = array_merge($_SESSION[':form-data'], $vars);
+            $originalTask = Task::lookup($tid);
+        }
         else
           unset($_SESSION[':form-data']);
 

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1382,7 +1382,7 @@ function refer($tid, $target=null) {
                 && ($f=$iform->getField('duedate'))) {
             $f->configure('max', Misc::db2gmtime($ticket->getEstDueDate()));
         }
-
+        $vars = array_merge($_SESSION[':form-data'], $vars);
 
         if ($_POST) {
             Draft::deleteForNamespace(

--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -108,16 +108,15 @@ extends InstrumentedList {
      */
     function keepOnlyFileIds($ids, $inline=false, $lang=false) {
         if (!$ids) $ids = array();
-        $new = array_flip($ids);
         foreach ($this as $A) {
-            if (!isset($new[$A->file_id]) && $A->lang == $lang && $A->inline == $inline)
+            if (!isset($ids[$A->file_id]) && $A->lang == $lang && $A->inline == $inline)
                 // Not in the $ids list, delete
                 $this->remove($A);
-            unset($new[$A->file_id]);
+            unset($ids[$A->file_id]);
         }
         $attachments = array();
         // Format $new for upload() with new name
-        foreach ($new as $id=>$name) {
+        foreach ($ids as $id=>$name) {
             $attachments[] = array(
                     'id' => $id,
                     'name' => $name
@@ -134,7 +133,7 @@ extends InstrumentedList {
         foreach ($files as $file) {
             if (is_numeric($file))
                 $fileId = $file;
-            elseif (is_array($file) && isset($file['id']))
+            elseif (is_array($file) && isset($file['id']) && $file['id'] != 0)
                 $fileId = $file['id'];
             elseif (isset($file['tmp_name']) && ($F = AttachmentFile::upload($file)))
                 $fileId = $F->getId();

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1082,21 +1082,21 @@ implements TemplateVariable {
             $files = array($files);
 
         $ids = array();
-        foreach ($files as $name => $file) {
-            $F = array('inline' => is_array($file) && @$file['inline']);
+        foreach ($files as $id => $info) {
+            $F = array('inline' => is_array($info) && @$info['inline']);
 
-            if (is_numeric($file))
-                $fileId = $file;
-            elseif ($file instanceof AttachmentFile)
-                $fileId = $file->getId();
-            elseif (is_array($file) && isset($file['id']))
-                $fileId = $file['id'];
-            elseif ($AF = AttachmentFile::create($file))
+            if (is_numeric($id) && $id != 0)
+                $fileId = $id;
+            elseif ($info instanceof AttachmentFile)
+                $fileId = $info->getId();
+            elseif (is_array($info) && isset($info['id']))
+                $fileId = $info['id'];
+            elseif ($AF = AttachmentFile::create($info))
                 $fileId = $AF->getId();
             elseif ($add_error) {
-                $error = $file['error']
+                $error = $info['error']
                     ?: sprintf(_S('Unable to import attachment - %s'),
-                        $name ?: $file['name']);
+                        $id ?: $info['name']);
                 if (is_numeric($error) && isset($error_descriptions[$error])) {
                     $error = sprintf(_S('Error #%1$d: %2$s'), $error,
                         _S($error_descriptions[$error]));
@@ -1119,15 +1119,15 @@ implements TemplateVariable {
 
             $F['id'] = $fileId;
 
-            if (is_string($name))
-                $F['name'] = $name;
+            if (is_string($info))
+                $F['name'] = $info;
             if (isset($AF))
                 $F['file'] = $AF;
 
             // Add things like the `key` field, but don't change current
             // keys of the file array
-            if (is_array($file))
-                $F += $file;
+            if (is_array($info))
+                $F += $info;
 
             // Key is required for CID rewriting in the body
             if (!isset($F['key']) && ($AF = AttachmentFile::lookup($F['id'])))

--- a/include/class.thread_actions.php
+++ b/include/class.thread_actions.php
@@ -525,6 +525,7 @@ JS
               foreach ($this->entry->getAttachments() as $a)
                   if (!$a->inline && $a->file) {
                     $_SESSION[':form-data'][$k][$a->file->getId()] = $a->getFilename();
+                    $_SESSION[':uploadedFiles'][$a->file->getId()] = $a->getFilename();
                   }
         }
 

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -31,6 +31,7 @@ if (!$user && $_GET['tid'] && ($entry = ThreadEntry::lookup($_GET['tid']))) {
         foreach ($entry->getAttachments() as $a) {
           if (!$a->inline && $a->file) {
             $_SESSION[':form-data'][$k][$a->file->getId()] = $a->getFilename();
+            $_SESSION[':uploadedFiles'][$a->file->getId()] = $a->getFilename();
           }
         }
      }

--- a/scp/tasks.php
+++ b/scp/tasks.php
@@ -48,9 +48,7 @@ if($_POST && !$errors):
         switch(strtolower($_POST['a'])):
         case 'postnote': /* Post Internal Note */
             $vars = $_POST;
-            $attachments = $note_attachments_form->getField('attachments')->getClean();
-            $vars['cannedattachments'] = array_merge(
-                $vars['cannedattachments'] ?: array(), $attachments);
+            $vars['cannedattachments'] = $note_attachments_form->getField('attachments')->getClean();
 
             $wasOpen = ($task->isOpen());
             if(($note=$task->postNote($vars, $errors, $thisstaff))) {
@@ -78,9 +76,7 @@ if($_POST && !$errors):
             break;
         case 'postreply': /* Post an update */
             $vars = $_POST;
-            $attachments = $reply_attachments_form->getField('attachments')->getClean();
-            $vars['cannedattachments'] = array_merge(
-                $vars['cannedattachments'] ?: array(), $attachments);
+            $vars['cannedattachments'] = $reply_attachments_form->getField('attachments')->getClean();
 
             $wasOpen = ($task->isOpen());
             if (($response=$task->postReply($vars, $errors))) {

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -211,9 +211,7 @@ if($_POST && !$errors):
             break;
         case 'postnote': /* Post Internal Note */
             $vars = $_POST;
-            $attachments = $note_form->getField('attachments')->getClean();
-            $vars['cannedattachments'] = array_merge(
-                $vars['cannedattachments'] ?: array(), $attachments);
+            $vars['cannedattachments'] = $note_form->getField('attachments')->getClean();
             $vars['note'] = ThreadEntryBody::clean($vars['note']);
 
             if ($cfg->isTicketLockEnabled()) {
@@ -418,6 +416,10 @@ if($_POST && !$errors):
                         $response_form->getField('attachments')->reset();
                         $_SESSION[':form-data'] = null;
                     } elseif(!$errors['err']) {
+                        // ensure that we retain the tid if ticket is created from thread
+                        if ($_SESSION[':form-data']['ticketId'] || $_SESSION[':form-data']['taskId'])
+                            $_GET['tid'] = $_SESSION[':form-data']['ticketId'] ?: $_SESSION[':form-data']['taskId'];
+
                         $errors['err']=sprintf('%s %s',
                             __('Unable to create the ticket.'),
                             __('Correct any errors below and try again.'));


### PR DESCRIPTION
- Make sure we keep attachments in the session even if the page refreshes to display an error message
- Reverse the array of files to be id => name instead of name => id
- Make sure we retain the old ticket or task id if we encounter an error while trying to create a ticket or task from a thread entry
- Make sure we have a valid fileId before returning file info
- Make sure we can still add files for Canned Responses (id and name flip issue)
- Make sure we can still add attachments to Internal Notes for Tickets and Tasks