### PR TITLE
Mime Decode - Encoded chars

### DIFF
--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -645,7 +645,10 @@ class Mail_mimeDecode extends PEAR
         $input = preg_replace("/=\r?\n/", '', $input);
 
         // Replace encoded characters
-		$input = preg_replace('/=([a-f0-9]{2})/ie', "chr(hexdec('\\1'))", $input);
+       $input = preg_replace_callback('/=([a-f0-9]{2})/i',
+               create_function('$matches',
+                   ' return chr(hexdec($matches[0]));'),
+               $input);
 
         return $input;
     }


### PR DESCRIPTION
This commit addresses an issue where pre_replace fails in php 7.x resulting in a ticket with an empty body.