### PR TITLE
issue: markAs() elseif

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -162,8 +162,8 @@ if($ticket->isOverdue())
                             echo __('Mark as Overdue'); ?></a></li>
                     <?php
                     }
-                 } elseif($ticket->isOpen() && $canAnswer) {
-
+                 }
+                 if($ticket->isOpen() && $canAnswer) {
                     if($ticket->isAnswered()) { ?>
                     <li><a href="#tickets/<?php echo $ticket->getId();
                         ?>/mark/unanswered" class="ticket-action"


### PR DESCRIPTION
This addresses an issue where Department Managers would not see the option for Marking tickets as (un)answered due to an elseif (should be an if instead).