### PR TITLE
queue: Top-Level Ticket Counts

### DIFF
--- a/include/ajax.search.php
+++ b/include/ajax.search.php
@@ -396,6 +396,6 @@ class SearchAjaxAPI extends AjaxController {
             $criteria = array('id__in' => $ids);
         $counts = SavedQueue::counts($thisstaff, true, $criteria);
         Http::response(200, false, 'application/json');
-        return $this->encode($counts);
+        return $this->encode(Format::number($counts));
     }
 }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -767,6 +767,10 @@ class OsticketConfig extends Config {
         return $sequence;
     }
 
+    function showTopLevelTicketCounts() {
+        return ($this->get('queue_bucket_counts'));
+    }
+
     function getDefaultTicketNumberFormat() {
         return $this->get('ticket_number_format');
     }
@@ -1277,6 +1281,7 @@ class OsticketConfig extends Config {
         return $this->updateAll(array(
             'ticket_number_format'=>$vars['ticket_number_format'] ?: '######',
             'ticket_sequence_id'=>$vars['ticket_sequence_id'] ?: 0,
+            'queue_bucket_counts'=>isset($vars['queue_bucket_counts'])?1:0,
             'default_priority_id'=>$vars['default_priority_id'],
             'default_help_topic'=>$vars['default_help_topic'],
             'default_ticket_status_id'=>$vars['default_ticket_status_id'],

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -503,6 +503,22 @@ class Format {
         return implode( $separator, $string );
     }
 
+    function number($number, $locale=false) {
+        if (is_array($number))
+            return array_map(array('Format','number'), $number);
+
+        if (!is_numeric($number))
+            return $number;
+
+        if (extension_loaded('intl') && class_exists('NumberFormatter')) {
+            $nf = NumberFormatter::create($locale ?: Internationalization::getCurrentLocale(),
+                NumberFormatter::DECIMAL);
+            return $nf->format($number);
+        }
+
+        return number_format((int) $number);
+    }
+
     /* elapsed time */
     function elapsedTime($sec) {
 

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -77,6 +77,7 @@ core:
     email_attachments: 1
     ticket_number_format: '######'
     ticket_sequence_id: 0
+    queue_bucket_counts: 0
     task_number_format: '#'
     task_sequence_id: 2
     log_level: 2

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -32,6 +32,12 @@ sequence_id:
         in the <span class="doc-desc-title">Ticket Number
         Format</span> configuration for help topics.
 
+queue_bucket_counts:
+    title: Top-Level Ticket Counts
+    content: >
+        This setting is used to hide or show the ticket counts on Main-Level
+        queues. Get back to the way things used to be.
+
 default_ticket_status:
     title: Default Status for new Tickets
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -65,6 +65,12 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
                 <i class="help-tip icon-question-sign" href="#sequence_id"></i>
             </td>
         </tr>
+        <tr><td width="220"><?php echo __('Top-Level Ticket Counts'); ?>:</td>
+            <td>
+                <input type="checkbox" name="queue_bucket_counts" <?php echo $config['queue_bucket_counts']?'checked="checked"':''; ?>>
+                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#queue_bucket_counts"></i>
+            </td>
+        </tr>
         <tr>
             <td width="180" class="required">
                 <?php echo __('Default Status'); ?>:

--- a/include/staff/templates/queue-navigation.tmpl.php
+++ b/include/staff/templates/queue-navigation.tmpl.php
@@ -4,6 +4,7 @@
 // $q - <CustomQueue> object for this navigation entry
 // $selected - <bool> true if this queue is currently active
 // $child_selected - <bool> true if the selected queue is a descendent
+global $cfg;
 $childs = $children;
 $this_queue = $q;
 $selected = (!isset($_REQUEST['a'])  && $_REQUEST['queue'] == $this_queue->getId());
@@ -11,7 +12,15 @@ $selected = (!isset($_REQUEST['a'])  && $_REQUEST['queue'] == $this_queue->getId
 <li class="top-queue item <?php if ($child_selected) echo 'child active';
     elseif ($selected) echo 'active'; ?>">
   <a href="<?php echo $this_queue->getHref(); ?>"
-    class="Ticket"><i class="small icon-sort-down pull-right"></i><?php echo $this_queue->getName(); ?></a>
+    class="Ticket"><i class="small icon-sort-down pull-right"></i><?php echo $this_queue->getName(); ?>
+<?php if ($cfg->showTopLevelTicketCounts()) { ?>
+    <span id="queue-count-bucket" class="hidden">
+      (<span class="queue-count"
+        data-queue-id="<?php echo $this_queue->id; ?>"><span class="faded-more"></span>
+      </span>)
+    </span>
+<?php } ?>
+  </a>
   <div class="customQ-dropdown">
     <ul class="scroll-height">
       <!-- Add top-level queue (with count) -->

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -534,9 +534,10 @@ var scp_prep = function() {
         url: 'ajax.php/queue/counts',
         dataType: 'json',
         success: function(json) {
-          $('li > span.queue-count').each(function(i, e) {
+          $('li span.queue-count').each(function(i, e) {
             var $e = $(e);
             $e.text(json['q' + $e.data('queueId')]);
+            $(e).parents().find('#queue-count-bucket').show();
           });
         }
       });


### PR DESCRIPTION
This adds a setting in the Ticket Settings to give the option of showing the ticket counts on Top-Level queues. If enabled, this will populate the ticket counts next to the Top-Level queue names like they used to be. The only caveat is the counts are triggered by mousing-over any of the queue names as we only load the counts when we need to display the sub-queues (for better performance).

This also adds a new format function called `number` (Phase 1). As of now it will format any integer to a comma separated number (eg. `1337 -> 1,337`).