### PR TITLE
issue: SubQueues Hide PersonalQueues

### DIFF
--- a/include/staff/templates/queue-subnavigation.tmpl.php
+++ b/include/staff/templates/queue-subnavigation.tmpl.php
@@ -34,21 +34,21 @@ global $thisstaff;
     <ul class="subMenuQ">
     <?php
     foreach ($children as $_) {
-        list($q, $childs) = $_;
+        list($q, $childz) = $_;
         if (!$q->isPrivate())
-          $closure_include($q, $childs);
+          $closure_include($q, $childz);
     }
 
     // Include personal sub-queues
     $first_child = true;
     foreach ($children as $_) {
-      list($q, $childs) = $_;
+      list($q, $childz) = $_;
       if ($q->isPrivate()) {
         if ($first_child) {
           $first_child = false;
           echo '<li class="personalQ"></li>';
         }
-        $closure_include($q, $childs);
+        $closure_include($q, $childz);
       }
     } ?>
     </ul>


### PR DESCRIPTION
This addresses an issue where adding SubQueues hides PersonalQueues. This was due to the variable `$childs` being reset in the sub-navigation template.