### PR TITLE
issue: Search Reindexing Thread Entries

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -477,7 +477,7 @@ class MysqlSearchBackend extends SearchBackend {
         $sql = "SELECT A1.`id`, A1.`title`, A1.`body`, A1.`format` FROM `".THREAD_ENTRY_TABLE."` A1
             LEFT JOIN `".TABLE_PREFIX."_search` A2 ON (A1.`id` = A2.`object_id` AND A2.`object_type`='H')
             WHERE A2.`object_id` IS NULL AND (A1.poster <> 'SYSTEM')
-            AND (LENGTH(A1.`title`) + LENGTH(A1.`body`) > 0)
+            AND (IFNULL(LENGTH(A1.`title`), 0) + IFNULL(LENGTH(A1.`body`), 0) > 0)
             ORDER BY A1.`id` DESC LIMIT 500";
         if (!($res = db_query_unbuffered($sql, $auto_create)))
             return false;


### PR DESCRIPTION
This addresses an issue where `IndexOldStuff()` doesn't reindex everything it's supposed to. The reindex leaves out all of the Thread Entries with empty titles or bodies. This is due to the SQL statement that retrieves thread entries. In the SQL statement, we check if the sum of the Thread Entry Title length and the Thread Entry Body length is greater than 0. If so we reindex the entry, otherwise we exclude it. The problem is both ```LENGTH(A1.`title`)``` and ```LENGTH(A1.`body`)``` can return `NULL` and you cannot add `NULL` (a string) to an integer. This updates the SQL to add `IFNULL()` statements around the possible `NULL` values so that if `NULL` we typecast to integer of 0 which can be added to integers successfully.