### PR TITLE
issue: ACL Move To Inc Files

### DIFF
--- a/client.inc.php
+++ b/client.inc.php
@@ -22,6 +22,10 @@ require_once($thisdir.'main.inc.php');
 
 if(!defined('INCLUDE_DIR')) die('Fatal error');
 
+// Enforce ACL (if applicable)
+if (!Validator::check_acl('client'))
+    die(__('Access Denied'));
+
 /*Some more include defines specific to client only */
 define('CLIENTINC_DIR',INCLUDE_DIR.'client/');
 define('OSTCLIENTINC',TRUE);

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -8,10 +8,6 @@ $signout_url = ROOT_PATH . "logout.php?auth=".$ost->getLinkToken();
 header("Content-Type: text/html; charset=UTF-8");
 header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
 
-// Enforce ACL (if applicable)
-if (!Validator::check_acl('client'))
-    die(__('Access Denied'));
-
 if (($lang = Internationalization::getCurrentLanguage())) {
     $langs = array_unique(array($lang, $cfg->getPrimaryLanguage()));
     $langs = Internationalization::rfc1766($langs);

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -2,10 +2,6 @@
 header("Content-Type: text/html; charset=UTF-8");
 header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
 
-// Enforce ACL (if applicable)
-if (!Validator::check_acl('staff'))
-    die(__('Access Denied'));
-
 $title = ($ost && ($title=$ost->getPageTitle()))
     ? $title : ('osTicket :: '.__('Staff Control Panel'));
 

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -21,6 +21,10 @@ require_once('../main.inc.php');
 
 if(!defined('INCLUDE_DIR')) die('Fatal error... invalid setting.');
 
+// Enforce ACL (if applicable)
+if (!Validator::check_acl('staff'))
+    die(__('Access Denied'));
+
 /*Some more include defines specific to staff only */
 define('STAFFINC_DIR',INCLUDE_DIR.'staff/');
 define('SCP_DIR',str_replace('//','/',dirname(__FILE__).'/'));


### PR DESCRIPTION
This moves ACL enforcement from the header files to the `client.inc.php` & `staff.inc.php` files so that AJAX/PJAX may bypass ACL.