### PR TITLE
issue: sendAccessLink On NULL v1.11

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -406,6 +406,8 @@ class Mailer {
         if (!is_array($recipients) && (!$recipients instanceof MailingList))
             $recipients =  array($recipients);
         foreach ($recipients as $recipient) {
+            if ($recipient instanceof ClientSession)
+                $recipient = $recipient->getSessionUser();
             switch (true) {
                 case $recipient instanceof EmailRecipient:
                     $addr = sprintf('"%s" <%s>',

--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -123,6 +123,10 @@ class ClientSession extends EndUser {
         $this->session= new UserSession($user->getId());
     }
 
+    function getSessionUser() {
+        return $this->user;
+    }
+
     function isValid(){
         global $_SESSION,$cfg;
 


### PR DESCRIPTION
This addresses an issue in v1.11 where sending an Access Link via email to a Collaborator fails with fatal error. This is due to the type of User class that is sent to the `Mailer::send()` function. The ClientSession User class is not appropriate for this method, rather, TicketOwner or Collaborator User classes are appropriate. This adds a function called `getSessionUser()` to the ClientSession class so we can retrieve the TicketOwner/Collaborator User class from the session.