### PR TITLE
issue: v1.12 Git MAJOR_VERSION

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -337,7 +337,7 @@ define('CLI_DIR', INCLUDE_DIR.'cli/');
 #Current version && schema signature (Changes from version to version)
 define('THIS_VERSION','1.8-git'); //Shown on admin panel
 define('GIT_VERSION','$git');
-define('MAJOR_VERSION', '1.10');
+define('MAJOR_VERSION', '1.12');
 //Path separator
 if(!defined('PATH_SEPARATOR')){
     if(strpos($_ENV['OS'],'Win')!==false || !strcasecmp(substr(PHP_OS, 0, 3),'WIN'))


### PR DESCRIPTION
This addresses an issue where if you’re running an outdated version of the 1.12 series, the latest version it shows available is the latest release of the 1.10 series. This updates the `MAJOR_VERSION` variable used to check for the latest release for the series you’re currently on so that it shows the appropriate release.