### PR TITLE
issue: Delete User Error

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -635,12 +635,11 @@ implements TemplateVariable, Searchable {
     }
 
     function deleteAllTickets() {
-        $event_id = Event::getIdByName('deleted');
-        $deleted = TicketStatus::lookup(array('event_id' => $event_id));
+        $status_id = TicketStatus::lookup(array('state' => 'deleted'));
         foreach($this->tickets as $ticket) {
             if (!$T = Ticket::lookup($ticket->getId()))
                 continue;
-            if (!$T->setStatus($deleted))
+            if (!$T->setStatus($status_id))
                 return false;
         }
         $this->tickets->reset();


### PR DESCRIPTION
This addresses an issue reported on the forum where deleting a User will throw a fatal error. This was caused by #4558 where the `state` column was mistakenly overwritten with `event_id`. In addition, this changes `$deleted` to `$status_id` for better readability.