### PR TITLE
issue: Retained Deleted ListItem Errors

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1775,7 +1775,8 @@ class SelectionField extends FormField {
             // Add in the properties for all selected list items in sub
             // labeled by their field id
             foreach ($v as $id=>$L) {
-                if (!($li = DynamicListItem::lookup($id)))
+                if (!($li = DynamicListItem::lookup($id))
+                      || !$li->getListId())
                     continue;
                 foreach ($li->getFilterData() as $prop=>$value) {
                     if (!isset($data[$prop]))


### PR DESCRIPTION
This addresses an issue where New Tickets will fail for Users with a deleted ListItem retained in their Contact Information form. This is due to the system deleting the `list_id` for the ListItem so when we run `getFilterData()` for the User we can't find the list which causes a fatal error later down the line. This adds an OR statement to the `SelectionField::getFilterData()` method to skip said ListItems if no `list_id` is present.