### PR TITLE
Fix bug: send new ticket alert to account manager

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1385,7 +1385,7 @@ implements RestrictedAccess, Threadable {
             }
 
             // Account manager
-            if ($cfg->alertAcctManagerONNewMessage()
+            if ($cfg->alertAcctManagerONNewTicket()
                 && ($org = $this->getOwner()->getOrganization())
                 && ($acct_manager = $org->getAccountManager())
             ) {


### PR DESCRIPTION
not sending new ticket alert to account manager in case:
"New ticket alert to Organization Account Manager" selected
"New message alert to Organization Account Manager" not selected