### PR TITLE
issue: Canned Response Variables

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -364,7 +364,7 @@ class TicketsAjaxAPI extends AjaxController {
             $format.='.plain';
 
         $varReplacer = function (&$var) use($ticket) {
-            return $ticket->replaceVars($var);
+            return $ticket->replaceVars($var, array('recipient' => $ticket->getOwner()));
         };
 
         include_once(INCLUDE_DIR.'class.canned.php');


### PR DESCRIPTION
This addresses issue #4756 where the `%{recipient.ticket_link}` variable is not being replaced when the canned response is loaded in the reply box; all other link variables work. This is due to the recipient object not being passed to the variableReplacer which means the ticket_link is not available. This adds the recipient object to the variableReplacer so the ticket_link variable is properly replaced like the others on load.