### PR TITLE
Issue: Duplicate Tickets in Closed Queue

### DIFF
--- a/include/staff/templates/queue-tickets.tmpl.php
+++ b/include/staff/templates/queue-tickets.tmpl.php
@@ -90,9 +90,9 @@ if (isset($tickets->extra['tables'])) {
             $criteria->values_flat('ticket_id')]);
     # Index hint should be used on the $criteria query only
     $tickets->clearOption(QuerySet::OPT_INDEX_HINT);
-    $tickets->distinct('ticket_id');
 }
 
+$tickets->distinct('ticket_id');
 $count = $queue->getCount($thisstaff) ?: (PAGE_LIMIT*3);
 $pageNav->setTotal($count, true);
 $pageNav->setURL('tickets.php', $args);


### PR DESCRIPTION
When going to my closed queue, I had the same ticket showing multiple times. This commit moves the call to the distinct method outside of any if statements so that the tickets will always be grouped by their id.