### PR TITLE
feature: ACL (Access Control List)

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -424,6 +424,26 @@ class OsticketConfig extends Config {
         return str_replace(array(', ', ','), array(' ', ' '), $this->get('allow_iframes')) ?: 'self';
     }
 
+    function getACL() {
+        if (!($acl = $this->get('acl')))
+            return null;
+
+        return explode(',', str_replace(' ', '', $acl));
+    }
+
+    function getACLBackendOpts() {
+        return array(
+            0 => __('Disabled'),
+            1 => __('All'),
+            2 => __('Client Portal'),
+            3 => __('Staff Panel')
+        );
+    }
+
+    function getACLBackend() {
+        return $this->get('acl_backend') ?: 0;
+    }
+
     function isAvatarsEnabled() {
         return $this->get('enable_avatars');
     }
@@ -1125,6 +1145,7 @@ class OsticketConfig extends Config {
         $f['default_dept_id']=array('type'=>'int',   'required'=>1, 'error'=>__('Default Department is required'));
         $f['autolock_minutes']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter lock time in minutes'));
         $f['allow_iframes']=array('type'=>'cs-domain',   'required'=>0, 'error'=>__('Enter comma separated list of domains'));
+        $f['acl']=array('type'=>'ipaddr',   'required'=>0, 'error'=>__('Enter comma separated list of IP addresses'));
         //Date & Time Options
         $f['time_format']=array('type'=>'string',   'required'=>1, 'error'=>__('Time format is required'));
         $f['date_format']=array('type'=>'string',   'required'=>1, 'error'=>__('Date format is required'));
@@ -1134,6 +1155,18 @@ class OsticketConfig extends Config {
         $f['system_language']=array('type'=>'string',   'required'=>1, 'error'=>__('A primary system language is required'));
 
         $vars = Format::htmlchars($vars, true);
+
+        // ACL Checks
+        if ($vars['acl']) {
+            // Check if Admin's IP is in the list, if not, return error
+            // to avoid locking self out
+            if (!in_array($vars['acl_backend'], array(0,2))) {
+                $acl = explode(',', str_replace(' ', '', $acl));
+                if (!in_array(osTicket::get_client_ip(), $acl))
+                    $errors['acl'] = __('Cowardly refusing to lock out active administrator');
+            }
+        } elseif ((int) $vars['acl_backend'] !== 0)
+            $errors['acl'] = __('IP address required when selecting panel');
 
         // Make sure the selected backend is valid
         $storagebk = null;
@@ -1184,6 +1217,8 @@ class OsticketConfig extends Config {
             'enable_richtext' => isset($vars['enable_richtext']) ? 1 : 0,
             'files_req_auth' => isset($vars['files_req_auth']) ? 1 : 0,
             'allow_iframes' => Format::sanitize($vars['allow_iframes']),
+            'acl' => Format::sanitize($vars['acl']),
+            'acl_backend' => Format::sanitize((int) $vars['acl_backend']) ?: 0,
         ));
     }
 

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -131,6 +131,13 @@ class Validator {
                                 ltrim($v)))
                             $this->errors[$k]=$field['error'];
                 break;
+            case 'ipaddr':
+                if($values=explode(',', $this->input[$k])){
+                    foreach($values as $v)
+                        if(!preg_match_all('/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/', ltrim($v)))
+                            $this->errors[$k]=$field['error'];
+                }
+                break;
             default://If param type is not set...or handle..error out...
                 $this->errors[$k]=$field['error'].' '.__('(type not set)');
             endswitch;
@@ -306,6 +313,37 @@ class Validator {
             $errors=array_merge($errors,$val->errors());
 
         return (!$errors);
+    }
+
+    function check_acl($backend) {
+        global $cfg;
+
+        $acl = $cfg->getACL();
+        if (empty($acl))
+            return true;
+        $ip = osTicket::get_client_ip();
+        if (empty($ip))
+            return false;
+
+        $aclbk = $cfg->getACLBackend();
+        switch($backend) {
+            case 'client':
+                if (in_array($aclbk, array(0,3)))
+                    return true;
+                break;
+            case 'staff':
+                if (in_array($aclbk, array(0,2)))
+                    return true;
+                break;
+            default:
+                return false;
+                break;
+        }
+
+        if (!in_array($ip, $acl))
+            return false;
+
+        return true;
     }
 }
 ?>

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -7,6 +7,11 @@ $signout_url = ROOT_PATH . "logout.php?auth=".$ost->getLinkToken();
 
 header("Content-Type: text/html; charset=UTF-8");
 header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+
