### PR TITLE
issue: Form Instructions Translation

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -112,7 +112,7 @@ class Form {
     }
 
     function getTitle() { return $this->title; }
-    function getInstructions() { return $this->instructions; }
+    function getInstructions() { return Format::htmldecode($this->instructions); }
     function getSource() { return $this->_source; }
     function setSource($source) { $this->_source = $source; }
 


### PR DESCRIPTION
This addresses issue #4909 where setting a translated Form Instruction fails to render properly on the client side. This is due to us formatting the instructions but not decoding before we render. This adds the decode method to the translated Form Instructions so they are rendered properly on the client side.