### PR TITLE
issue: Dashboard Export Period

### DIFF
--- a/include/staff/dashboard.inc.php
+++ b/include/staff/dashboard.inc.php
@@ -122,4 +122,16 @@ foreach ($groups as $g=>$desc) {
 </form>
 <script>
     $.drawPlots(<?php echo JsonDataEncoder::encode($report->getPlotData()); ?>);
+    // Set Selected Period For Dashboard Stats and Export
+    <?php if ($report && $report->end) { ?>
+        $("div#basic_search select option").each(function(){
+            // Remove default selection
+            if ($(this)[0].selected)
+                $(this).removeAttr('selected');
+            // Set the selected period by the option's value (periods equal
+            // option's values)
+            if ($(this).val() == "<?php echo $report->end; ?>")
+                $(this).attr("selected","selected");
+        });
+    <?php } ?>
 </script>


### PR DESCRIPTION
This addresses an issue where exporting statistics via the dashboard within a certain timeframe (eg. 07/01/2018 -> One Quarter) will always export the statistics from the selected date up to today. This is due to the Period option always being set to "Up to today" when the Export button is clicked which in return exports the stats from the selected start date to today. This adds JS to set the period the Agent selects so the Export will return the stats from the selected date to the selected period.