### PR TITLE
issue: Task Response With Collaborators

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1189,7 +1189,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         global $cfg;
 
         if (!$entry instanceof ThreadEntry
-            || !($recipients=$this->getThread()->getParticipants())
+            || !($recipients=$this->getThread()->getRecipients())
             || !($dept=$this->getDept())
             || !($tpl=$dept->getTemplate())
             || !($msg=$tpl->getTaskActivityNoticeMsgTemplate())

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -263,6 +263,17 @@ implements Searchable {
         return $this->_participants;
     }
 
+    // MailingList of recipients (collaborators)
+    function getRecipients() {
+        $list = new MailingList();
+        if ($collabs = $this->getActiveCollaborators()) {
+            foreach ($collabs as $c)
+                $list->addCc($c);
+        }
+
+        return $list;
+    }
+
     function getReferral($id, $type) {
 
         return $this->referrals->findFirst(array(

--- a/include/class.util.php
+++ b/include/class.util.php
@@ -5,6 +5,7 @@ require_once INCLUDE_DIR . 'class.variable.php';
 // Used by the email system
 interface EmailContact {
     function getId();
+    function getUserId();
     function getName();
     function getEmail();
 }
@@ -26,6 +27,10 @@ implements EmailContact {
 
     function getId() {
         return $this->contact->getId();
+    }
+
+    function getUserId() {
+        return $this->contact->getUserId();
     }
 
     function getEmail() {


### PR DESCRIPTION
This addresses a fatal error when adding a new response to a Task with Collaborators. When we implemented the MailingList for Users/Collaborators we forgot about the little Task Collaborators (poor little guys). This adds a new function called `getRecipients()` to `class Thread` that utilizes MailingList instead of UserList. This also adds two new functions to `class Util` that retrieves the User’s `user_id`.