### PR TITLE
issue: Organizations Users Sort

### DIFF
--- a/include/staff/orgs.inc.php
+++ b/include/staff/orgs.inc.php
@@ -18,7 +18,7 @@ if ($_REQUEST['query']) {
 
 $sortOptions = array(
         'name' => 'name',
-        'users' => 'users',
+        'users' => 'user_count',
         'create' => 'created',
         'update' => 'updated'
         );


### PR DESCRIPTION
This addresses issue #4803 where sorting by Users on Organizations does not sort properly. It sorts by name instead of the User count. This corrects the value in the `$sortOptions` array from `users` to `user_count`.