### PR TITLE
filedrop: Fix file drag and drop

### DIFF
--- a/js/filedrop.field.js
+++ b/js/filedrop.field.js
@@ -11,6 +11,7 @@
       progressUpdated: $.proxy(this.progressUpdated, this),
       speedUpdated: $.proxy(this.speedUpdated, this),
       dragOver: $.proxy(this.dragOver, this),
+      dragLeave: $.proxy(this.dragLeave, this),
       drop: $.proxy(this.drop, this),
       beforeSend: $.proxy(this.beforeSend, this),
       beforeEach: $.proxy(this.beforeEach, this),
@@ -29,6 +30,9 @@
   };
 
   FileDropbox.prototype = {
+    dragLeave: function(e) {
+        this.$element.removeAttr('style');
+    },
     drop: function(e) {
         this.$element.removeAttr('style');
     },
@@ -361,9 +365,9 @@
 
     function drop(e) {
       if( opts.drop.call(this, e) === false ) return false;
-      if(!e.dataTransfer)
+      if(!e.originalEvent.dataTransfer)
         return;
-      files = e.dataTransfer.files;
+      files = e.originalEvent.dataTransfer.files;
       if (files === null || files === undefined || files.length === 0) {
         opts.error(errors[0]);
         return false;

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1308,7 +1308,7 @@ jQuery(function($) {
     $.fn.show = function() {
         var argsArray = Array.prototype.slice.call(arguments),
             arg = argsArray[0],
-            options = {};
+            options = argsArray[1] || {duration: 0};
         if (typeof(arg) === 'number')
             options.duration = arg;
         else


### PR DESCRIPTION
This fixes an issue introduced in the upgrade to jQuery three. The filedrop field was not updated correctly and drag and drop files was broken. 

Additionally, this handles cases where files are dragged over the box but not dropped. The style of the box is correctly reset after the drag leaves the box.