### PR TITLE
issue: Scrollable Quickfilters

### DIFF
--- a/include/staff/templates/queue-quickfilter.tmpl.php
+++ b/include/staff/templates/queue-quickfilter.tmpl.php
@@ -36,7 +36,7 @@ $.pjax({
     url: '?' + query,
     timeout: 2000,
     container: '#pjax-container'});">
-  <ul>
+  <ul <?php if (count($choices) > 20) echo 'style="height:500px;overflow-x:hidden;overflow-y:scroll;"'; ?>>
   <?php foreach ($choices as $k=>$desc) {
     $selected = isset($quick_filter) && $quick_filter == $k;
   ?>


### PR DESCRIPTION
This addresses an issue where having more than 30+ choices for a Quickfilter makes the dropdown run off the page causing some choices to be hidden. This makes it to where if you have more than 20+ choices we will make the dropdown a fixed height and make it scrollable.