### PR TITLE
issue: FAQ Return Errors

### DIFF
--- a/include/staff/faq.inc.php
+++ b/include/staff/faq.inc.php
@@ -4,7 +4,7 @@ if (!defined('OSTSCPINC') || !$thisstaff
     die('Access Denied');
 
 $info = $qs = array();
-if($faq){
+if($faq && $faq->getId()){
     $title=__('Update FAQ').': '.$faq->getQuestion();
     $action='update';
     $submit_text=__('Save Changes');

--- a/scp/faq.php
+++ b/scp/faq.php
@@ -143,7 +143,7 @@ if ($_POST) {
 }
 
 $inc='faq-categories.inc.php'; //FAQs landing page.
-if($faq) {
+if($faq && $faq->getId()) {
     $inc='faq-view.inc.php';
     if ($_REQUEST['a']=='edit'
             && $thisstaff->hasPerm(FAQ::PERM_MANAGE))


### PR DESCRIPTION
This addresses an issue reported on the Forum where creating a new FAQ and not filling out required information returns the correct error but returns the incorrect template (FAQ View Template). This is due to the check for an FAQ when determining the template to return. This adds a check for the FAQ ID to determine if it’s an actual FAQ or just a model instance.