### PR TITLE
Missing Pid Fix

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2496,6 +2496,9 @@ implements RestrictedAccess, Threadable {
         if (!$vars['ip_address'] && $_SERVER['REMOTE_ADDR'])
             $vars['ip_address'] = $_SERVER['REMOTE_ADDR'];
 
+        if (!$vars['msgId'] && $thisstaff)
+            $vars['msgId'] = $this->getLastMessage()->id;
+
         if (!($response = $this->getThread()->addResponse($vars, $errors)))
             return null;
 


### PR DESCRIPTION
This Pull Request fixes the missing `pid` in `thread_entry` table.

Before:
Everytime an agent replies to a ticket, the `pid` in `thread_entry` table is always `0`. The `pid` should be the `id` of the last message posted by the user. And missing `pid` does also affect the Response Time in the dashboard since it calculates the time difference between the last message from user and reply from agent. 

After:
The `pid` is assigned with the `id` of the last message posted by user. The Response Time in the dashboard should be working correctly now.