### PR TITLE
issue: Reset Role Permissions

### DIFF
--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -145,7 +145,7 @@ class StaffAjaxAPI extends AjaxController {
         $form = new ResetAgentPermissionsForm($_POST);
 
         if (@is_array($_GET['ids'])) {
-            $perms = new RolePermission();
+            $perms = new RolePermission(null);
             $selected = Staff::objects()->filter(array('staff_id__in' => $_GET['ids']));
             foreach ($selected as $staff)
                 // XXX: This maybe should be intersection rather than union


### PR DESCRIPTION
This addresses an issue reported on the Forum where clicking the "Reset Permissions" action in the Agent Directory shows a blank popup. Inspecting the console shows 500 error and checking the error logs shows `Too few arguments to function` error. This is due to the `RolePermission::__construct()` method expecting 1 parameter but in `ajax.staff.php` we are not passing anything to it. This updates `resetPermissions()` to pass `null` to `RolePermission::__construct()` so that it doesn't complain and error out.