### PR TITLE
Add/Remove Collabs Without Refresh

### DIFF
--- a/include/ajax.thread.php
+++ b/include/ajax.thread.php
@@ -222,20 +222,7 @@ class ThreadAjaxAPI extends AjaxController {
             Http::response(404, 'No such thread');
 
         $errors = $info = array();
-        if ($thread->updateCollaborators($_POST, $errors))
-            $users = array();
-            foreach ($thread->getCollaborators() as $c)
-                $users[] = array('id' => $c->getUserId(),
-                        'name' => $c->getName(),
-                        'email' => $c->getEmail());
-
-            Http::response(201, $this->json_encode(array(
-                            'id' => $thread->getId(),
-                            'users' => $users,
-                            'text' => sprintf('(%d)',
-                                $thread->getNumCollaborators())
-                            )
-                        ));
+        $thread->updateCollaborators($_POST, $errors);
 
         if($errors && $errors['err'])
             $info +=array('error' => $errors['err']);

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -119,7 +119,7 @@ implements Searchable {
 
     // Collaborators
     function getNumCollaborators() {
-        return $this->collaborators->count();
+        return $this->getCollaborators()->count();
     }
 
     function getNumActiveCollaborators() {

--- a/include/staff/templates/collaborators.tmpl.php
+++ b/include/staff/templates/collaborators.tmpl.php
@@ -14,7 +14,7 @@ if ($thread->object_type == 'A')
 <?php
 if(($users=$thread->getCollaborators())) {?>
 <div id="manage_collaborators">
-<form method="post" class="collaborators" onsubmit="refreshAndClose(<?php echo $thread->object_id; ?>, <?php echo $type; ?>);" action="#thread/<?php echo $thread->getId(); ?>/collaborators">
+<form method="post" class="collaborators" action="#thread/<?php echo $thread->getId(); ?>/collaborators">
     <table border="0" cellspacing="1" cellpadding="1" width="100%">
     <?php
     foreach($users as $user) {
@@ -24,15 +24,13 @@ if(($users=$thread->getCollaborators())) {?>
         echo sprintf('<tr>
                         <td>
                             <label class="inline checkbox">
-                            <input type="checkbox" class="hidden" name="uid[]" id="%d" value="%d" checked="checked">
                             <input type="checkbox" name="cid[]" id="c%d" value="%d" %s>
                             </label>
                             <a class="collaborator" href="#thread/%d/collaborators/%d/view">%s%s</a>
                             <div align="left">
                                 <span class="faded"><em>%s</em></span>
                             </div>
-                        </td>', $user->getId(),
-                        $user->getId(),
+                        </td>',
                         $user->getId(),
                         $user->getId(),
                         $checked,
@@ -65,7 +63,7 @@ if(($users=$thread->getCollaborators())) {?>
     <p class="full-width">
         <span class="buttons pull-left">
             <input type="reset" value="<?php echo __('Reset'); ?>">
-            <input type="button" value="<?php echo __('Cancel'); ?>" class="close">
+            <input type="button" value="<?php echo __('Done'); ?>" class="close">
         </span>
         <span class="buttons pull-right">
         <input type="submit" value="<?php echo __('Save Changes'); ?>">
@@ -79,22 +77,24 @@ if(($users=$thread->getCollaborators())) {?>
     echo __("Bro, not sure how you got here!");
 }
 
-if ($_POST && $thread && $thread->getNumCollaborators()) {
-
-    $collaborators = sprintf('Collaborators (%d)',
-            $thread->getNumCollaborators());
-
-    $recipients = sprintf(__('Collaborators (%d of %d)'),
+if ($_POST && $thread) {
+    $collabs = $thread->getCollaborators();
+    foreach ($collabs as $c) {
+        $options .= sprintf('<option value="%s" %s class="%s">%s</option>',
+                  $c->getUserId(),
+                  $c->isActive() ? 'selected="selected"' : '',
+                  $c->isActive() ? 'active' : 'disabled',
+                  $c->getName());
+    }
+    $recipients = sprintf(__('(%d of %d)'),
           $thread->getNumActiveCollaborators(),
           $thread->getNumCollaborators());
     ?>
     <script type="text/javascript">
         $(function() {
-            $('#emailcollab').show();
-            $('#t<?php echo $thread->getId(); ?>-recipients')
-            .html('<?php echo $recipients; ?>');
-            $('#t<?php echo $thread->getId(); ?>-collaborators')
-            .html('<?php echo $collaborators; ?>');
+            $('#t<?php echo $thread->getId(); ?>-recipients').html('<?php echo $recipients; ?>');
+            $('#t<?php echo $thread->getId(); ?>-collaborators').html('<?php echo $thread->getNumCollaborators(); ?>');
+            $('#collabselection').html('<?php echo $options; ?>');
             });
     </script>
 <?php
@@ -153,8 +153,4 @@ $(function() {
     });
 
 });
-
-function refreshAndClose(tid, type) {
-  window.location.href = type + '.php?id=' + tid;
-}
 </script>

--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -486,15 +486,15 @@ else
                         style="display:<?php echo $thread->getNumCollaborators() ? 'inline-block': 'none'; ?>;"
                         >
                     <?php
-                    $recipients = __('Collaborators');
                     if ($thread->getNumCollaborators())
-                        $recipients = sprintf(__('Collaborators (%d of %d)'),
+                        $recipients = sprintf(__('(%d of %d)'),
                                 $thread->getNumActiveCollaborators(),
                                 $thread->getNumCollaborators());
 
                     echo sprintf('<span><a class="collaborators preview"
-                            href="#thread/%d/collaborators"><span id="t%d-recipients">%s</span></a></span>',
+                            href="#thread/%d/collaborators"> %s &nbsp;<span id="t%d-recipients">%s</span></a></span>',
                             $thread->getId(),
+                            __('Collaborators'),
                             $thread->getId(),
                             $recipients);
                    ?>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -383,7 +383,7 @@ if($ticket->isOverdue())
                               $recipients = 0;
 
                              echo sprintf('<span><a class="manage-collaborators preview"
-                                    href="#thread/%d/collaborators"><span id="t%d-recipients"><i class="icon-group"></i> (%s)</span></a></span>',
+                                    href="#thread/%d/collaborators"><span><i class="icon-group"></i> (<span id="t%d-collaborators">%s</span>)</span></a></span>',
                                     $ticket->getThreadId(),
                                     $ticket->getThreadId(),
                                     $recipients);
@@ -794,26 +794,26 @@ if ($errors['err'] && isset($_POST['a'])) {
                    <td>
                    <div style="margin-bottom:2px;">
                     <?php
-                         echo sprintf('<span><a id="show_ccs">
+                    if ($ticket->getThread()->getNumCollaborators())
+                        $recipients = sprintf(__('(%d of %d)'),
+                                $ticket->getThread()->getNumActiveCollaborators(),
+                                $ticket->getThread()->getNumCollaborators());
+
+                         echo sprintf('<span"><a id="show_ccs">
                                  <i id="arrow-icon" class="icon-caret-right"></i>&nbsp;%s </a>
                                  &nbsp;
                                  <a class="manage-collaborators
                                  collaborators preview noclick %s"
                                   href="#thread/%d/collaborators">
-                                 (%s)</a></span>',
+                                 %s</a></span>',
                                  __('Collaborators'),
                                  $ticket->getNumCollaborators()
                                   ? '' : 'hidden',
                                  $ticket->getThreadId(),
-                                 sprintf(__('%s of %s'),
-                                         sprintf('<span
-                                             class="collabselection__count">%d</span>',
-                                             $ticket->getNumActiveCollaborators()),
-                                         sprintf('<span
-                                             class="collabselection__total">%d</span>',
-                                              $ticket->getNumCollaborators())
-                                         )
-                                     );
+                                         sprintf('<span id="t%d-recipients">%s</span></a></span>',
+                                             $ticket->getThreadId(),
+                                             $recipients)
+                         );
                     ?>
                    </div>
                    <div id="ccs" class="hidden">


### PR DESCRIPTION
This code allows Agents to Manage Collaborators without the page refreshing so that they will not lose any drafts that might not have been saved yet. Instead, adding/removing collaborators will show up instantly in the active collaborators section.

This code also removes the http response from the updateCollaborators function. This triggers collaborators.tmpl.php to correctly update the active collaborators section without needing to refresh the page.