### PR TITLE
Selected Navigation Item

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -445,12 +445,13 @@ foreach ($queues as $_) {
     $nav->addSubMenu(function() use ($q, $queue, $children) {
         // A queue is selected if it is the one being displayed. It is
         // "child" selected if its ID is in the path of the one selected
+        $_selected = ($queue && $queue->getId() == $q->getId());
         $child_selected = $queue
             && ($queue->parent_id == $q->getId()
                 || false !== strpos($queue->getPath(), "/{$q->getId()}/"));
         include STAFFINC_DIR . 'templates/queue-navigation.tmpl.php';
 
-        return $child_selected;
+        return ($child_selected || $_selected);
     });
 }
 


### PR DESCRIPTION
This addresses an issue where main queues were not marked as active resulting in "New Ticket" link getting auto-set as active (bold).