### PR TITLE
issue: Organization Ticket Export No Filename

### DIFF
--- a/scp/orgs.php
+++ b/scp/orgs.php
@@ -118,7 +118,7 @@ if ($org) {
         } elseif ($_REQUEST['a'] == 'export' && ($query=$_SESSION[':O:tickets'])) {
             $filename = sprintf('%s-tickets-%s.csv',
                     $org->getName(), strftime('%Y%m%d'));
-            if (!Export::saveTickets($query, $filename, 'csv'))
+            if (!Export::saveTickets($query, NULL, $filename, 'csv'))
                 $errors['err'] = __('Unable to dump query results.')
                     .' '.__('Internal error occurred');
         }


### PR DESCRIPTION
This addresses an issue where clicking Export on an Organization's Tickets will export a file with the filename of 'csv' and no extension. This is due to the variables we are passing to the `saveTickets` function. We are missing a variable called '$fields' that contains a list of fields.