### PR TITLE
feature: Public Mark As Answered/Unanswered

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1088,6 +1088,24 @@ function refer($tid, $target=null) {
         $state = strtolower($status->getState());
 
         if (!$errors && $ticket->setStatus($status, $_REQUEST['comments'], $errors)) {
+            // Mark as Answered
+            if ($_POST['status_answered'] && ($_POST['status_answered'] == 'on')) {
+                if (!$ticket->getDept()->isManager($thisstaff)
+                  && !$role->hasPerm(Ticket::PERM_REPLY))
+                    $errors['err'] = sprintf(__('You do not have permission %s'),
+                                        __('to mark tickets as answered'));
+
+                if (!in_array($status, array('closed', 'resolved')))
+                    $errors['err'] = __('Cannot mark as answered if status is of closed/resolved state');
+
+                if ($ticket->markAnswered()) {
+                    $msg = sprintf(__('Ticket flagged as answered by %s'), $thisstaff->getName());
+                    $ticket->logActivity(__('Ticket Marked Answered'), $msg);
+                } else
+                    $errors['err'] = sprintf('%s %s',
+                        __('Problems marking the ticket answered.'),
+                        __('Please try again!'));
+            }
 
             if ($state == 'deleted') {
                 $msg = sprintf('%s %s',
@@ -1338,6 +1356,7 @@ function refer($tid, $target=null) {
 
         $info['status_id'] = $info['status_id'] ?: $ticket->getStatusId();
         $info['comments'] = Format::htmlchars($_REQUEST['comments']);
+        $info['ticket_id'] = $ticket->getId();
 
         return self::_changeStatus($state, $info, $errors);
     }

--- a/include/staff/templates/ticket-status.tmpl.php
+++ b/include/staff/templates/ticket-status.tmpl.php
@@ -1,9 +1,18 @@
 <?php
-global $cfg;
+global $cfg, $thisstaff;
 
 if (!$info['title'])
     $info['title'] = __('Change Tickets Status');
 
+if ($info['ticket_id'])
+    $ticket = Ticket::lookup($info['ticket_id']);
+
+if ($ticket) {
+    $dept = $ticket->getDept();
+    $role = $ticket->getRole($thisstaff);
+    $isManager = $dept->isManager($thisstaff); //Check if Agent is Manager
+    $canAnswer = ($isManager || $role->hasPerm(Ticket::PERM_REPLY)); //Check if Agent can mark as answered/unanswered
+}
 ?>
 <h3 class="drag-handle"><?php echo $info['title']; ?></h3>
 <b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
@@ -56,8 +65,9 @@ $action = $info['action'] ?: ('#tickets/status/'. $state);
                             <select name="status_id">
                             <?php
                             foreach ($statuses as $s) {
-                                echo sprintf('<option value="%d" %s>%s</option>',
+                                echo sprintf('<option value="%d" data-state="%s" %s>%s</option>',
                                         $s->getId(),
+                                        $s->getState(),
                                         ($info['status_id'] == $s->getId())
                                          ? 'selected="selected"' : '',
                                         $s->getName()
@@ -75,7 +85,19 @@ $action = $info['action'] ?: ('#tickets/status/'. $state);
                 </tr>
             </tbody>
             <?php
-            } ?>
+            }
+            if ($ticket && !$ticket->isAnswered() && $canAnswer) { ?>
+            <tbody>
+                <tr>
+                    <td>
+                        <label class="checkbox inline" id="status_answered_container">
+                            <input type="checkbox" name="status_answered" id="status_answered"></i>
+                            <?php echo __('Mark as Answered'); ?>
+                        </label>
+                    </td>
+                </tr>
+            </tbody>
+            <?php } ?>
             <tbody>
                 <tr>
                     <td colspan="2">
@@ -118,5 +140,22 @@ $(function() {
         .val($(this).val())
         .appendTo('form#status');
     });
+
+   // Toggle Internal Note "answered" checkbox visibility
+   function toggleAnswered() {
+       var state = $('select[name=status_id]').find(':selected').data('state');
+       if ($.inArray(state, ['closed', 'resolved']) == -1)
+           $('#status_answered_container').show();
+       else {
+           $('#status_answered_container').hide();
+           $('#status_answered').removeAttr('checked');
+       }
+   }
+
+   toggleAnswered();
+
+   $('select[name=status_id]').change(function() {
+       toggleAnswered();
+   });
 });
 </script>


### PR DESCRIPTION
This feature extends the ability to mark tickets as Answered/Unanswered to any Agent with the Role Permission to Post Reply in the Department. This also extends the Mark As Answered option to Internal Notes and Change Status. If you Post an Internal Note you will see a checkbox to "Mark As Answered" same goes for changing a Ticket's Status to a status that status is not "closed" or "resolved".