### PR TITLE
PJAX: Increase default timeout

### DIFF
--- a/include/staff/templates/tasks-actions.tmpl.php
+++ b/include/staff/templates/tasks-actions.tmpl.php
@@ -166,6 +166,7 @@ $(function() {
             +'&_uid='+new Date().getTime();
             var $redirect = $(this).data('redirect');
             $.dialog(url, [201], function (xhr) {
+               $.pjax.defaults.timeout = 30000;
                 if (!!$redirect)
                     $.pjax({url: $redirect, container:'#pjax-container'});
                 else

--- a/include/staff/ticket-tasks.inc.php
+++ b/include/staff/ticket-tasks.inc.php
@@ -195,7 +195,7 @@ $(function() {
                 $container.load(url+'/'+tid+'/view', function () {
                     $('.tip_box').remove();
                     $('div#tasks_content').hide();
-                    $.pjax({url: url, container: '#tasks_content', push: false});
+                    $.pjax({url: url, container: '#tasks_content', timeout: 30000, push: false});
                 }).show();
             } else {
                 window.location.href = $redirect ? $redirect : window.location.href;

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -595,6 +595,7 @@ $(document).ajaxSend(function(event, xhr, settings) {
 /* Get config settings from the backend */
 jQuery.fn.exists = function() { return this.length>0; };
 
+$.pjax.defaults.timeout = 30000;
 $.translate_format = function(str) {
     var translation = {
         'DD':   'oo',
@@ -1131,7 +1132,7 @@ if ($.support.pjax) {
     if (!$this.hasClass('no-pjax')
         && !$this.closest('.no-pjax').length
         && $this.attr('href').charAt(0) != '#')
-      $.pjax.click(event, {container: $this.data('pjaxContainer') || '#pjax-container', timeout: 2000});
+      $.pjax.click(event, {container: $this.data('pjaxContainer') || '#pjax-container', timeout: 30000});
   })
 }
 

--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -307,7 +307,7 @@ $.refreshTicketView = function(interval) {
         return;
 
       clearInterval(refresh);
-      $.pjax({url: document.location.href, container:'#pjax-container'});
+      $.pjax({url: document.location.href, container:'#pjax-container', timeout: 30000});
     }, interval);
     $(document).on('pjax:start', function() {
         clearInterval(refresh);


### PR DESCRIPTION
Increase default pjax timeout to 30 seconds to avoid double requests  & reloads.