### PR TITLE
issue: iFrame Single Quotes

### DIFF
--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -6,7 +6,7 @@ $signin_url = ROOT_PATH . "login.php"
 $signout_url = ROOT_PATH . "logout.php?auth=".$ost->getLinkToken();
 
 header("Content-Type: text/html; charset=UTF-8");
-header("Content-Security-Policy: frame-ancestors '".$cfg->getAllowIframes()."';");
+header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
 
 if (($lang = Internationalization::getCurrentLanguage())) {
     $langs = array_unique(array($lang, $cfg->getPrimaryLanguage()));


### PR DESCRIPTION
It's all about the single quotes baby! Apparently I can't read; the single quotes are only meant for word options such as `'self'` and `'none'`. When adding single quotes to the `<host-source>` options it takes them literally…too literally. For example, if your options are `'localhost:80 localhost:8080 localhost:8000'` then `'localhost:80` and `localhost:8000'` will be seen as "invalid" due to the single quotes. This removes the single quotes from every line that sets the CSP so all options are valid. This also adds single quotes around the `self` option so it stays valid as well.