### PR TITLE
issue: Dupe Page Requests Fix

### DIFF
--- a/js/osticket.js
+++ b/js/osticket.js
@@ -47,7 +47,15 @@ $(document).ready(function(){
         $(window).unbind('beforeunload');
         // Disable client-side Post Reply/Create Ticket buttons to help
         // prevent duplicate POST
-        $(':submit', $(this)).attr('disabled', true);
+        var form = $(this);
+        $(this).find('input[type="submit"]').each(function (index) {
+            // Clone original input
+            $(this).clone(false).removeAttr('id').prop('disabled', true).insertBefore($(this));
+
+            // Hide original input and add it to top of form
+            $(this).hide();
+            form.prepend($(this));
+        });
         $('#overlay, #loading').show();
         return true;
        });

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -165,7 +165,15 @@ var scp_prep = function() {
         $(window).unbind('beforeunload');
         // Disable staff-side Post Reply/Open buttons to help prevent
         // duplicate POST
-        $(':submit', $(this)).attr('disabled', true);
+        var form = $(this);
+        $(this).find('input[type="submit"]').each(function (index) {
+            // Clone original input
+            $(this).clone(false).removeAttr('id').prop('disabled', true).insertBefore($(this));
+
+            // Hide original input and add it to top of form
+            $(this).hide();
+            form.prepend($(this));
+        });
         $('#overlay, #loading').show();
         return true;
      });


### PR DESCRIPTION
This addresses an issue with pull #4472 where disabling the Submit button does not submit the Input value for the button. This affects the installation of plugins, where the Install Path is not sent therefore the plugin is not installed. This clones the original submit button, hides it, then displays a dummy disabled Submit button which will submit the value and prevent dupe posts.