### PR TITLE
issue: is_formula Dotall Mode

### DIFF
--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -205,7 +205,7 @@ class Validator {
     }
 
     static function is_formula($text, &$error='') {
-        if (!preg_match('/^[^=\+@-].*$/', $text))
+        if (!preg_match('/^[^=\+@-].*$/s', $text))
             $error = __('Content cannot start with the following characters: = - + @');
         return $error == '';
     }


### PR DESCRIPTION
This addresses an issue where having a new line in a standard, non-richtext textarea field fails on `is_formula` validation. This is due to the regex not running in Dotall mode, which does not match new line characters. Dotall mode makes the dot (`.`) character match anything _including_ new line characters. This adds the `s` flag to the regex so that new lines are properly matched.