+// Enforce ACL (if applicable)
+if (!Validator::check_acl('client'))
+    die(__('Access Denied'));
+
 if (($lang = Internationalization::getCurrentLanguage())) {
     $langs = array_unique(array($lang, $cfg->getPrimaryLanguage()));
     $langs = Internationalization::rfc1766($langs);

--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -106,6 +106,26 @@ allow_iframes:
       - title: Syntax Information (host-source)
         href: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors#Sources"
 
+acl:
+    title: ACL (Access Control List)
+    content: >
+        Enter a comma separated list of IP addresses to allow access to the system.
+        There are four options to choose which panel(s) to apply the ACL to.
+        <table border="1" cellpadding="2px" cellspacing="0" style="margin-top:7px"
+            ><tbody style="vertical-align:top;">
+            <tr><th>Apply To</th>
+                <th>Description</th></tr>
+            <tr><td>Disabled</td>
+                <td>Disables ACL altogether.</td></tr>
+            <tr><td>All</td>
+                <td>Applies ACL to all Panels. (ie. Client Portal, Staff Panel,
+                 Admin Panel)</td></tr>
+            <tr><td>Client Portal</td>
+                <td>Applies ACL to only Client Portal.</td></tr>
+            <tr><td>Staff Panel</td>
+                <td>Applies ACL to only Staff Panel and Admin Panel.</td></tr>
+        </tbody></table>
+
 # Date and time options
 date_time_options:
     title: Date &amp; Time Options

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -2,6 +2,10 @@
 header("Content-Type: text/html; charset=UTF-8");
 header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
 
+// Enforce ACL (if applicable)
+if (!Validator::check_acl('staff'))
+    die(__('Access Denied'));
+
 $title = ($ost && ($title=$ost->getPageTitle()))
     ? $title : ('osTicket :: '.__('Staff Control Panel'));
 

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -139,6 +139,26 @@ $gmtime = Misc::gmtime();
             </td>
         </tr>
         <tr>
+            <td><?php echo __('ACL'); ?>:</td>
+            <td><input type="text" size="40" name="acl" value="<?php echo $config['acl']; ?>"
+                    placeholder="eg. 192.168.1.1, 192.168.2.2, 192.168.3.3">
+                &nbsp;Apply To:
+                <select name="acl_backend">
+                    <?php foreach($cfg->getACLBackendOpts() as $k=>$v) { ?>
+                    <option <?php if ($cfg->getACLBackend() == $k) echo 'selected="selected"'; ?>
+                    value="<?php echo $k; ?>">
+                        <?php echo $v; ?>
+                    </option>
+                    <?php } ?>
+                </select>
+                <i class="help-tip icon-question-sign" href="#acl"></i>
+            <?php if ($errors['acl']) { ?>
+                <br>
+                <font class="error">&nbsp;<?php echo $errors['acl']; ?></font>
+            <?php } ?>
+            </td>
+        </tr>
+        <tr>
             <th colspan="2">
                 <em><b><?php echo __('Date and Time Options'); ?></b>&nbsp;
                 <i class="help-tip icon-question-sign" href="#date_time_options"></i>


### PR DESCRIPTION
This adds a new feature called ACL that offers the ability to control what IP addresses are allowed to access the Login Page(s). This adds a new textfield to the System Settings to add a comma separated list of IPs. This also adds a checkbox called "Apply To Backend Only" that, if enabled, will only apply the ACL to the Agent Login Page. Lastly, this adds a validator for a simple comma-separated list of IP addresses. (eg. `111.111.111.111, 222.222.222.222, 333.333.333.333`)

If the requester's IP is not in the ACL the system will show an "Access Denied" page. If the requester's IP is in the ACL they will be able to access the Login Page(s) as usual. If the ACL field is left blank anyone will be able to access the User/Agent Login Pages.