### PR TITLE
issue: Remove Referral Borked

### DIFF
--- a/include/staff/templates/refer.tmpl.php
+++ b/include/staff/templates/refer.tmpl.php
@@ -77,7 +77,7 @@ $manage = (!$target);
    <form class="mass-action" method="post"
     name="referrals"
     id="rf"
-    action="<?php echo sprintf('#/tickets/%d/referrals', $ticket->getId()); ?>">
+    action="<?php echo sprintf('#tickets/%d/referrals', $ticket->getId()); ?>">
      <input type='hidden' name='do' value='manage'>
     <table width="100%">
         <tbody>


### PR DESCRIPTION
This addresses an issue where removing a Referral from the Manage Referrals modal just loads and loads, never actually removing the referral. This is due to the AJAX URL containing an extra `/` causing an "Unsupported URL" error.