### PR TITLE
Required Short Answer Field = '0'

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1441,6 +1441,8 @@ class TextboxField extends FormField {
     }
 
     function validateEntry($value) {
+        //check to see if value is the string '0'
+        $value = ($value == '0') ? '&#48' : Format::htmlchars($this->toString($value ?: $this->value));
         parent::validateEntry($value);
         $config = $this->getConfiguration();
         $validators = array(


### PR DESCRIPTION
This commit fixes an issue where trying to save the value '0' to a required short answer field would not save because it did not register that the field contained a value.