### PR TITLE
issue: FAQ/Page Attachments

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -405,7 +405,7 @@ class FAQ extends VerySimpleModel {
         }
 
         $images = Draft::getAttachmentIds($vars['answer']);
-        $images = array_map(function($i) { return $i['id']; }, $images);
+        $images = array_flip(array_map(function($i) { return $i['id']; }, $images));
         $this->getAttachments()->keepOnlyFileIds($images, true);
 
         // Handle language-specific attachments

--- a/include/class.page.php
+++ b/include/class.page.php
@@ -282,7 +282,7 @@ class Page extends VerySimpleModel {
 
         // Attach inline attachments from the editor
         $keepers = Draft::getAttachmentIds($vars['body']);
-        $keepers = array_map(function($i) { return $i['id']; }, $keepers);
+        $keepers = array_flip(array_map(function($i) { return $i['id']; }, $keepers));
         $this->attachments->keepOnlyFileIds($keepers, true);
 
         if ($rv)


### PR DESCRIPTION
This addresses an issue where inserting images on a Page or FAQ and having the setting enabled for "Login required to view attachments." does not display the images at all when the Page/FAQ renders in view. This is due to the Page/FAQ update functions that were not updated to fit the new `id=>name` format for `keepOnlyFileIds()` introduced with `f179cf1`.