### PR TITLE
Issue: Attachments on Information Fields

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4657,7 +4657,7 @@ class FreeTextField extends FormField {
 
     function to_config($config) {
         if ($config && isset($config['attachments']))
-            $keepers = $config['attachments'] = array_values($config['attachments']);
+            $keepers = $config['attachments'];
         $this->getAttachments()->keepOnlyFileIds($keepers);
 
         return $config;


### PR DESCRIPTION
This commit fixes an issue where we failed to upload attachments on Information Fields. In the to_config function, we were only taking the array_values of attachments which would return an array with only the file name ([0] => 'filename') instead of an array with the file id and file name ([123] => 'filename').

Now, when we pass the keepers to keepOnlyFileIds, we have a file id that can be passed to the upload function.