### PR TITLE
issue: Column Annotations

### DIFF
--- a/include/staff/templates/queue-column.tmpl.php
+++ b/include/staff/templates/queue-column.tmpl.php
@@ -86,6 +86,7 @@ foreach (Internationalization::sortKeyedList($annotations) as $class=>$desc) {
           position.attr('name', position.data('name'));
           if (pos)
             position.val(pos);
+          clone.removeClass('hidden');
           template.closest('.tab_content').find('.empty').hide();
         };
         $('select.add-annotation', '#annotations').change(function() {


### PR DESCRIPTION
This addresses issue #4698 where you are not able to edit/delete column annotations in the queue edit. This is due to the JS not removing the hidden class.