### PR TITLE
Add persian calendar in date formatter

### DIFF
--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -428,13 +428,20 @@ class Internationalization {
         if (isset($cache[$k]) && $cache[$k])
             return $cache[$k];
 
+        // Check if persian calendar is needed
+        // https://en.wikipedia.org/wiki/Jalali_calendar
+        if (strstr($options['locale'], 'fa')) {
+            $options['locale'] .= '@calendar=persian';
+            $options['calendar'] = IntlDateFormatter::TRADITIONAL;
+        }
+
         // Create formatter && cache
         $cache[$k] = $formatter = new IntlDateFormatter(
                 $options['locale'],
                 $options['daytype'] ?: null,
                 $options['timetype'] ?: null,
                 $options['timezone'] ?: null,
-                $options['calendar'] ?: IntlDateFormatter::GREGORIAN,
+                $options['calendar'] ?? IntlDateFormatter::GREGORIAN,
                 $options['pattern'] ?: null
                 );
 


### PR DESCRIPTION
Hi, In this PR, I added [Jalali Calendar](https://en.wikipedia.org/wiki/Jalali_calendar) to osTicket, I saw some requests for this in Forum:
- https://forum.osticket.com/d/84766-custom-date-and-time-plugin-for-contries
- https://forum.osticket.com/d/9334-how-to-change-osticket-default-date

For more information you can check following links:
- https://www.php.net/manual/en/intldateformatter.create.php#105460
- https://stackoverflow.com/questions/49110844/how-to-set-default-date-to-persian-date-in-php