### PR TITLE
task: Implement edit of task thread

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -204,8 +204,24 @@ class TaskModel extends VerySimpleModel {
         return $this->setFlag(self::ISOPEN);
     }
 
-    function isAssigned() {
-        return ($this->isOpen() && ($this->getStaffId() || $this->getTeamId()));
+    function isAssigned($to=null) {
+        if (!$this->isOpen())
+            return false;
+
+        if (is_null($to))
+            return ($this->getStaffId() || $this->getTeamId());
+
+        switch (true) {
+        case $to instanceof Staff:
+            return ($to->getId() == $this->getStaffId() ||
+                    $to->isTeamMember($this->getTeamId()));
+            break;
+        case $to instanceof Team:
+            return ($to->getId() == $this->getTeamId());
+            break;
+        }
+
+        return false;
     }
 
     function isOverdue() {

--- a/include/class.thread_actions.php
+++ b/include/class.thread_actions.php
@@ -138,6 +138,13 @@ class TEA_EditThreadEntry extends ThreadEntryAction {
                 && ($role = $thisstaff->getRole($T->getDeptId(), $T->isAssigned($thisstaff)))
                 && $role->hasPerm(ThreadEntry::PERM_EDIT)
             )
+            || ($T instanceof Task
+                && $T->getDept()->getManagerId() == $thisstaff->getId()
+            )
+            || ($T instanceof Task
+                && ($role = $thisstaff->getRole($T->getDeptId(), $T->isAssigned($thisstaff)))
+                && $role->hasPerm(ThreadEntry::PERM_EDIT)
+            )
         );
     }
 


### PR DESCRIPTION
This fixes an issue where, for task threads, if an agent has the thread edit permission, the agent was neither able to edit his or her own entries, nor the entries of other agents.