### PR TITLE
Queue Columns

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -723,7 +723,7 @@ class CustomQueue extends VerySimpleModel {
                 "bits" => QueueColumn::FLAG_SORTABLE,
             )),
             QueueColumn::placeholder(array(
-                "id" => 6,
+                "id" => 8,
                 "heading" => "Assignee",
                 "primary" => 'assignee',
                 "width" => 100,
@@ -1229,7 +1229,7 @@ class CustomQueue extends VerySimpleModel {
         $this->path = $this->buildPath();
         $this->setFlag(self::FLAG_INHERIT_CRITERIA, $this->parent_id);
         $this->setFlag(self::FLAG_INHERIT_COLUMNS,
-            isset($vars['inherit-columns']));
+            $this->parent_id > 0 && isset($vars['inherit-columns']));
         $this->setFlag(self::FLAG_INHERIT_EXPORT,
             $this->parent_id > 0 && isset($vars['inherit-exports']));
         $this->setFlag(self::FLAG_INHERIT_SORTING,

--- a/include/staff/templates/queue-columns.tmpl.php
+++ b/include/staff/templates/queue-columns.tmpl.php
@@ -29,7 +29,8 @@ if ($queue->parent) { ?>
     </tr>
   </tbody>
 <?php }
-$hidden_cols = $queue->inheritColumns() || $queue->useStandardColumns();
+$hidden_cols = $queue->inheritColumns() || ($queue->useStandardColumns() &&
+        $queue->parent_id);
 ?>
   <tbody class="if-not-inherited <?php if ($hidden_cols) echo 'hidden'; ?>">
     <tr class="header">


### PR DESCRIPTION
Allow admin to setup columns when creating a new parent queue and address an issue where Assignee standard columns used a wrong Id.