### PR TITLE
issue: Queue Sort Title No Validation Error

### DIFF
--- a/include/ajax.admin.php
+++ b/include/ajax.admin.php
@@ -237,6 +237,9 @@ class AdminAjaxAPI extends AjaxController {
             }
         }
 
+        if (!$data_form)
+            $data_form = $sort->getDataConfigForm();
+
         include STAFFINC_DIR . 'templates/queue-sorting-add.tmpl.php';
 
     }

--- a/include/staff/templates/queue-sorting.tmpl.php
+++ b/include/staff/templates/queue-sorting.tmpl.php
@@ -1,4 +1,4 @@
-<?php echo $sort->getDataConfigForm()->asTable(); ?>
+<?php echo $data_form->asTable(); ?>
 
 <table class="table">
     <tbody class="sortable-rows">


### PR DESCRIPTION
This addresses an issue reported on the Forum where adding a new Sort Option for Queues without a title fails without error. This is due to the queue-sorting template that uses a new instance of the `QueueSortDataConfigForm` form from a new instance of `QueueSort` rather than the existing form with existing POST data/errors when a POST is submitted. This updates the queue-sorting template to use the already available `$data_form` form instance. This also adds an if statement to set the `$data_form` if one doesn’t exist (this only applies to new modals without a POST).