### PR TITLE
oops: .eml/.msg Missing Not Operator

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -701,7 +701,7 @@ class MailFetcher {
                         $body = $this->fetchBody($mid, $info['index'].'.0',
                             $info['encoding']);
                         // Add fake body to make the parser happy
-                        if ($body)
+                        if (!$body)
                              $body.="\n\nJunk";
 
                         $parser = new Mail_Parse($body);


### PR DESCRIPTION
This addresses a typo where we are missing a not operator in class MailFetcher when checking for no `$body` in the fetched attachments. This adds the not operator so that the `if()` statement is properly executed and we correctly set a fake body when there is none.