### PR TITLE
issue: Task EstDueDate

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1037,7 +1037,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         case 'create_date':
             return new FormattedDate($this->getCreateDate());
          case 'due_date':
-            if ($due = $this->getEstDueDate())
+            if ($due = $this->getDueDate())
                 return new FormattedDate($due);
             break;
         case 'close_date':


### PR DESCRIPTION
This addresses an issue where having the `%{task.due_date}` variable in a Task alert template whilst creating a Task with an Assignee causes a fatal error in the backend leaving the Create Task modal spinning forever. This is due to the `getVar()` method for Tasks where the `due_date` case references a non-existing method. This updates the referenced method to an existing method so it gets the correct value and does not cause a fatal error.