### PR TITLE
issue: Account Registration Throws Errors

### DIFF
--- a/account.php
+++ b/account.php
@@ -58,6 +58,7 @@ elseif ($_POST) {
     if ($thisclient) {
         $user_form->getField('email')->configure('disabled', true);
         $user_form->getField('email')->value = $thisclient->getEmail();
+        $_POST['email'] = $thisclient->getEmail();
     }
 
     if (!$user_form->isValid(function($f) { return !$f->isVisibleToUsers(); }))


### PR DESCRIPTION
This addresses issue #4898 where a User that clicks the ticket link in an email alert to view the ticket, in that ticket view clicks the link to register for an account, fills out the registration form, and clicks Create will throw a an "Unable to register account. See messages below." error. When the Users get this error there are no messages below so they can't see anything to fix which prevents them from creating an account. This is due to the email field being disabled which means the value is not sent in POST so the system thinks the User sent no email address which throws a hidden "Email field required." error. We disabled the email field to prevent an attacker from accessing the user’s guest login and registering the user with a different email (possibly his own). This sets a POST value called 'email' to the client's email so that the registration process acknowledges and validates the email allowing registration to continue.