### PR TITLE
upgrade: Actually re-fetch the config from database

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -30,10 +30,6 @@ class Config {
     # new settings and the corresponding default values.
     var $defaults = array();                # List of default values
 
-
-    # Items
-    var $items = null;
-
     function __construct($section=null, $defaults=array()) {
         if ($section)
             $this->section = $section;
@@ -133,18 +129,11 @@ class Config {
 
     function destroy() {
         unset($this->session);
-        if ($this->items)
-            $this->items->delete();
-
-        return true;
+        return $this->items()->delete() > 0;
     }
 
     function items() {
-
-        if (!isset($this->items))
-            $this->items = ConfigItem::items($this->section, $this->section_column);
-
-        return $this->items;
+        return ConfigItem::items($this->section, $this->section_column);
     }
 }
 

--- a/include/cli/modules/upgrade.php
+++ b/include/cli/modules/upgrade.php
@@ -51,12 +51,12 @@ class CliUpgrader extends Module {
         $cfg = $ost->getConfig();
 
         while (true) {
-            if ($upgrader->getTask()) {
-                // If there's anythin in the model cache (like a Staff
-                // object or something), ensure that changes to the database
-                // model won't cause crashes
-                ModelInstanceManager::flushCache();
+            // If there's anythin in the model cache (like a Staff
+            // object or something), ensure that changes to the database
+            // model won't cause crashes
+            ModelInstanceManager::flushCache();
 
+            if ($upgrader->getTask()) {
                 // More pending tasks - doTasks returns the number of pending tasks
                 $this->stdout->write("... {$upgrader->getNextAction()}\n");
                 $upgrader->doTask();


### PR DESCRIPTION
This patch fixes the issue where the configuration was not properly reloaded during an upgrade. The configuration items were stashed in the Config class and were not re-fetched from the ::load() method. Additionally, this patch forces the ORM cached objects to be flushed on each loop through the automated upgrader to ensure that cached data which might have been modified directly in the database during the database process is destroyed.