### PR TITLE
xss: Install Form

### DIFF
--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -188,8 +188,8 @@ class Installer extends SetupWizard {
             'dept_id' => $dept_id,
             'role_id' => $role_id,
             'email' => $vars['admin_email'],
-            'firstname' => $vars['fname'],
-            'lastname' => $vars['lname'],
+            'firstname' => Format::htmlchars($vars['fname']),
+            'lastname' => Format::htmlchars($vars['lname']),
             'username' => $vars['username'],
         ));
         $staff->updatePerms(array(


### PR DESCRIPTION
This addresses an issue reported by Aishwarya Iyer where inserting `<img src =x onerror = prompt(1)` into any text field on the install form will execute in the browser after the system is installed and you log in. This is due to us not sanitizing the content before it’s saved in the database. This adds `Format::htmlchars()` to the installer to ensure the text field data is sanitized properly.