### PR TITLE
Issue: PDF printout

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -39,7 +39,7 @@ class mPDFWithLocalImages extends Mpdf {
                 if (!($file = @$images[strtolower($match[1])]))
                     return $match[0];
                 $key = "__attached_file_".$filenumber++;
-                $self->{$key} = $file->getData();
+                $self->imageVars[$key] = $file->getData();
                 return 'var:'.$key;
             },
             $html

--- a/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -262,8 +262,8 @@ class ConfigVariables
 			// Reduce memory usage processing tables (but with increased processing time)
 			'packTableData' => false,
 
-			'ignore_table_percents' => false,
-			'ignore_table_widths' => false,
+			'ignore_table_percents' => true,
+			'ignore_table_widths' => true,
 			// If table width set > page width, force resizing but keep relative sizes
 			// Also forces respect of cell widths set by %
 			'keep_table_proportions' => true,


### PR DESCRIPTION
This commit fixes 2 issues we had with using MPDF to export Tickets:

1. Tickets with inline images
	To refer to images as var:varname, imageVars needs to be set for the MPDF object.
2. Tickets with tables
	When exporting a Ticket where a Thread Entry contains a table, we must ignore table percents and table widths, otherwise, it will always throw the error "Word is too long to fit in table"