### PR TITLE
ticket-view: Add ZIP export option

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -555,3 +555,103 @@ class DatabaseExporter {
         $this->write_block(array('end-table'));
     }
 }
+
+class TicketZipExporter {
+    var $ticket;
+    var $tmpfiles;
+
+    function __construct(Ticket $ticket) {
+        $this->ticket = $ticket;
+        $this->tmpfiles = array();
+    }
+
+    function addTicket($ticket, $zip, $prefix, $notes=true, $psize=null) {
+        require_once(INCLUDE_DIR.'class.pdf.php');
+
+        $pdf_file = $this->tmpfiles[] = tempnam(sys_get_temp_dir(), 'zip');
+        $pdf = new Ticket2PDF($ticket, $psize, $notes);
+        $pdf->output($pdf_file, 'F');
+
+        $zip->addFile($pdf_file, "{$ticket->getNumber()}.pdf");
+
+        // Include all the (non-inline) attachments
+        // XXX: Handle attachments with duplicate filenames between entry posts
+        $attachments = Attachment::objects()
+            ->filter([
+                'thread_entry__thread' => $ticket->getThread(),
+                'inline' => 0
+            ])
+            ->order_by('thread_entry__created')
+            ->select_related('file');
+
+        foreach ($attachments as $att) {
+            $zip->addFromString("{$prefix}/{$att->getFilename()}",
+                $att->getFile()->getData());
+        }
+    }
+
+    function addTask($task, $zip, $prefix, $notes=true, $psize=null) {
+        require_once(INCLUDE_DIR.'class.pdf.php');
+
+        $pdf_file = $this->tmpfiles[] = tempnam(sys_get_temp_dir(), 'zip');
+        $pdf = new Task2PDF($task, ['psize' => $psize]);
+        $pdf->output($pdf_file, 'F');
+
+        $zip->addFile($pdf_file, "{$prefix}/{$task->getNumber()}.pdf");
+
+        // Include all the (non-inline) attachments
+        // XXX: Handle attachments with duplicate filenames between entry posts
+        $attachments = Attachment::objects()
+            ->filter([
+                'thread_entry__thread' => $task->getThread(),
+                'inline' => 0
+            ])
+            ->order_by('thread_entry__created')
+            ->select_related('file');
+
+        foreach ($attachments as $att) {
+            $zip->addFromString("{$prefix}/{$task->getNumber()}/{$att->getFilename()}",
+                $att->getFile()->getData());
+        }
+    }
+
+    function download($options = array()) {
+        global $thisstaff;
+
+        $notes = @$options['notes'] ?? false;
+        $tasks = @$options['tasks'] ?? false;
+
+        // TODO: Use a streaming ZIP library
+        $zipfile = tempnam(sys_get_temp_dir(), 'zip');
+        try {
+            $zip = new ZipArchive();
+            if (!$zip->open($zipfile, ZipArchive::CREATE))
+                return;
+
+            $prefix = "{$this->ticket->getNumber()}";
+
+            // Include a PDF of the ticket thread (with optional notes)
+            if (!$thisstaff || !($psize = $thisstaff->getDefaultPaperSize()))
+                $psize = 'Letter';
+
+            $this->addTicket($this->ticket, $zip, $prefix, $notes, $psize);
+
+            if ($tasks) {
+                foreach ($this->ticket->tasks as $task)
+                    $this->addTask($task, $zip, "{$prefix}/tasks", $notes, $psize);
+            }
+
+            $zip->close();
+            Http::download("ticket-{$this->ticket->getNumber()}.zip", "application/zip",
+                null, 'attachment');
+            $fp = fopen($zipfile, 'r');
+            fpassthru($fp);
+            fclose($fp);
+        }
+        finally {
+            foreach ($this->tmpfiles as $T)
+                @unlink($T);
+            unlink($zipfile);
+        }
+    }
+}

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3128,6 +3128,12 @@ implements RestrictedAccess, Threadable, Searchable {
         exit;
     }
 
+    function zipExport($notes=true, $tasks=false) {
+        $exporter = new TicketZipExporter($this);
+        $exporter->download(['notes'=>$notes, 'tasks'=>$tasks]);
+        exit;
+    }
+
     function delete($comments='') {
         global $ost, $thisstaff;
 

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -41,6 +41,10 @@ $extensions = array(
             'name' => 'fileinfo',
             'desc' => __('Used to detect file types for uploads')
             ),
+        'zip' => array(
+            'name' => 'zip',
+            'desc' => __('Used for ticket and task exporting')
+            ),
         'apcu' => array(
             'name' => 'APCu',
             'desc' => __('Improves overall performance')

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -85,6 +85,12 @@ if($ticket->isOverdue())
                  class="icon-file-alt"></i> <?php echo __('Ticket Thread'); ?></a>
                  <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=print&notes=1"><i
                  class="icon-file-text-alt"></i> <?php echo __('Thread + Internal Notes'); ?></a>
+                 <?php if (extension_loaded('zip')) { ?>
+                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=zip&notes=1"><i
+                 class="icon-download-alt"></i> <?php echo __('Export with Notes + Attachments'); ?></a>
+                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=zip&notes=1&tasks=1"><i
+                 class="icon-download"></i> <?php echo __('Export with Notes + Attachments + Tasks'); ?></a>
+                 <?php } ?>
               </ul>
             </div>
             <?php

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -495,9 +495,13 @@ if($ticket) {
             $f->filterFields(function($f) { return !$f->isStorable(); });
             $f->addMissingFields();
         }
-    } elseif($_REQUEST['a'] == 'print' && !$ticket->pdfExport($_REQUEST['psize'], $_REQUEST['notes']))
+    } elseif($_REQUEST['a'] == 'print' && !$ticket->pdfExport($_REQUEST['psize'], $_REQUEST['notes'])) {
         $errors['err'] = __('Unable to export the ticket to PDF for print.')
             .' '.__('Internal error occurred');
+    } elseif ($_GET['a'] == 'zip' && !$ticket->zipExport($_REQUEST['notes'], $_REQUEST['tasks'])) {
+        $errors['err'] = __('Unable to export the ticket to ZIP.')
+            .' '.__('Internal error occurred');
+    }
 } else {
     $inc = 'templates/queue-tickets.tmpl.php';
     if ($_REQUEST['a']=='open' &&


### PR DESCRIPTION
This adds the ability to dowload a ticket thread PDF in a ZIP file with all of the attachments included. And, optionally, also include the associated tasks, again with a PDF of the thread and all attachments included.

It requires the PHP `zip` extension. So a new line item was added to the system information page, and to prevent errors, the option does not show up on the ticket view page if the extension is not available.

It would be possible to also include this as a feature on the ticket listing page, but exporting lots of tickets could easily exceed the max_execution_time and create confusion. So I left that out for this request.

This could be mocked up as a plugin; however, it doesn't look like the drop-downs on the ticket view page currently support plugins?