### PR TITLE
issue: iFrame On Install

### DIFF
--- a/setup/inc/header.inc.php
+++ b/setup/inc/header.inc.php
@@ -1,5 +1,6 @@
 <?php
-header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+if ($cfg)
+    header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
 ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
     "http://www.w3.org/TR/html4/loose.dtd">


### PR DESCRIPTION
This addresses the "Call to getAllowIframes() on NULL" error on installation pages. This is due to #4781 that introduced the concept of allowing multiple iFrames, where we are not checking for `$cfg` before calling the method. This adds a check for `$cfg` so the errors do not occur.