### PR TITLE
Issue: Choosing Fields to Export

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -807,9 +807,17 @@ class CustomQueue extends VerySimpleModel {
         // See if we have cached export preference
         if (isset($_SESSION['Export:Q'.$this->getId()])) {
             $opts = $_SESSION['Export:Q'.$this->getId()];
-            if (isset($opts['fields']))
+            if (isset($opts['fields'])) {
                 $fields = array_intersect_key($fields,
                         array_flip($opts['fields']));
+                $exportableFields = CustomQueue::getExportableFields();
+                foreach ($opts['fields'] as $key => $name) {
+                    if (is_null($fields[$name]) && isset($exportableFields)) {
+                        $fields[$name] = $exportableFields[$name];
+                    }
+                 }
+            }
+
             if (isset($opts['filename'])
                     && ($parts = pathinfo($opts['filename']))) {
                 $filename = $opts['filename'];


### PR DESCRIPTION
This commit fixes an issue where only the saved export fields would export, whether you checked more fields to export or unchecked some of the saved fields.

For any fields not saved that need to be exported, we need to find their label and then put it in the fields array. For any saved export fields that are unchecked, we need to compare what was checked vs what is saved and then unset the fields that were unchecked.