### PR TITLE
issue: DatetimeField Remove Unused Vars / Use parseDateTime()

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -95,7 +95,10 @@ class Misc {
             return $timestamp - $tz->getOffset($date);
         }
 
-        $date = new DateTime($timestamp ?: 'now', $tz);
+        $date = Format::parseDateTime($timestamp ?: 'now');
+        if ($tz)
+            $date->setTimezone($tz);
+
         return $date ? $date->getTimestamp() : $timestamp;
     }
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3601,11 +3601,9 @@ implements RestrictedAccess, Threadable, Searchable {
 
         // Make sure the due date is valid
         if ($vars['duedate']) {
-            if (!$vars['time'] || strpos($vars['time'],':') === false)
-                $errors['time']=__('Select a time from the list');
-            elseif (strtotime($vars['duedate'].' '.$vars['time']) === false)
+            if (strtotime($vars['duedate']) === false)
                 $errors['duedate']=__('Invalid due date');
-            elseif (Misc::user2gmtime($vars['duedate'].' '.$vars['time']) <= Misc::user2gmtime())
+            elseif (Misc::user2gmtime($vars['duedate']) <= Misc::user2gmtime())
                 $errors['duedate']=__('Due date must be in the future');
         }
 
@@ -3839,7 +3837,7 @@ implements RestrictedAccess, Threadable, Searchable {
         //Make sure the origin is staff - avoid firebug hack!
         if ($vars['duedate'] && !strcasecmp($origin,'staff'))
             $ticket->duedate = date('Y-m-d G:i',
-                Misc::dbtime($vars['duedate'].' '.$vars['time']));
+                Misc::dbtime($vars['duedate']));
 
 
         if (!$ticket->save())


### PR DESCRIPTION
This addresses an issue where creating a ticket with a Due Date set fails with an error of `Select a time from the list`. This is due to unused variables in the `Ticket::create()` function. This also improves the datetime conversion to GMT by using `Format::parseDateTime()` instead of trying to create a DateTime object directly which also provides a fallback if an incorrect time. This can correctly determine the timezone (if present) and return a proper DateTime object.