### PR TITLE
issue: Delete Org Session Failure

### DIFF
--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -486,6 +486,9 @@ implements TemplateVariable, Searchable {
         if (!parent::delete())
             return false;
 
+        // Clear organization from session to avoid refetch failure
+        unset($_SESSION[':Q:orgs'], $_SESSION[':O:tickets']);
+
         // Remove users from this organization
         User::objects()
             ->filter(array('org' => $this))

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -717,9 +717,11 @@ class VerySimpleModel {
     }
 
     private function refetch() {
-        $this->ht =
-            static::objects()->filter($this->getPk())->values()->one()
-            + $this->ht;
+        try {
+            $this->ht =
+                static::objects()->filter($this->getPk())->values()->one()
+                + $this->ht;
+        } catch (DoesNotExist $ex) {}
     }
 
     private function getPk() {


### PR DESCRIPTION
This addresses an issue on the Forum where deleting an Organization causes the session to fail. This is due to the Organization QuerySet being stored in the session and not being cleared out when deleted from the system. This causes the system to try to refetch the object from the database which it's not there as it's been deleted and therefore causes the session to crash.