### PR TITLE
Empty extra in list_items

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -807,7 +807,10 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
                     'sort' => 'sort',
                     'value' => 'value',
                     'abbrev' => 'extra') as $k => $v) {
-            if (isset($vars[$k]))
+            if ($k == 'abbrev' && empty($vars[$k])) {
+                $vars[$k] = NULL;
+                $this->set($v, $vars[$k]);
+            } elseif (isset($vars[$k]))
                 $this->set($v, $vars[$k]);
         }
 


### PR DESCRIPTION
If you have a custom field that's based on a list and the default value is set to a list item where the extra field is empty ('') instead of NULL, you cannot set the default value back to 'Select a Default'. You CAN set it to other default values

Extra is set to empty if you erase the abbreviation and save it. Should save as NULL instead of empty

Note: for some reason this didn't work

if ($k == 'abbrev' && empty($vars[$k]))
                $this->set($v, NULL);