### PR TITLE
security: HTML File Browser Execution (Windows: Firefox/IE)

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -240,14 +240,16 @@ class AttachmentFile extends VerySimpleModel {
     }
 
     function download($disposition=false, $expires=false) {
-        $disposition = $disposition ?: 'inline';
+        $disposition = ($disposition && strcasecmp($disposition, 'inline') == 0
+              && strpos($this->getType(), 'image/') !== false)
+            ? 'inline' : 'attachment';
         $bk = $this->open();
         if ($bk->sendRedirectUrl($disposition))
             return;
         $ttl = ($expires) ? $expires - Misc::gmtime() : false;
         $this->makeCacheable($ttl);
         $type = $this->getType() ?: 'application/octet-stream';
-        Http::download($this->getName(), $type, null, 'inline');
+        Http::download($this->getName(), $type, null, $disposition);
         header('Content-Length: '.$this->getSize());
         $this->sendData(false);
         exit();


### PR DESCRIPTION
This addresses an issue reported by Aishwarya Iyer where attached HTML files are executed in the browser instead of forcing download in Firefox and IE for Windows specifically. This is caused by an incorrect `Content-Disposition` set in the `AttachmentFile::download` function. Instead of attachments having a disposition of `attachment` (which forces download) they have a disposition of `inline` (which displays the file contents in the browser). This updates the download function to use whatever disposition is passed (for S3 plugin), if none it defaults to `attachment`. In addition, this overwrites the disposition and sets it to `attachment` after the `$bk->sendRedirectURL()` so that S3 attachments still work and the issue of an attacker passing their own disposition is mitigated.