### PR TITLE
issue: Single Quotes In DB Password

### DIFF
--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -272,7 +272,7 @@ class Installer extends SetupWizard {
             '%CONFIG-DBHOST' => $vars['dbhost'],
             '%CONFIG-DBNAME' => $vars['dbname'],
             '%CONFIG-DBUSER' => $vars['dbuser'],
-            '%CONFIG-DBPASS' => $vars['dbpass'],
+            '%CONFIG-DBPASS' => addcslashes($vars['dbpass'], "'"),
             '%CONFIG-PREFIX' => $vars['prefix'],
             '%CONFIG-SIRI' => Misc::randCode(32),
         ));


### PR DESCRIPTION
This addresses an issue reported on twitter where single quotes in a db password causes 500 Error after installation. This is due to the system not escaping the single quotes before writing to the config file. This adds `addcslashes()` to the password before it’s saved to the config file so it escapes any single quotes properly.