### PR TITLE
issue: Internal Note Ignored

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4120,7 +4120,7 @@ implements RestrictedAccess, Threadable, Searchable {
         }
 
         // Not assigned...save optional note if any
-        if (!$ticket->isAssigned() && $vars['note']) {
+        if (!$vars['assignId'] && $vars['note']) {
             if (!$cfg->isRichTextEnabled())
                 $vars['note'] = new TextThreadEntryBody($vars['note']);
             $ticket->logNote(_S('New Ticket'), $vars['note'], $thisstaff, false);


### PR DESCRIPTION
This addresses issue #4743 where the system ignores Internal Notes on Ticket Creation. This is due to the ticket being assigned and not having the Internal Note passed along.