### PR TITLE
users: Fix searching of users

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -79,8 +79,10 @@ class UsersAjaxAPI extends AjaxController {
                     'org__name__contains' => $q,
                     'account__username__contains' => $q,
                 ));
-                if (UserForm::getInstance()->getField('phone'))
+                if (UserForm::getInstance()->getField('phone')) {
+                    UserForm::ensureDynamicDataView();
                     $filter->add(array('cdata__phone__contains' => $q));
+                }
 
                 $users->filter($filter);
             }

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -475,7 +475,7 @@ var scp_prep = function() {
 
   $('div.tab_content[id] div.error:not(:empty)').each(function() {
     var div = $(this).closest('.tab_content');
-    $('a[href^=#'+div.attr('id')+']').parent().addClass('error');
+    $('a[href^="#'+div.attr('id')+'"]').parent().addClass('error');
   });
 
   $('[data-toggle="tooltip"]').tooltip()


### PR DESCRIPTION
The CDATA table may be dropped on upgrade and is not created on new installs. So it should be created on demand when searching for users.

Also, fix a Javascript issue not highlighting tabs in red where errors exist.