### PR TITLE
Dashboard Statistics Issue

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -219,7 +219,8 @@ class OverviewReport {
                 ->distinct('dept__id');
             $times = $times
                 ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                ->values('dept__id');
+                ->values('dept__id')
+                ->distinct('dept__id');
             break;
         case 'topic':
             $headers = array(__('Help Topic'));
@@ -232,7 +233,8 @@ class OverviewReport {
                 ->distinct('topic_id');
             $times = $times
                 ->values('topic_id')
-                ->filter(array('topic_id__gt' => 0));
+                ->filter(array('topic_id__gt' => 0))
+                ->distinct('topic_id');
             break;
         case 'staff':
             $headers = array(__('Agent'));
@@ -244,7 +246,7 @@ class OverviewReport {
                 ->values('staff_id', 'staff__firstname', 'staff__lastname')
                 ->filter(array('staff_id__in' => array_keys($staff)))
                 ->distinct('staff_id');
-            $times = $times->values('staff_id');
+            $times = $times->values('staff_id')->distinct('staff_id');
             $depts = $thisstaff->getManagedDepartments();
             if ($thisstaff->hasPerm(ReportModel::PERM_AGENTS))
                 $depts = array_merge($depts, $thisstaff->getDepts());


### PR DESCRIPTION
This commit addresses an issue where we lost the logic for needed GROUP BYs in the dashboard report. They were added back for the Statistics query but not for the query that calculates Response and Service time. This now adds it back.