### PR TITLE
Inline Edit Save Permissions

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3330,7 +3330,10 @@ implements RestrictedAccess, Threadable, Searchable {
             $errors['field'] = sprintf(__('%s is already assigned this value'),
                     __($field->getLabel()));
         else {
-            if ($field->answer) {
+            if (!$field->isEditableToStaff())
+                $errors['field'] = sprintf(__('%s can not be edited'),
+                        __($field->getLabel()));
+            elseif ($field->answer) {
                 if (!$field->save())
                     $errors['field'] =  __('Unable to update field');
                 $changes['fields'] = array($field->getId() => $changes);


### PR DESCRIPTION
This commit ensures that we make sure a field can be edited before doing an inline update.