### PR TITLE
issue: Export Event State Error

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -76,7 +76,7 @@ class Export {
                     ->aggregate(array('count' => SqlAggregate::COUNT('entries__attachments__id'))),
                 'reopen_count' => TicketThread::objects()
                     ->filter(array('ticket__ticket_id' => new SqlField('ticket_id', 1)))
-                    ->filter(array('events__annulled' => 0, 'events__state' => 'reopened'))
+                    ->filter(array('events__annulled' => 0, 'events__event_id' => Event::getIdByName('reopened')))
                     ->aggregate(array('count' => SqlAggregate::COUNT('events__id'))),
                 'thread_count' => TicketThread::objects()
                     ->filter(array('ticket__ticket_id' => new SqlField('ticket_id', 1)))

--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1637,7 +1637,7 @@ extends QueueColumnAnnotation {
         return $query->annotate(array(
             $name => TicketThread::objects()
             ->filter(array('ticket__ticket_id' => new SqlField('ticket_id', 1)))
-            ->filter(array('events__annulled' => 0, 'events__state' => 'reopened'))
+            ->filter(array('events__annulled' => 0, 'events__event_id' => Event::getIdByName('reopened')))
             ->aggregate(array('count' => SqlAggregate::COUNT('events__id')))
         ));
     }


### PR DESCRIPTION
This addresses an issue where export does not work due to a fatal error "Unknown column 'R0.state' in 'where clause'". This was caused by #4558 due to the removal of enums and the `state` column. This updates the filter to match the `event_id` instead of `state`.