### PR TITLE
feature: Expanded Print View

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -57,15 +57,18 @@ class Ticket2PDF extends mPDFWithLocalImages
 
 	var $includenotes = false;
 
+       var $includeevents = false;
+
 	var $pageOffset = 0;
 
     var $ticket = null;
 
-	function __construct($ticket, $psize='Letter', $notes=false) {
+	function __construct($ticket, $psize='Letter', $notes=false, $events=false) {
         global $thisstaff;
 
         $this->ticket = $ticket;
         $this->includenotes = $notes;
+        $this->includeevents = $events;
 
 	parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir()]);
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3112,7 +3112,7 @@ implements RestrictedAccess, Threadable, Searchable {
     }
 
     // Print ticket... export the ticket thread as PDF.
-    function pdfExport($psize='Letter', $notes=false) {
+    function pdfExport($psize='Letter', $notes=false, $events=false) {
         global $thisstaff;
 
         require_once(INCLUDE_DIR.'class.pdf.php');
@@ -3123,7 +3123,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 $psize = 'Letter';
         }
 
-        $pdf = new Ticket2PDF($this, $psize, $notes);
+        $pdf = new Ticket2PDF($this, $psize, $notes, $events);
         $name = 'Ticket-'.$this->getNumber().'.pdf';
         Http::download($name, 'application/pdf', $pdf->output($name, 'S'));
         //Remember what the user selected - for autoselect on the next print.

--- a/include/staff/templates/ticket-print.tmpl.php
+++ b/include/staff/templates/ticket-print.tmpl.php
@@ -94,6 +94,18 @@ div.hr {
 .thread-entry, .thread-body {
     page-break-inside: avoid;
 }
+img.avatar {
+    vertical-align: middle;
+    padding-right: 2px;
+    max-height: 20px;
+    width: auto;
+}
+.thread-event {
+    margin: 10px;
+    padding: 10px;
+    border-radius: 10px;
+    background-color: rgba(224,224,224,0.2);
+}
 <?php include ROOT_DIR . 'css/thread.css'; ?>
     </style>
 </head>
@@ -212,13 +224,54 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
 <h2><?php echo $ticket->getSubject(); ?></h2>
 <div id="ticket_thread">
 <?php
+$events = null;
 $types = array('M', 'R');
 if ($this->includenotes)
     $types[] = 'N';
 
-if ($thread = $ticket->getThreadEntries($types)) {
-    $threadTypes=array('M'=>'message','R'=>'response', 'N'=>'note');
-    foreach ($thread as $entry) { ?>
+$thread = $ticket->getThread();
+$entries = $ticket->getThreadEntries($types);
+if ($this->includeevents) {
+    $events = $thread->getEvents();
+    $sort = 'id';
+    if ($options['sort'] && !strcasecmp($options['sort'], 'DESC'))
+        $sort = '-id';
+    $cmp = function ($a, $b) use ($sort) {
+        return ($sort == 'id')
+            ? ($a < $b) : $a > $b;
+    };
+    $events = $events->order_by($sort);
+    $eventCount = count($events);
+    $events = new IteratorIterator($events->getIterator());
+    $events->rewind();
+    $event = $events->current();
+}
+
+if ($entries->exists(true)) {
+    // Go through all the entries and bucket them by time frame
+    $buckets = array();
+    $rel = 0;
+    foreach ($entries as $i=>$E) {
+        // First item _always_ shows up
+        if ($i != 0)
+            // Set relative time resolution to 12 hours
+            $rel = Format::relativeTime(Misc::db2gmtime($E->created, false, 43200));
+        $buckets[$rel][] = $E;
+    }
+    // Go back through the entries and render them on the page
+    foreach ($buckets as $rel=>$entries) {
+        // TODO: Consider adding a date boundary to indicate significant
+        //       changes in dates between thread items.
+        foreach ($entries as $entry) {
+            if ($this->includeevents) {
+                // Emit all events prior to this entry
+                while ($event && $cmp($event->timestamp, $entry->created)) {
+                    $event->render(ThreadEvent::MODE_STAFF);
+                    $events->next();
+                    $event = $events->current();
+                }
+            }
+    $threadTypes=array('M'=>'message','R'=>'response', 'N'=>'note'); ?>
         <div class="thread-entry <?php echo $threadTypes[$entry->type]; ?>">
             <table class="header" style="width:100%"><tr><td>
                     <span><?php
@@ -247,7 +300,16 @@ if ($thread = $ticket->getThreadEntries($types)) {
 <?php       } ?>
             </div>
         </div>
-<?php }
+<?php
+
+        }
+    }
+}
+// Emit all other events
+while ($event) {
+    $event->render(ThreadEvent::MODE_STAFF);
+    $events->next();
+    $event = $events->current();
 } ?>
 </div>
 </body>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -81,10 +81,12 @@ if($ticket->isOverdue())
             </span>
             <div id="action-dropdown-print" class="action-dropdown anchor-right">
               <ul>
-                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=print&notes=0"><i
+                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=print&notes=0&events=0"><i
                  class="icon-file-alt"></i> <?php echo __('Ticket Thread'); ?></a>
-                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=print&notes=1"><i
+                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=print&notes=1&events=0"><i
                  class="icon-file-text-alt"></i> <?php echo __('Thread + Internal Notes'); ?></a>
+                 <li><a class="no-pjax" target="_blank" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=print&notes=1&events=1"><i
+                 class="icon-list-alt"></i> <?php echo __('Thread + Internal Notes + Events'); ?></a>
               </ul>
             </div>
             <?php
@@ -1142,6 +1144,12 @@ if ($errors['err'] && isset($_POST['a'])) {
             <label class="fixed-size" for="notes"><?php echo __('Print Notes');?>:</label>
             <label class="inline checkbox">
             <input type="checkbox" id="notes" name="notes" value="1"> <?php echo __('Print <b>Internal</b> Notes/Comments');?>
+            </label>
+        </fieldset>
+        <fieldset class="events">
+            <label class="fixed-size" for="events"><?php echo __('Print Events');?>:</label>
+            <label class="inline checkbox">
+            <input type="checkbox" id="events" name="events" value="1"> <?php echo __('Print Thread Events');?>
             </label>
         </fieldset>
         <fieldset>

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -495,7 +495,7 @@ if($ticket) {
             $f->filterFields(function($f) { return !$f->isStorable(); });
             $f->addMissingFields();
         }
-    } elseif($_REQUEST['a'] == 'print' && !$ticket->pdfExport($_REQUEST['psize'], $_REQUEST['notes']))
+    } elseif($_REQUEST['a'] == 'print' && !$ticket->pdfExport($_REQUEST['psize'], $_REQUEST['notes'], $_REQUEST['events']))
         $errors['err'] = __('Unable to export the ticket to PDF for print.')
             .' '.__('Internal error occurred');
 } else {


### PR DESCRIPTION
This feature adds a new Print option labeled "Thread + Internal Notes + Events" that, when clicked, will print the entire Ticket Thread with Internal Notes AND all of the Thread Events. This also adds a new option in the Ticket Print Options labeled "Print Events". Previous print options only included the Thread only or the Thread + Internal Notes, but people want more! This inserts the events in the correct order just like it is in the Ticket View. The only difference between the PDF Thread Events and the Ticket View Thread Events is the styling. In the Ticket View each event has it's own icon to separate/differentiate them between the others. In the PDF the events will not have their own icons rather their own background to separate/differentiate them.