### PR TITLE
Issue: Edit Export Column Heading

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1141,9 +1141,6 @@ class CustomQueue extends VerySimpleModel {
             return false;
 
         $order = array_keys($fields);
-        // Filter exportable fields
-        if (!($fields = array_intersect_key($this->getExportableFields(), $fields)))
-            return false;
 
         $new = $fields;
         foreach ($this->exports as $f) {


### PR DESCRIPTION
This commit addresses an issue where we did not save headings for export fields.
We just need to leave the heading in the array rather than filtering it out so that we can save its new heading.