### PR TITLE
Assignment Restriction Issue

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -597,6 +597,10 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
 
         $visibility = Q::any(new Q(array('status__state'=>'open', $assigned)));
 
+        // -- If access is limited to assigned only, return assigned
+        if ($this->isAccessLimited())
+            return $visibility;
+
         // -- Routed to a department of mine
         if (($depts=$this->getDepts()) && count($depts)) {
             $visibility->add(array('dept_id__in' => $depts));

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -261,7 +261,6 @@ implements RestrictedAccess, Threadable, Searchable {
     }
 
     function isAssigned($to=null) {
-
         if (!$this->isOpen())
             return false;
 
@@ -308,8 +307,6 @@ implements RestrictedAccess, Threadable, Searchable {
 
         // check department access first
         if (!$staff->canAccessDept($this->getDept())
-                // no restrictions
-                && !$staff->isAccessLimited()
                 // check assignment
                 && !$this->isAssigned($staff)
                 // check referral


### PR DESCRIPTION
This commit fixes an issue where we were not checking the restrictions on Ticket assignment correctly. isAccessLimited returns true if showAssignedOnly is true, so we wouldn't want to negate the isAccessLimited check (that would return true if access is not limited).

Also, if an Agent's access is limited to assigned tickets only, we can return the assigned tickets once we have them without needing to go through any further processing.

Note: queue counts update themselves a little after you toggle the 'Limit ticket access to ONLY assigned tickets' check box. The 'See all tickets in search results, regardless of access' still works correctly as well.