### PR TITLE
Status Column: Fix display and sorting

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -2377,7 +2377,7 @@ extends VerySimpleModel {
 
             $reverse = $reverse ? '-' : '';
             $query = $query->order_by("{$reverse}{$alias}");
-        } else {
+        } elseif($keys[0]) {
             list($path, $field) = $keys[0];
             $query = $field->applyOrderBy($query, $reverse, $path);
         }

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1565,6 +1565,11 @@ class TicketStatusChoiceField extends SelectionField {
             return parent::getSearchQ($method, $value, $name);
         }
     }
+
+    function applyOrderBy($query, $reverse=false, $name=false) {
+        $reverse = $reverse ? '-' : '';
+        return $query->order_by("{$reverse}status__name");
+    }
 }
 
 class TicketThreadCountField extends NumericField {

--- a/include/i18n/en_US/queue_column.yaml
+++ b/include/i18n/en_US/queue_column.yaml
@@ -69,8 +69,8 @@
   conditions: "[]"
 
 - id: 6
-  name: "Status Name"
-  primary: "status__name"
+  name: "Status"
+  primary: "status__id"
   truncate: "wrap"
   annotations: "[]"
   conditions: "[]"


### PR DESCRIPTION
This commit addresses where wrong "primary" field was used to indicate Ticket Status column. It also fixes an issue where sorting was done via `id` instead of `name`.