### PR TITLE
Issue: Tasks Within Tickets

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -146,7 +146,7 @@ if ($task->isOverdue())
                 <ul>
 
                     <?php
-                    if ($task->isOpen()) { ?>
+                    if (!$task->isOpen()) { ?>
                     <li>
                         <a class="no-pjax task-action"
                             href="#tasks/<?php echo $task->getId(); ?>/reopen"><i

--- a/include/staff/templates/tasks-actions.tmpl.php
+++ b/include/staff/templates/tasks-actions.tmpl.php
@@ -7,57 +7,23 @@ if ($agent->hasPerm(Task::PERM_CLOSE, false)) {
 
     if (isset($options['status'])) {
         $status = $options['status'];
-    ?>
-        <span
-            class="action-button"
-            data-dropdown="#action-dropdown-tasks-status">
-            <i class="icon-caret-down pull-right"></i>
-            <a class="tasks-status-action"
-                href="#statuses"
-                data-placement="bottom"
-                data-toggle="tooltip"
-                title="<?php echo __('Change Status'); ?>"><i
-                class="icon-flag"></i></a>
-        </span>
-        <div id="action-dropdown-tasks-status"
-            class="action-dropdown anchor-right">
-            <ul>
-                <?php
-                if (!$status || !strcasecmp($status, 'closed')) { ?>
-                <li>
-                    <a class="no-pjax tasks-action"
-                        href="#tasks/mass/reopen"><i
-                        class="icon-fixed-width icon-undo"></i> <?php
-                        echo __('Reopen');?> </a>
-                </li>
-                <?php
-                }
-                if (!$status || !strcasecmp($status, 'open')) {
-                ?>
-                <li>
-                    <a class="no-pjax tasks-action"
-                        href="#tasks/mass/close"><i
-                        class="icon-fixed-width icon-ok-circle"></i> <?php
-                        echo __('Close');?> </a>
-                </li>
-                <?php
-                } ?>
-            </ul>
-        </div>
-<?php
-    } else {
 
-        $actions += array(
-                'reopen' => array(
-                    'icon' => 'icon-undo',
-                    'action' => __('Reopen')
-                ));
+        if (strpos($status, 'closed') !== false) {
+            $actions += array(
+                    'reopen' => array(
+                        'icon' => 'icon-undo',
+                        'action' => __('Reopen')
+                    ));
+        }
 
-        $actions += array(
-                'close' => array(
-                    'icon' => 'icon-ok-circle',
-                    'action' => __('Close')
-                ));
+
+        if (strpos($status, 'open') !== false) {
+            $actions += array(
+                    'close' => array(
+                        'icon' => 'icon-ok-circle',
+                        'action' => __('Close')
+                    ));
+        }
     }
 }
 
@@ -95,7 +61,7 @@ if ($agent->hasPerm(Task::PERM_DELETE, false)) {
                 'action' => __('Delete')
             ));
 }
-if ($actions && !isset($options['status'])) {
+if ($actions && isset($options['status'])) {
     $more = $options['morelabel'] ?: __('More');
     ?>
     <span

--- a/include/staff/ticket-tasks.inc.php
+++ b/include/staff/ticket-tasks.inc.php
@@ -40,12 +40,17 @@ $showing = $pageNav->showing().' '._N('task', 'tasks', $count);
             print __('Add New Task'); ?></a>
     <?php
     }
+    foreach ($tasks as $task)
+        $taskStatus .= $task->isOpen() ? 'open' : 'closed';
+
     if ($count)
         Task::getAgentActions($thisstaff, array(
                     'container' => '#tasks_content',
                     'callback_url' => sprintf('ajax.php/tickets/%d/tasks',
                         $ticket->getId()),
-                    'morelabel' => __('Options')));
+                    'morelabel' => __('Options'),
+                    'status' => $taskStatus ? $taskStatus : '')
+                );
     ?>
 </div>
 <div class="clear"></div>


### PR DESCRIPTION
This commit addresses issues we had with viewing Task(s) within a Ticket:

1. When viewing the table of all Tasks on a Ticket, the Options dropdown should only allow the Agent to Reopen or Close the Tasks based on the status of the Tasks.
Ex: If there is only 1 Open Task, you should only see the 'Close' Option
    If there are 2 Closed Tasks, you should only see the 'Reopen' Option
    If there are multiple Tasks in which some are Open and some are Closed, you should see both the 'Reopen' and 'Close' options

2. When viewing an individual Task within a Ticket, the status options were the opposite of what they should have been. Now, if the Task is Open, the Agent will see the option to 'Close' the Task. If the Task is Closed, the Agent will see the option to 'Reopen' the Task.