### PR TITLE
Plugin Architecture: Allow Signal on threadentry.rendered

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2579,7 +2579,11 @@ class ThreadEntryBody /* extends SplString */ {
     }
 
     function toHtml() {
-        return $this->display('html');
+        $data = array(
+            "html" => $this->display("html")
+        );
+        Signal::send('threadentry.rendered', $this, $data);
+        return $data["html"];
     }
 
     function prepend($what) {


### PR DESCRIPTION
Hi. In order to make all my addons for OsTicket suitable for other users, I want do distribute them as Plugins. I need some more interface than the existing Signals, so I will provide some pull requests, which just add more signals to the core code.

Please merge them or tell me how you would like me to proceed, so I can soon create more powerful plugins.

This particular PR contains just one Signal: **threadentry.rendered**. It comes with the ThreadEntry Object and a hashmap containing the html code.

A possible plugin would be one to fix broken HTML (ebay sometimes sends such mails), which crash the ticket-view page otherwise.

Another use-case is replacing order-numbers in tickets with links to the ERP system, or amazon-order numbers with links to the seller-central, ebay names with links to the ebay customer etc.