### PR TITLE
issue: APC CLI

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3173,7 +3173,7 @@ implements RestrictedAccess, Threadable, Searchable {
     function save($refetch=false) {
         if ($this->dirty) {
             $this->updated = SqlFunction::NOW();
-            if (isset($this->dirty['status_id']))
+            if (isset($this->dirty['status_id']) && PHP_SAPI !== 'cli')
                 // Refetch the queue counts
                 SavedQueue::clearCounts();
         }


### PR DESCRIPTION
This addresses issue #4720 where creating tickets via CLI fails to set a status and crashes with an "APC must be enabled" error. This adds a check to see if the APC module is loaded before continuing.