### PR TITLE
Issue: Saving Checkbox Values

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1194,11 +1194,10 @@ class DynamicFormEntry extends VerySimpleModel {
             $field = $a->getField();
             if (!$field->hasData() || $field->isPresentationOnly())
                 continue;
-            $after = $field->to_database($field->getClean());
-            $before = $field->to_database($a->getValue());
-            if ($before == $after)
+            $changes = $field->getChanges();
+            if (!$changes)
                 continue;
-            $fields[$field->get('id')] = array($before, $after);
+            $fields[$field->get('id')] = $changes;
         }
         return $fields;
     }

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1677,6 +1677,24 @@ class BooleanField extends FormField {
         return ($value) ? __('Yes') : __('No');
     }
 
+    function getClean($validate=true) {
+        if (!isset($this->_clean)) {
+            $this->_clean = (isset($this->value))
+                ? $this->value : $this->getValue();
+
+            if ($this->isVisible() && $validate)
+                $this->validateEntry($this->_clean);
+        }
+        return $this->_clean;
+    }
+
+    function getChanges() {
+        $new = $this->getValue();
+        $old = $this->answer ? $this->answer->getValue() : $this->get('default');
+
+        return ($old != $new) ? array($this->to_database($old), $this->to_database($new)) : false;
+    }
+
     function getSearchMethods() {
         return array(
             'set' =>        __('checked'),


### PR DESCRIPTION
This commit fixes an issue where checkboxes could not be edited for inline edit or all field edits.

When a BooleanField is directly passed to the to_database method, you are not able to accurately check to see if old != new. To fix this, I added a new getChanges method to the BooleanField class that will first do a comparison on the raw boolean value (true, false) and then get the value needed for the database. I then made sure that we use that new function when editing all fields together as well.

Additionally, I added a getClean method to the BooleanField class so that $this->_clean for the field would be set to either true or NULL depending on if the box is checked or not and would accurately save to the database when calling $form->saveAnswers()

This fixes Issue #4782