### PR TITLE
cli: Package No File Permissions

### DIFF
--- a/include/cli/modules/package.php
+++ b/include/cli/modules/package.php
@@ -125,7 +125,7 @@ class Packager extends Deployment {
                     if ($php56) {
                         // Set the Unix mode of the file
                         $stat = stat($full);
-                        $zip->setExternalAttributesName($local, ZipArchive::OPSYS_UNIX, $stat['mode']);
+                        $zip->setExternalAttributesName($local, ZipArchive::OPSYS_UNIX, $stat['mode'] << 16);
                     }
             }
         };


### PR DESCRIPTION
This addresses an issue where the `package` cli module is leaving out the permissions on files. This causes the final ZIP archive to contain files without permissions meaning the files are un-usable until you restore permissions. This can make life difficult on people trying to install osTicket with minimal knowledge as they wouldn’t know what is wrong.

This is due to the `setExternalAttributesName` method not shifting 16 bits on the file "mode" which will not translate to binary. The file "mode" is the inode protection mode for a file returned by the `stat()` method. It is essentially a decimal representation of a file's permissions. Since "mode" is in decimal format we need to shift by 16 bits to translate it to binary so the archiver understands. Once the mode is translated to binary the permissions are preserved.