### PR TITLE
export: Organizations/Users Tickets

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1112,6 +1112,49 @@ implements RestrictedAccess, Threadable, Searchable {
         return $fields ? $fields[0] : null;
     }
 
+    function getExportableFields() {
+        $cdata = $fields = array();
+        foreach (TicketForm::getInstance()->getFields() as $f) {
+            // Ignore core fields
+            if (in_array($f->get('name'), array('priority')))
+                continue;
+            // Ignore non-data fields
+            elseif (!$f->hasData() || $f->isPresentationOnly())
+                continue;
+
+            $name = $f->get('name') ?: 'field_'.$f->get('id');
+            $key = 'cdata.'.$name;
+            $cdata[$key] = $f->getLocal('label');
+        }
+
+        // Standard export fields if none is provided.
+        $fields = array(
+                'number' =>         __('Ticket Number'),
+                'created' =>        __('Date Created'),
+                'cdata.subject' =>  __('Subject'),
+                'user.name' =>      __('From'),
+                'user.default_email.address' => __('From Email'),
+                'cdata.:priority.priority_desc' => __('Priority'),
+                'dept::getLocalName' => __('Department'),
+                'topic::getName' => __('Help Topic'),
+                'source' =>         __('Source'),
+                'status::getName' =>__('Current Status'),
+                'lastupdate' =>     __('Last Updated'),
+                'est_duedate' =>    __('SLA Due Date'),
+                'duedate' =>        __('Due Date'),
+                'closed' =>         __('Closed Date'),
+                'isoverdue' =>      __('Overdue'),
+                'isanswered' =>     __('Answered'),
+                'staff::getName' => __('Agent Assigned'),
+                'team::getName' =>  __('Team Assigned'),
+                'thread_count' =>   __('Thread Count'),
+                'reopen_count' =>   __('Reopen Count'),
+                'attachment_count' => __('Attachment Count'),
+                ) + $cdata;
+
+        return $fields;
+    }
+
     function addCollaborator($user, $vars, &$errors, $event=true) {
 
         if (!$user || $user->getId() == $this->getOwnerId())

--- a/scp/orgs.php
+++ b/scp/orgs.php
@@ -118,7 +118,8 @@ if ($org) {
         } elseif ($_REQUEST['a'] == 'export' && ($query=$_SESSION[':O:tickets'])) {
             $filename = sprintf('%s-tickets-%s.csv',
                     $org->getName(), strftime('%Y%m%d'));
-            if (!Export::saveTickets($query, NULL, $filename, 'csv'))
+            $target = Ticket::getExportableFields() ?: '';
+            if (!Export::saveTickets($query, $target, $filename, 'csv'))
                 $errors['err'] = __('Unable to dump query results.')
                     .' '.__('Internal error occurred');
         }

--- a/scp/users.php
+++ b/scp/users.php
@@ -184,7 +184,8 @@ if ($user ) {
         } elseif ($_REQUEST['a'] == 'export' && ($query=$_SESSION[':U:tickets'])) {
             $filename = sprintf('%s-tickets-%s.csv',
                     $user->getName(), strftime('%Y%m%d'));
-            if (!Export::saveTickets($query, '', $filename, 'csv'))
+            $target = Ticket::getExportableFields() ?: '';
+            if (!Export::saveTickets($query, $target, $filename, 'csv'))
                 $errors['err'] = __('Unable to dump query results.')
                     .' '.__('Internal error occurred');
         }


### PR DESCRIPTION
This addresses issue #4822 where exporting Tickets in an Organization or User shows keys as values for some fields and does not populate actual data. This is due to the exporter that uses `CustomQueue::getExportableFields()` to get the exportable fields by default. This method does not format cdata fields and alike properly which shows the keys instead of the actual values. This adds a `getExportableFields()` method to class Ticket that properly formats the cdata fields and alike which returns the appropriate data.