### PR TITLE
issue: Hide Task Loading Overlay

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -665,7 +665,10 @@ $(function() {
                 .slideUp();
             }
         })
-        .done(function() { })
+        .done(function() {
+            $('#loading').hide();
+            $.toggleOverlay(false);
+        })
         .fail(function() { });
      });
     <?php


### PR DESCRIPTION
This addresses an issue where the Loading overlay on Tasks will not disappear after the request was submitted. This adds two lines to first hide the "Loading" modal and then toggle the overlay.