### PR TITLE
Clarify User Import Instructions

### DIFF
--- a/include/staff/templates/user-import.tmpl.php
+++ b/include/staff/templates/user-import.tmpl.php
@@ -34,7 +34,7 @@ if ($org_id) { ?>
 'To import more other fields, use the Upload tab.'); ?></em>
 </p>
 <textarea name="pasted" style="display:block;width:100%;height:8em"
-    placeholder="<?php echo __('e.g. John Doe, john.doe@osticket.com'); ?>">
+    placeholder="<?php echo __('Name, Email'. PHP_EOL. ' John Doe, john.doe@osticket.com'); ?>">
 <?php echo $info['pasted']; ?>
 </textarea>
 </div>


### PR DESCRIPTION
This commit updates the instructions for User imports letting the Agent know they should type 'Name, Email' on the first line and then put each new User Name/Email on the following lines to import Users.

<img width="642" alt="screen shot 2019-01-02 at 1 51 30 pm" src="https://user-images.githubusercontent.com/22985133/50609521-88d3ab00-0e95-11e9-9719-9329b0e50f25.png">
