### PR TITLE
issue: PHP 7.2 Ticket Status

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -149,6 +149,8 @@ class DynamicFormsAjaxAPI extends AjaxController {
     function saveListItem($list_id, $item_id) {
         global $thisstaff;
 
+        $errors = array();
+
         if (!$thisstaff)
             Http::response(403, 'Login required');
 
@@ -177,7 +179,7 @@ class DynamicFormsAjaxAPI extends AjaxController {
                     'name' =>   $basic['name'],
                     'value' =>  $basic['value'],
                     'abbrev' =>  $basic['extra'],
-                ]);
+                ], $errors);
             }
         }
 


### PR DESCRIPTION
This addresses issue #4716 where updating a Ticket Status throws a fatal error of "Too few arguments" when using PHP 7.2. This is due to `$errors` not being passed to the `update()` function causing PHP 7.2 to freak out. This creates an `$errors` array and passes it to `update()` so PHP 7.2 is happy and we are all happy. :)