### PR TITLE
issue: Email Default Dept

### DIFF
--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -99,9 +99,9 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info);
             </td>
             <td>
                 <select name="status">
-                  <option value="active"<?php echo ($info['status'] == __('Active'))?'selected="selected"':'';?>><?php echo __('Active'); ?></option>
-                  <option value="disabled"<?php echo ($info['status'] == __('Disabled'))?'selected="selected"':'';?>><?php echo __('Disabled'); ?></option>
-                  <option value="archived"<?php echo ($info['status'] == __('Archived'))?'selected="selected"':'';?>><?php echo __('Archived'); ?></option>
+                  <option value="active"<?php echo (!strcasecmp($info['status'], 'active'))?'selected="selected"':'';?>><?php echo __('Active'); ?></option>
+                  <option value="disabled"<?php echo (!strcasecmp($info['status'], 'disabled'))?'selected="selected"':'';?>><?php echo __('Disabled'); ?></option>
+                  <option value="archived"<?php echo (!strcasecmp($info['status'], 'archived'))?'selected="selected"':'';?>><?php echo __('Archived'); ?></option>
                 </select>
                 &nbsp;<span class="error">&nbsp;</span> <i class="help-tip icon-question-sign" href="#status"></i>
             </td>

--- a/include/staff/departments.inc.php
+++ b/include/staff/departments.inc.php
@@ -143,7 +143,7 @@ $showing = $pageNav->showing().' '._N('department', 'departments', $count);
                 echo Dept::getNameById($id); ?></a>&nbsp;<?php echo $default; ?>
                 </td>
                 <td><?php
-                  if($dept->getStatus() == __('Active'))
+                  if(!strcasecmp($dept->getStatus(), 'Active'))
                     echo $dept->getStatus();
                   else
                     echo '<b>'.$dept->getStatus();

--- a/scp/departments.php
+++ b/scp/departments.php
@@ -25,9 +25,6 @@ if($_REQUEST['id'] && !($dept=Dept::lookup($_REQUEST['id'])))
                 if(!$dept){
                     $errors['err']=sprintf(__('%s: Unknown or invalid'), __('department'));
                 }elseif($dept->update($_POST,$errors)){
-                    if ($_POST["status"] != __('Active'))
-                      Dept::clearInactiveDept($dept->getId());
-
                     $msg=sprintf(__('Successfully updated %s.'),
                         __('this department'));
                 }elseif(!$errors['err']){
@@ -133,8 +130,6 @@ if($_REQUEST['id'] && !($dept=Dept::lookup($_REQUEST['id'])))
                               FilterAction::setFilterFlag($filter_actions, 'dept', true);
                               if($d->save()) {
                                 $num++;
-                                //set dept_id to default for topics/emails using disabled dept
-                                Dept::clearInactiveDept($d->getId());
                               }
                             }
                             if ($num > 0) {


### PR DESCRIPTION
This addresses an issue where configuring a System Email to have a Department and then editing/saving changes on the configured Department will change the System Email's Department back to the the default Department. This was due to a un-needed Department Status check introduced with commit `1d361b5`. This also updates all instances of Dept Status comparison to be case insensitive and non-translated.