### PR TITLE
Issue: Ticket Export Headers

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1144,25 +1144,23 @@ class CustomQueue extends VerySimpleModel {
 
         $new = $fields;
         foreach ($this->exports as $f) {
+            $heading = $f->getHeading();
             $key = $f->getPath();
             if (!isset($fields[$key])) {
                 $this->exports->remove($f);
                 continue;
             }
 
-            $info = $fields[$key];
-            if (is_array($info))
-                $heading = $info['heading'];
-            else
-                $heading = $info;
-
             $f->set('heading', $heading);
             $f->set('sort', array_search($key, $order)+1);
             unset($new[$key]);
         }
 
+        $exportableFields = CustomQueue::getExportableFields();
         foreach ($new as $k => $field) {
-            if (is_array($field))
+            if (isset($exportableFields[$k]))
+                $heading = $exportableFields[$k];
+            elseif (is_array($field))
                 $heading = $field['heading'];
             else
                 $heading = $field;


### PR DESCRIPTION
This commit fixes an issue where custom export headings were being set to numeric values rather than field labels.

For exports that are already saved, we can get the heading directly using getHeading. To get the heading for fields that are not already saved as exports, we can use getExportableFields, which will return path => heading.