### PR TITLE
issue: PHP 7.2 Plugin Delete

### DIFF
--- a/scp/plugins.php
+++ b/scp/plugins.php
@@ -40,7 +40,7 @@ if($_POST) {
             case 'delete':
                 foreach ($_POST['ids'] as $id) {
                     if ($p = Plugin::lookup($id)) {
-                        $p->uninstall();
+                        $p->uninstall($errors);
                     }
                 }
                 break;


### PR DESCRIPTION
This addresses issue #4718 where deleting a plugin using PHP 7.2 throws an error. This is due to errors not being passed to uninstall which causes the "Too Few Arguments" error.