### PR TITLE
Issue: Mass Assign

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -792,7 +792,15 @@ function refer($tid, $target=null) {
                                 );
 
                     if ($depts) {
-                        $members->filter(Q::any( array(
+                        $all_agent_depts = Dept::objects()->filter(
+                            Q::all( array('id__in' => $depts,
+                            Q::not(array('flags__hasbit'
+                                => Dept::FLAG_ASSIGN_MEMBERS_ONLY)),
+                            Q::not(array('flags__hasbit'
+                                => Dept::FLAG_ASSIGN_PRIMARY_ONLY))
+                            )))->values_flat('id');
+                        if (!count($all_agent_depts)) {
+                            $members->filter(Q::any( array(
                                         'dept_id__in' => $depts,
                                         Q::all(array(
                                             'dept_access__dept__id__in' => $depts,
@@ -802,6 +810,7 @@ function refer($tid, $target=null) {
                                                     => Dept::FLAG_ASSIGN_PRIMARY_ONLY))
                                             ))
                                         )));
+                        }
                     }
 
                     switch ($cfg->getAgentNameFormat()) {


### PR DESCRIPTION
This commit addresses an issue where a Department might have the Ticket Assignment option set to All Agents, but when trying to mass assign Tickets, only Department Agents were shown in the list.

Note: If mass assign is done on Tickets with different Departments that have different Ticket Assignment rules, Tickets will only be assigned to the Tickets that are allowed the assignment.