### PR TITLE
Issue: Can’t use “0” in Short Answer Field

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1478,6 +1478,11 @@ class TextboxField extends FormField {
     function parse($value) {
         return Format::striptags($value);
     }
+
+    function display($value) {
+        $value = $value ?: $this->value;
+        return ($value == 0) ? '&#48' : Format::htmlchars($this->toString($value));
+    }
 }
 
 class PasswordField extends TextboxField {


### PR DESCRIPTION
This commit fixes an issue where a Short Answer Field would show as Empty if the value saved in it was '0'