### PR TITLE
issue: create_date Variable

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -1017,11 +1017,11 @@ implements TemplateVariable {
         case 'short':
             return Format::date($this->date, $this->fromdb, false, $this->timezone, $this->user);
         case 'long':
-            return Format::datetime($this->date, $this->fromdb, $this->timezone, $this->user);
+            return Format::datetime($this->date, $this->fromdb, false, $this->timezone, $this->user);
         case 'time':
             return Format::time($this->date, $this->fromdb, false, $this->timezone, $this->user);
         case 'full':
-            return Format::daydatetime($this->date, $this->fromdb, $this->timezone, $this->user);
+            return Format::daydatetime($this->date, $this->fromdb, false, $this->timezone, $this->user);
         }
     }
 


### PR DESCRIPTION
This addresses an issue where the create_date variable is showing as Unix timestamp instead of formatted date. This was due to a typo introduced in commit `8623ed6` where the `$format` argument was forgotten for `Format::datetime()` in the `FormattedLocalDate::getVar()` method.