### PR TITLE
issue: ticket_link Fatal Error

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -59,19 +59,20 @@ implements EmailContact, ITicketUser, TemplateVariable {
         case 'ticket_link':
             $qstr = array();
             if ($cfg && $cfg->isAuthTokenEnabled()
-                    && ($ticket=$this->getTicket())
-                    && !$ticket->getThread()->getNumCollaborators()) {
-                      $qstr['auth'] = $ticket->getAuthToken($this);
-                      return sprintf('%s/view.php?%s',
-                              $cfg->getBaseUrl(),
-                              Http::build_query($qstr, false)
-                              );
-                    }
-                    else {
-                      return sprintf('%s/tickets.php?id=%s',
-                              $cfg->getBaseUrl(),
-                              $ticket->getId()
-                              );
+                    && ($ticket=$this->getTicket())) {
+                      if (!$ticket->getThread()->getNumCollaborators()) {
+                          $qstr['auth'] = $ticket->getAuthToken($this);
+                          return sprintf('%s/view.php?%s',
+                               $cfg->getBaseUrl(),
+                               Http::build_query($qstr, false)
+                               );
+                      }
+                      else {
+                          return sprintf('%s/tickets.php?id=%s',
+                               $cfg->getBaseUrl(),
+                               $ticket->getId()
+                               );
+                      }
                     }
 
 


### PR DESCRIPTION
This addresses an issue where replying to a ticket causes a Fatal Error for the system. This is due to the `$ticket` object not being set before the else statement therefore causing the `getId()` function to fail. This breaks down the if/else statement to make sure the `$ticket` object is in-fact set before continuing.