### PR TITLE
xss: XSS To LFI Vulnerability

### DIFF
--- a/include/class.import.php
+++ b/include/class.import.php
@@ -39,7 +39,7 @@ class CsvImporter {
             rewind($this->stream);
         }
         else {
-            throw new ImportError(__('Unable to parse submitted csv: ').print_r($stream, true));
+            throw new ImportError(__('Unable to parse submitted csv: ').print_r(Format::htmlchars($stream), true));
         }
     }
 
@@ -59,7 +59,7 @@ class CsvImporter {
             throw new ImportError(__('Whoops. Perhaps you meant to send some CSV records'));
 
         $headers = array();
-        foreach ($data as $h) {
+        foreach (Format::htmlchars($data) as $h) {
             $h = trim($h);
             $found = false;
             foreach ($all_fields as $f) {
@@ -68,7 +68,7 @@ class CsvImporter {
                     $found = true;
                     if (!$f->get('name'))
                         throw new ImportError(sprintf(__(
-                            '%s: Field must have `variable` set to be imported'), $h));
+                            '%s: Field must have `variable` set to be imported'), Format::htmlchars($h)));
                     $headers[$f->get('name')] = $f->get('label');
                     break;
                 }
@@ -85,7 +85,7 @@ class CsvImporter {
                 }
                 else {
                     throw new ImportError(sprintf(
-                                __('%s: Unable to map header to the object field'), $h));
+                                __('%s: Unable to map header to the object field'), Format::htmlchars($h)));
                 }
             }
         }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -946,8 +946,8 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
                 }
                 else {
                     throw new ImportError(sprintf(__('Unable to import (%s): %s'),
-                        $data['username'],
-                        print_r($errors, true)
+                        Format::htmlchars($data['username']),
+                        print_r(Format::htmlchars($errors), true)
                     ));
                 }
                 $imported++;

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -456,7 +456,7 @@ implements TemplateVariable {
                     throw new ImportError('Both `name` and `email` fields are required');
                 if (!($user = static::fromVars($data, true, true)))
                     throw new ImportError(sprintf(__('Unable to import user: %s'),
-                        print_r($data, true)));
+                        print_r(Format::htmlchars($data), true)));
                 $imported++;
             }
             db_autocommit(true);


### PR DESCRIPTION
This addresses a vulnerability found by [AkkuS](https://pentest.com.tr) where a simple XSS attempt can lead to an LFI (Local File Inclusion) attack. The issue stems from the system returning the unformatted file contents in an error message when uploading a CSV to the User Importer. This formats the contents before uploading so that if the contents are returned in an error message they will not be executed by the browser which therefore prevents XSS attempts and the possibility of an LFI attack. This also formats all the user-created data sent to ImportError to prevent the same issue.