### PR TITLE
MPDF Issues

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -155,7 +155,8 @@ class FAQ extends VerySimpleModel {
         include STAFFINC_DIR . 'templates/faq-print.tmpl.php';
         $html = ob_get_clean();
 
-        $pdf = new mPDFWithLocalImages('', $paper);
+        $pdf = new mPDFWithLocalImages(['mode' => 'utf-8', 'format' =>
+               $paper, 'tempDir'=>sys_get_temp_dir()]);
         // Setup HTML writing and load default thread stylesheet
         $pdf->WriteHtml(
             '<style>

--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -108,7 +108,7 @@ class Task2PDF extends mPDFWithLocalImages {
         $this->task = $task;
         $this->options = $options;
 
-        parent::__construct(['format' => $this->options['psize']]);
+        parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir()]);
         $this->_print();
     }
 

--- a/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -262,7 +262,7 @@ class ConfigVariables
 			// Reduce memory usage processing tables (but with increased processing time)
 			'packTableData' => false,
 
-			'ignore_table_percents' => true,
+			'ignore_table_percents' => false,
 			'ignore_table_widths' => true,
 			// If table width set > page width, force resizing but keep relative sizes
 			// Also forces respect of cell widths set by %


### PR DESCRIPTION
1. Task Exports: This commit fixes the contructor for printing Tasks using MPDF

2. PDF Formatting: This commit fixes an issue where the header of each thread entry did not stretch across the page correctly. This was an unintentional side effect of trying to fix the way HTML tables printed in PDFs.

3. FAQ PDFs: This commit passes the correct values to mPDFWithLocalImages when printing FAQs