### PR TITLE
issue: Set Staff Password On Creation

### DIFF
--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -35,12 +35,14 @@ class StaffAjaxAPI extends AjaxController {
 
       if ($_POST && $form->isValid()) {
           $clean = $form->getClean();
-          if ($id == 0) {
-              // Stash in the session later when creating the user
-              $_SESSION['new-agent-passwd'] = $clean;
-              Http::response(201, 'Carry on');
-          }
           try {
+              // Validate password
+              PasswordPolicy::checkPassword($clean['passwd1']);
+              if ($id == 0) {
+                  // Stash in the session later when creating the user
+                  $_SESSION['new-agent-passwd'] = $clean;
+                  Http::response(201, 'Carry on');
+              }
               if ($clean['welcome_email']) {
                   $staff->sendResetEmail();
               }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1064,6 +1064,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $this->mobile = Format::phone($vars['mobile']);
         $this->notes = Format::sanitize($vars['notes']);
 
+        // Set staff password if exists
+        if (!$vars['welcome_email'] && $vars['passwd1']) {
+            $this->setPassword($vars['passwd1'], null);
+            $this->change_passwd = $vars['change_passwd'] ? 1 : 0;
+        }
+
         if ($errors)
             return false;
 


### PR DESCRIPTION
This addresses an issue reported on the Forum where setting a password for an Agent upon creation doesn't save the password in the backend. This means if you set a password, click Create, and then try to login as the agent you will be denied access (as there is no password saved). We store the PasswordResetForm data in the session for later use but we do not actually use the form data anywhere in the `Staff::update()` method. This updates the `Staff::update()` method to include a check for the form data and if exists sets the password and saves it in the backend. This maintains current functionality where if `Send the agent a password reset email` is enabled then we do not set the password, instead we send the Agent a registration email.

In addition, this updates the `StaffAjaxAPI::setPassword()` to include password validation so if a password is not valid we do not save it. Instead, we will keep the modal open and throw validation errors until a valid password is given. This means the form data will not be stored in the session until we have a valid password.