### PR TITLE
issue: PDF Squares Instead Of Text

### DIFF
--- a/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -93,12 +93,12 @@ class ConfigVariables
 			// AUTOMATIC FONT SELECTION
 			// Based on script and/or language
 			// mPDF 6.0 (similar to previously using function SetAutoFont() )
-			'autoScriptToLang' => false,
+			'autoScriptToLang' => true,
 			'baseScript' => Ucdn::SCRIPT_LATIN,
 			'autoVietnamese' => true,
 			'autoArabic' => true,
 			// mPDF 6.0 (similar to old useLang)
-			'autoLangToFont' => false,
+			'autoLangToFont' => true,
 
 			// Substitute missing characters in UTF-8(multibyte) documents - from other fonts
 			'useSubstitutions' => false,


### PR DESCRIPTION
This addresses an issue with Thai fonts (and a few others like Hebrew, Arabic, etc.) where printing a PDF will show square characters instead of the actual content. This is due to `autoScriptToLang` and `autoLangToFont` not being set to `TRUE`. This updates the mPDF config to set the value of `autoScriptToLang` to `TRUE` as this formats the HTML using the lang attribute for the specific language of the content. In addition, this updates the mPDF config to set `autoLangToFont` to `TRUE` as this selects the correct font to use for the specific language of the content.

#### References:
https://mpdf.github.io/fonts-languages/automatic-font-selection.html