### PR TITLE
issue: System Ban List

### DIFF
--- a/include/class.banlist.php
+++ b/include/class.banlist.php
@@ -81,7 +81,7 @@ class Banlist {
     }
 
     function getSystemBanList() {
-        return new Filter(self::ensureSystemBanList());
+        return self::ensureSystemBanList();
     }
 
     static function getFilter() {

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -184,7 +184,8 @@ extends VerySimpleModel {
         $rule = array_merge($extra,array('what'=>$what, 'how'=>$how, 'val'=>$val));
         $rule = new FilterRule($rule);
         $this->rules->add($rule);
-        $rule->save();
+        if ($rule->save())
+            return true;
     }
 
     function removeRule($what, $how, $val) {
@@ -200,7 +201,7 @@ extends VerySimpleModel {
     }
 
     function getRuleById($id) {
-        return FilterRule::lookup($id, $this->getId());
+        return FilterRule::lookup(array('id'=>$id, 'filter_id'=>$this->getId()));
     }
 
     function containsRule($what, $how, $val) {


### PR DESCRIPTION
This addresses an issue where the system banlist throws the error "SYSTEM BAN LIST filter is DISABLED". This is due to the Filters moving to ORM but not updating everywhere they are used.