### PR TITLE
issue: API Validate Request Structure

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -244,14 +244,17 @@ class ApiController {
      * expected. It is assumed that the functions actually implementing the
      * API will further validate the contents of the request
      */
-    function validateRequestStructure($data, $structure, $prefix="", $strict=true) {
+    function validateRequestStructure($data, $structure, $prefix="", $strict=true, $level=0) {
         global $ost;
 
         foreach ($data as $key=>$info) {
+            if($level == 6)
+                break;
             if (is_array($structure) && (is_array($info) || $info instanceof ArrayAccess)) {
+                $level++;
                 $search = (isset($structure[$key]) && !is_numeric($key)) ? $key : "*";
                 if (isset($structure[$search])) {
-                    $this->validateRequestStructure($info, $structure[$search], "$prefix$key/", $strict);
+                    $this->validateRequestStructure($info, $structure[$search], "$prefix$key/", $strict, $level);
                     continue;
                 }
             } elseif (in_array($key, $structure)) {


### PR DESCRIPTION
This addresses an issue where validating the request structure for an API call throws warnings when field values are arrays. This adds a new variable called `$level` to keep track of the level of the request structure we are in. Once we reach a certain level we will break and continue with the other fields. This will prevent warnings when a value is an array like `["cc"] => { [0] => "email2", [1] => "email1"}`.