### PR TITLE
Issue: Queue with Teams in Criteria

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2585,8 +2585,7 @@ class SqlCompiler {
         }
         $glue = $Q->ored ? ' OR ' : ' AND ';
         $clause = implode($glue, $filter);
-        if (($Q->negated || $parens) && count($filter) > 1)
-            $clause = '(' . $clause . ')';
+        $clause = '(' . $clause . ')';
         if ($Q->negated)
             $clause = 'NOT '.$clause;
         return new CompiledExpression($clause, $type);

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2560,8 +2560,10 @@ class SqlCompiler {
                         $criteria["{$field}__{$f}"] = $v;
                     }
                 }
-                $filter[] = $this->compileQ(new Q($criteria), $model,
-                    $Q->ored || $Q->negated);
+                // New criteria here is joined with AND, so if the outer
+                // criteria is joined with OR, then parentheses are
+                // necessary
+                $filter[] = $this->compileQ(new Q($criteria), $model, $Q->ored);
             }
             // Handle simple field = <value> constraints
             else {
@@ -2585,7 +2587,8 @@ class SqlCompiler {
         }
         $glue = $Q->ored ? ' OR ' : ' AND ';
         $clause = implode($glue, $filter);
-        $clause = '(' . $clause . ')';
+        if (($Q->negated || $parens) && count($filter) > 1)
+            $clause = '(' . $clause . ')';
         if ($Q->negated)
             $clause = 'NOT '.$clause;
         return new CompiledExpression($clause, $type);
@@ -2593,16 +2596,10 @@ class SqlCompiler {
 
     function compileConstraints($where, $model) {
         $constraints = array();
-        $prev = $parens = false;
         foreach ($where as $Q) {
-            if ($prev && !$prev->isCompatibleWith($Q)) {
-                $parens = true;
-                break;
-            }
-            $prev = $Q;
-        }
-        foreach ($where as $Q) {
-            $constraints[] = $this->compileQ($Q, $model, $parens);
+            // Constraints are joined by AND operators, so if they have
+            // internal OR operators, then they need to be parenthesized
+            $constraints[] = $this->compileQ($Q, $model, $Q->ored);
         }
         return $constraints;
     }

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1244,7 +1244,10 @@ class AssigneeChoiceField extends ChoiceField {
                     $agents[] = (int) substr($id, 1);
                     break;
                 case 'T':
-                    $teams = array_merge($thisstaff->getTeams());
+                    if (!$thisstaff || !($staffTeams = $thisstaff->getTeams()))
+                        return Q::any(['team_id' => null]);
+
+                    $teams = array_merge($staffTeams);
                     break;
                 case 't':
                     $teams[] = (int) substr($id, 1);
@@ -1425,12 +1428,13 @@ class TeamSelectionField extends AdvancedSearchSelectionField {
         global $thisstaff;
 
         // Unpack my teams
-        if (isset($value['T']) && $thisstaff
-                && ($teams = $thisstaff->getTeams())) {
+        if (isset($value['T'])) {
+             if (!$thisstaff || !($teams = $thisstaff->getTeams()))
+                return Q::any(['team_id' => null]);
+
             unset($value['T']);
             $value = $value + array_flip($teams);
         }
-
         return parent::getSearchQ($method, $value, $name);
     }
 


### PR DESCRIPTION
This commit fixes an issue with queues or searches that have a criteria for team assignment when the Agent is not assigned to any teams. In this case, the queue should not return any tickets. Previously, it would create an invalid query which would cause system errors.