### PR TITLE
xss: Overridetype Broken Images

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -247,8 +247,6 @@ class AttachmentFile extends VerySimpleModel {
         $ttl = ($expires) ? $expires - Misc::gmtime() : false;
         $this->makeCacheable($ttl);
         $type = $this->getType() ?: 'application/octet-stream';
-        if (isset($_REQUEST['overridetype']))
-            $type = $_REQUEST['overridetype'];
         Http::download($this->getName(), $type, null, 'inline');
         header('Content-Length: '.$this->getSize());
         $this->sendData(false);
@@ -358,6 +356,10 @@ class AttachmentFile extends VerySimpleModel {
     }
 
     static function create(&$file, $ft='T', $deduplicate=true) {
+        // Crap-out if file contents do not match expected file type
+        if (strpos('image/', $file['type']) !== 0 && !exif_imagetype($file['tmp_name']))
+            return false;
+
         if (isset($file['encoding'])) {
             switch ($file['encoding']) {
             case 'base64':


### PR DESCRIPTION
This addresses a security issue reported by Vincent Monier (Xenos) where someone can upload a broken image containing arbitrary code, add an `overridetype` to the download URL, send the link to anyone, and if clicked will display the image as HTML instead of a broken image ergo executing the code. This is due to an old if statement that set the file type to the `overridetype` if one is provided. We don’t use this if statement anymore so we are going to retire it. This will prevent anyone from faking/overriding the file type which will prevent XSS in broken images. In addition, this adds a new check with `exif_imagetype()` to ensure the file contents match the expected file type.