### PR TITLE
issue: FAQ Search Results

### DIFF
--- a/include/client/knowledgebase.inc.php
+++ b/include/client/knowledgebase.inc.php
@@ -18,12 +18,14 @@ if($_REQUEST['q'] || $_REQUEST['cid'] || $_REQUEST['topicId']) { //Search
         $faqs->filter(array('topics__topic_id'=>$_REQUEST['topicId']));
 
     if ($_REQUEST['q'])
-        $faqs->filter(Q::ANY(array(
-            'question__contains'=>$_REQUEST['q'],
-            'answer__contains'=>$_REQUEST['q'],
-            'keywords__contains'=>$_REQUEST['q'],
-            'category__name__contains'=>$_REQUEST['q'],
-            'category__description__contains'=>$_REQUEST['q'],
+        $faqs->filter(Q::all(array(
+            Q::ANY(array(
+                'question__contains'=>$_REQUEST['q'],
+                'answer__contains'=>$_REQUEST['q'],
+                'keywords__contains'=>$_REQUEST['q'],
+                'category__name__contains'=>$_REQUEST['q'],
+                'category__description__contains'=>$_REQUEST['q'],
+            ))
         )));
 
     include CLIENTINC_DIR . 'kb-search.inc.php';


### PR DESCRIPTION
This addresses an issue reported on the forum where searching for a keyword in FAQ search brings back more results than it should. This is due to the format of the query selecting the results, essentially, the `WHERE NOT` statement is not properly formatted so the `OR` statements take precedence over the `WHERE NOT` causing non-public results to be shown to the client. The `WHERE NOT` statement contains the bit to select from only public faqs and since the `OR` takes precedence it will return the non-public results too.