### PR TITLE
issue: iFrame Single Quotes

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -430,7 +430,7 @@ class OsticketConfig extends Config {
     }
 
     function getAllowIframes() {
-        return str_replace(array(', ', ','), array(' ', ' '), $this->get('allow_iframes')) ?: 'self';
+        return str_replace(array(', ', ','), array(' ', ' '), $this->get('allow_iframes')) ?: "'self'";
     }
 
     function isAvatarsEnabled() {

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -6,7 +6,7 @@ $signin_url = ROOT_PATH . "login.php"
 $signout_url = ROOT_PATH . "logout.php?auth=".$ost->getLinkToken();
 
 header("Content-Type: text/html; charset=UTF-8");
-header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
 if (($lang = Internationalization::getCurrentLanguage())) {
     $langs = array_unique(array($lang, $cfg->getPrimaryLanguage()));
     $langs = Internationalization::rfc1766($langs);

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -1,6 +1,6 @@
 <?php
 header("Content-Type: text/html; charset=UTF-8");
-header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
 
 $title = ($ost && ($title=$ost->getPageTitle()))
     ? $title : ('osTicket :: '.__('Staff Control Panel'));

--- a/include/staff/login.header.php
+++ b/include/staff/login.header.php
@@ -1,6 +1,6 @@
 <?php
 defined('OSTSCPINC') or die('Invalid path');
-header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">

--- a/setup/inc/header.inc.php
+++ b/setup/inc/header.inc.php
@@ -1,6 +1,6 @@
 <?php
 if ($cfg)
-    header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+    header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
 ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
     "http://www.w3.org/TR/html4/loose.dtd">


### PR DESCRIPTION
It's all about the single quotes baby! Apparently I can't read; the single quotes are only meant for word options such as `'self'` and `'none'`. When adding single quotes to the `<host-source>` options it takes them literally…too literally. For example, if your options are `'localhost:80 localhost:8080 localhost:8000'` then `'localhost:80` and `localhost:8000'` will be seen as "invalid" due to the single quotes. This removes the single quotes from every line that sets the CSP so all options are valid. This also adds single quotes around the `self` option so it stays valid as well.