### PR TITLE
issue: Error On QueueSort Config

### DIFF
--- a/include/ajax.search.php
+++ b/include/ajax.search.php
@@ -259,8 +259,8 @@ class SearchAjaxAPI extends AjaxController {
             Http::response(404, 'No such queue sort');
         }
 
+        $data_form = $sort->getDataConfigForm($_POST ?: false);
         if ($_POST) {
-            $data_form = $sort->getDataConfigForm($_POST);
             if ($data_form->isValid()) {
                 $sort->update($data_form->getClean() + $_POST);
                 if ($sort->save())


### PR DESCRIPTION
This addresses an issue where clicking on Config next to a Queue Sort will show a blank popup. Upon viewing the error logs you receive the error `Call to a member function asTable() on null`. This is due to defining `$data_form` inside of the `if ($_POST)` block instead of defining it outside the block. This updates `SearchAjaxAPI::editSort()` to define `$data_form` outside of the `if ($_POST)` block so that `$data_form` is always set.