### PR TITLE
issue: Task Print PDF

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -108,7 +108,7 @@ class Task2PDF extends mPDFWithLocalImages {
         $this->task = $task;
         $this->options = $options;
 
-        parent::__construct('', $this->options['psize']);
+        parent::__construct(['format' => $this->options['psize']]);
         $this->_print();
     }
 


### PR DESCRIPTION
This addresses an issue where clicking print on a Task throws a fatal error. This is due to the Task2PDF function passing a string instead of an array to `Mpdf::__construct()`. The `__construct()` of class Mpdf requires an array of configurations so we are now passing an array instead of a string.