### PR TITLE
issue: THIS_VERSION Utilize MAJOR_VERSION

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -314,9 +314,9 @@ define('CLI_DIR', INCLUDE_DIR.'cli/');
 /*############## Do NOT monkey with anything else beyond this point UNLESS you really know what you are doing ##############*/
 
 #Current version && schema signature (Changes from version to version)
-define('THIS_VERSION','1.8-git'); //Shown on admin panel
 define('GIT_VERSION','$git');
 define('MAJOR_VERSION', '1.10');
+define('THIS_VERSION', MAJOR_VERSION.'-git'); //Shown on admin panel
 //Path separator
 if(!defined('PATH_SEPARATOR')){
     if(strpos($_ENV['OS'],'Win')!==false || !strcasecmp(substr(PHP_OS, 0, 3),'WIN'))

--- a/include/cli/modules/deploy.php
+++ b/include/cli/modules/deploy.php
@@ -122,7 +122,7 @@ class Deployment extends Unpacker {
         }
 
         if (!$version)
-            $version = exec('git describe');
+            $version = preg_replace('/^v(\d{1}\.\d{2}).*$/', '$1-git', exec('git describe'));
 
         if (!$short || !$version)
             return false;


### PR DESCRIPTION
This addresses an issue where using osTicket from git would show the incorrect git version in `Admin Panel > Dashboard > Information`. This is due to a hardcoded git version of `1.8-git`. This updates `THIS_VERSION` to utilize `MAJOR_VERSION` so that it sets the correct git version. This also updates the `deploy` CLI module to match the same format (example: `1.12-git`).