### PR TITLE
issue: Translation Flags Not Clickable

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -1245,6 +1245,7 @@ ul.tabs.vertical li a {
 }
 
 ul.tabs.alt {
+  height: auto;
   background-color:initial;
   border-bottom:2px solid #ccc;
   border-bottom-color: rgba(0,0,0,0.1);


### PR DESCRIPTION
This addresses an issue where the second row of translation flags are not clickable when editing a Form with 23+ languages installed. This adds a `height` of "auto" so that the entire div fits the flags’ surface area, making them clickable again.