### PR TITLE
oops: Thread Variable Fatal Error

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -3047,6 +3047,10 @@ class ThreadEntries {
         $this->thread = $thread;
     }
 
+    function __tostring() {
+        return (string) $this->getVar();
+    }
+
     function asVar() {
         return $this->getVar();
     }


### PR DESCRIPTION
This addresses an issue introduced with #4737 where using `%{ticket.thread}` causes a fatal error. This is because `ObjectThread->asVar()` returns an object which cannot be converted to a string. This adds a `__tostring()` function to class ThreadEntries so it can be converted to a string properly.