### PR TITLE
FAQ Issues

### DIFF
--- a/include/class.category.php
+++ b/include/class.category.php
@@ -160,7 +160,6 @@ class Category extends VerySimpleModel {
     function delete() {
         try {
             parent::delete();
-            $this->faqs->expunge();
         }
         catch (OrmException $e) {
             return false;

--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -301,7 +301,7 @@ class FAQ extends VerySimpleModel {
         try {
             parent::delete();
             // Cleanup help topics.
-            $this->topics->delete();
+            $this->topics->expunge();
             // Cleanup attachments.
             $this->attachments->deleteAll();
         }
@@ -391,10 +391,10 @@ class FAQ extends VerySimpleModel {
         $this->notes = Format::sanitize($vars['notes']);
         $this->keywords = ' ';
 
-        $this->updateTopics($vars['topics']);
-
         if (!$this->save())
             return false;
+
+        $this->updateTopics($vars['topics']);
 
         // General attachments (for all languages)
         // ---------------------

--- a/scp/categories.php
+++ b/scp/categories.php
@@ -96,15 +96,23 @@ if($_POST){
                         }
                         break;
                     case 'delete':
-                        $i = Category::objects()->filter(array(
+                        $categories = Category::objects()->filter(array(
                             'category_id__in'=>$_POST['ids']
-                        ))->delete();
+                        ));
+                        foreach ($categories as $c) {
+                            if ($faqs = FAQ::objects()
+                                  ->filter(array('category_id'=>$c->getId()))) {
+                                      foreach ($faqs as $key => $faq)
+                                          $faq->delete();
+                                  }
+                             $c->delete();
+                        }
 
-                        if ($i==$count)
+                        if (count($categories)==$count)
                             $msg = sprintf(__('Successfully deleted %s.'),
                                 _N('selected category', 'selected categories', $count));
-                        elseif ($i > 0)
-                            $warn = sprintf(__('%1$d of %2$d %3$s deleted'), $i, $count,
+                        elseif ($categories > 0)
+                            $warn = sprintf(__('%1$d of %2$d %3$s deleted'), $categories, $count,
                                 _N('selected category', 'selected categories', $count));
                         elseif (!$errors['err'])
                             $errors['err'] = sprintf(__('Unable to delete %s.'),

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -102,15 +102,18 @@ if($_POST){
                         }
                         break;
                     case 'delete':
-                        $i = Topic::objects()->filter(array(
+                        $topics = Topic::objects()->filter(array(
                             'topic_id__in'=>$_POST['ids']
-                        ))->delete();
+                        ));
 
-                        if($i && $i==$count)
+                        foreach ($topics as $t)
+                            $t->delete();
+
+                        if($topics && $topics==$count)
                             $msg = sprintf(__('Successfully deleted %s.'),
                                 _N('selected help topic', 'selected help topics', $count));
-                        elseif($i>0)
-                            $warn = sprintf(__('%1$d of %2$d %3$s deleted'), $i, $count,
+                        elseif($topics>0)
+                            $warn = sprintf(__('%1$d of %2$d %3$s deleted'), $topics, $count,
                                 _N('selected help topic', 'selected help topics', $count));
                         elseif(!$errors['err'])
                             $errors['err']  = sprintf(__('Unable to delete %s.'),


### PR DESCRIPTION
This commit fixes several issues with how we manage FAQs and related objects.

1. When trying to add a Help Topic to an FAQ, we should add the record to the faq_topic table after saving the faq so that we can accurately retrieve the faq_id

2. When deleting a Help Topic, we need to make sure we're using the topic->delete function rather than deleting based on a QuerySet so that the related FAQ Topics will also be deleted.

3. When deleting a FAQ Category, we need to ensure that we delete all related FAQs and FAQ Topics. To do this, we should use the delete function from the FAQ class first to delete all related FAQs and FAQ Topics and then we should use the Category delete function to delete the remaining Category (remove faqs->expunge from the category->delete function since it we now pass through faq->delete as well)