### PR TITLE
issue: Rogue Closing div Breaks HTML Thread Tree

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -138,7 +138,7 @@ class Format {
             $xpath = new DOMXPath($doc);
             static $eE = array('area'=>1, 'br'=>1, 'col'=>1, 'embed'=>1,
                     'iframe' => 1, 'hr'=>1, 'img'=>1, 'input'=>1,
-                    'isindex'=>1, 'param'=>1);
+                    'isindex'=>1, 'param'=>1, 'div'=>1);
             do {
                 $done = true;
                 $nodes = $xpath->query('//*[not(text()) and not(node())]');


### PR DESCRIPTION
This addresses an issue reported by Vincent Monier (Xenos) where posting a single `</div>` tag as a message or response via the UI will break the HTML Thread Tree view. This is due to the `html_balance()` method not cleaning empty div tags. This adds `'div'=>1` to the empty tag array so that any rogue div tag + any empty div tags are properly removed.