### PR TITLE
issue: Custom Column Org Link

### DIFF
--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -489,7 +489,7 @@ implements TemplateVariable, Searchable {
         if (!$id || !$thisstaff)
             return false;
 
-        return ROOT_PATH . sprintf('orgs.php?id=%s', $id);
+        return ROOT_PATH . sprintf('scp/orgs.php?id=%s', $id);
     }
 
     static function fromVars($vars) {


### PR DESCRIPTION
This addresses issue #4579 where setting a Custom Column to User Organization and choosing the User Org Link filter the system shows the wrong link to the Org. This is due to "scp/" not being added to the URL therefore showing an invalid link.