### PR TITLE
oops: markAs() Typo

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1285,7 +1285,7 @@ function refer($tid, $target=null) {
                 case 'unanswered':
                     if(!$ticket->isAnswered())
                         $errors['err'] = __('Ticket is already marked as unanswered');
-                    elseif (!$ticket->markUnanswered())
+                    elseif (!$ticket->markUnAnswered())
                         $errors['err'] - __('Cannot mark ticket as unanswered');
                     break;
 


### PR DESCRIPTION
This addresses a typo in the `markAs()` function in `ajax.tickets.php`. DOH! Should’ve ran the lint tests