### PR TITLE
issue: sendAccessLink On NULL

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2884,7 +2884,10 @@ implements RestrictedAccess, Threadable {
             ->filter(array('number' => $number));
 
         if ($email)
-            $query->filter(array('user__emails__address' => $email));
+            $query->filter(Q::any(array(
+                'user__emails__address' => $email,
+                'thread__collaborators__user__emails__address' => $email
+            )));
 
 
         if (!$ticket) {


### PR DESCRIPTION
This addresses an issue where entering a collaborator's email to send ticket email access link throws a fatal error. This is due to the method that checks for tickets with the User's email equal to the email provided. This only checks for User's emails not Collaborator emails. This adds a check for Collaborator emails as well so this will not crash out.