### PR TITLE
Issue: Tickets Visibility

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -900,7 +900,7 @@ class SavedQueue extends CustomQueue {
        $counts = array();
         $query = Ticket::objects();
         // Apply tickets visibility for the agent
-        $query = $agent->applyVisibility($query);
+        $query = $agent->applyVisibility($query, true);
         // Aggregate constraints
         foreach ($queues as $queue) {
             $Q = $queue->getBasicQuery();

--- a/include/staff/templates/queue-tickets.tmpl.php
+++ b/include/staff/templates/queue-tickets.tmpl.php
@@ -6,7 +6,11 @@
 
 // Impose visibility constraints
 // ------------------------------------------------------------
-if (!$queue->ignoreVisibilityConstraints($thisstaff))
+//filter if limited visibility or if unlimited visibility and in a queue
+$ignoreVisibility = $queue->ignoreVisibilityConstraints($thisstaff);
+if (!$ignoreVisibility || //limited visibility
+   ($ignoreVisibility && ($queue->isAQueue() || $queue->isASubQueue())) //unlimited visibility + not a search
+)
     $tickets->filter($thisstaff->getTicketsVisibility());
 
 // Make sure the cdata materialized view is available


### PR DESCRIPTION
This commit ensures that an Agent with the 'See all tickets in search results, regardless of access' permission checked can see all Tickets in a search or a saved search, but does NOT see all Tickets within queues.