### PR TITLE
oops: Remove DST From User Update

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -436,7 +436,6 @@ class ClientAccount extends UserAccount {
         if ($errors) return false;
 
         $this->set('timezone', $vars['timezone']);
-        $this->set('dst', isset($vars['dst']) ? 1 : 0);
         // Change language
         $this->set('lang', $vars['lang'] ?: null);
         Internationalization::setCurrentLanguage(null);


### PR DESCRIPTION
This addresses an issue where Users updating their profile will throw an SQL error in the system logs. This is due to a line of code trying to set a value for the `dst` column which no longer exists as of `1.10.0`.