### PR TITLE
Issue: MPDF Export PHP < 7.0

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -295,6 +295,12 @@ class Bootstrap {
         if (extension_loaded('iconv'))
             iconv_set_encoding('internal_encoding', 'UTF-8');
 
+        if (intval(phpversion()) < 7) {
+            function random_int($a, $b) {
+                return rand($a, $b);
+            }
+        }
+
         function mb_str_wc($str) {
             return count(preg_split('~[^\p{L}\p{N}\'].+~u', trim($str)));
         }


### PR DESCRIPTION
This commit fixes an issue where using MPDF to print Tickets did not work if the PHP version was < 7.0 because MPDF called the random_int function which is only available for PHP 7.0+. Now, we check the PHP version before printing, and if it is less than 7.0, we use the rand function. If it is >= 7.0, we continue to use the random_int function.