### PR TITLE
Improve the Staff login

### DIFF
--- a/scp/login.php
+++ b/scp/login.php
@@ -40,7 +40,8 @@ if($_POST) {
 
     // Rotate the CSRF token (original cannot be reused)
     $ost->getCSRF()->rotate();
-
+}
+if ($_POST && isset($_POST['userid'])) {
     // Lookup support backends for this staff
     $username = trim($_POST['userid']);
     if ($user = StaffAuthenticationBackend::process($username,
@@ -66,8 +67,11 @@ elseif ($_GET['do']) {
 // Consider single sign-on authentication backends
 elseif (!$thisstaff || !($thisstaff->getId() || $thisstaff->isValid())) {
     if (($user = StaffAuthenticationBackend::processSignOn($errors, false))
-            && ($user instanceof StaffSession))
-       Http::redirect($dest);
+            && ($user instanceof StaffSession)) {
+        Http::redirect($dest);
+    } else if (isset($_SESSION['_staff']['auth']['msg'])) {
+        $msg = $_SESSION['_staff']['auth']['msg'];
+    }
 }
 
 // Browsers shouldn't suggest saving that username/password


### PR DESCRIPTION
- Follow the same pattern that the client login https://github.com/pitbulk/osTicket/blob/develop/login.php#L48 . Otherwise StaffAuthenticationBackend that receives a POST are not possible.
- Refresh $msg with the value stored in session if the StaffAuthenticationBackend backend defines it, otherwise the initial "Authentication Required" is prompted.