### PR TITLE
issue: Multilingual FAQ Category w/ Parent

### DIFF
--- a/include/staff/category.inc.php
+++ b/include/staff/category.inc.php
@@ -124,6 +124,14 @@ if (count($langs) > 1) { ?>
             <?php
             } ?>
         </select>
+        <script>
+            $('select[name=pid]').on('change', function() {
+                var val = this.value;
+                $('select[name=pid]').each(function() {
+                    $(this).val(val);
+                });
+            });
+        </script>
     </div>
     <div style="padding-bottom:8px;">
         <b><?php echo __('Category Name');?></b>:


### PR DESCRIPTION
This addresses issue #4810 where having more than one language installed and trying to add a new FAQ Category with a Parent Category relation fails to add the Parent Category relation. This is due to multiple Select2 fields; the POST data includes only the last Select2 field's value instead of the one in the tab you're currently on. This adds a script to set all Select2 fields in all the available languages to the same value so the POST will always contain the appropriate Parent ID no matter what language tab you’re on.