### PR TITLE
Double semicolon removed

### DIFF
--- a/include/client/templates/thread-export.tmpl.php
+++ b/include/client/templates/thread-export.tmpl.php
@@ -12,7 +12,7 @@ AttachmentFile::objects()->filter(array(
             ))->all();
 
 $entries = $thread->getEntries();
-$entries->filter(array('type__in' => array_keys($entryTypes)))->order_by("{$order}id");;
+$entries->filter(array('type__in' => array_keys($entryTypes)))->order_by("{$order}id");
 ?>
 <style type="text/css">
     div {font-family: sans-serif;}


### PR DESCRIPTION
This just removes an unnecessary "`;`" semicolon in `include/client/templates/thread-export.tmpl.php`