### PR TITLE
Deleting the Default Queue

### DIFF
--- a/scp/queues.php
+++ b/scp/queues.php
@@ -72,11 +72,13 @@ if ($_POST) {
                 if ($queue->save()) $updated++;
                 break;
             case 'delete':
-                if ($queue->delete()) $updated++;
+                if ($queue->getId() == $cfg->getDefaultTicketQueueId())
+                    $err = __('This queue is the default queue. Unable to delete. ');
+                elseif ($queue->delete()) $updated++;
             }
         }
         if (!$updated) {
-            Messages::error(__(
+            Messages::error($err ?: __(
                 'Unable to manage any of the selected queues'));
         }
         elseif ($_POST['count'] && $updated != $_POST['count']) {


### PR DESCRIPTION
This commit fixes an issue where Agents were able to delete their default queue which then prevented them from going to any queue upon logging in. Now, they will see an error message if they try to do so.