### PR TITLE
issue: API Unexpected Data Warnings

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -15,7 +15,12 @@ class TicketApiController extends ApiController {
                 array("name", "type", "data", "encoding", "size")
             ),
             "message", "ip", "priorityId",
-            "system_emails", "thread_entry_recipients"
+            "system_emails" => array(
+                "*" => "*"
+            ),
+            "thread_entry_recipients" => array (
+                "*" => array("to", "cc")
+            )
         );
         # Fetch dynamic form field names for the given help topic and add
         # the names to the supported request structure


### PR DESCRIPTION
This addresses an issue reported on the Forum where `API Unexpected Data` warnings are appearing in the system logs for the `thread_entry_recipients` and `system_emails` keys for piped emails. This is due to the API request validator that checks the keys of the API data; if a key's data is an array itself it loops through the validator again to check the key(s) inside the data array. This is fine for most keys but for the `thread_entry_recipients` and `system_emails` keys the request structure does not contain the necessary sub-keys to validate the data keys. This adds the necessary sub-keys to the request structure so that `thread_entry_recipients` and `system_emails` data keys can be validated.