### PR TITLE
MPDF Tasks

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -108,7 +108,7 @@ class Task2PDF extends mPDFWithLocalImages {
         $this->task = $task;
         $this->options = $options;
 
-        parent::__construct('', $this->options['psize']);
+        parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir()]);
         $this->_print();
     }
 

--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -108,7 +108,7 @@ class Task2PDF extends mPDFWithLocalImages {
         $this->task = $task;
         $this->options = $options;
 
-        parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir()]);
+        parent::__construct(['mode' => 'utf-8', 'format' => $this->options['psize'], 'tempDir'=>sys_get_temp_dir()]);
         $this->_print();
     }
 

--- a/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -262,7 +262,7 @@ class ConfigVariables
 			// Reduce memory usage processing tables (but with increased processing time)
 			'packTableData' => false,
 
-			'ignore_table_percents' => true,
+			'ignore_table_percents' => false,
 			'ignore_table_widths' => true,
 			// If table width set > page width, force resizing but keep relative sizes
 			// Also forces respect of cell widths set by %


### PR DESCRIPTION
Use the psize that is set in the options array since $psize is not in the Task2PDF contructor.