### PR TITLE
issue: Update Outdated Links

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 * [ ] Can you reproduce the problem in a fresh installation of the "develop" branch?
 * [ ] Do you have any errors in the PHP error log, or javascript console?
-* [ ] Did you check the [osTicket forums](http://osticket.com/forum/categories)?
+* [ ] Did you check the [osTicket forums](https://forum.osticket.com/)?
 * [ ] Did you [perform a cursory search](https://github.com/osTicket/osTicket/issues) to see if your bug or enhancement is already reported?
 
 For more information on how to write a good [bug report](https://github.com/osTicket/osTicket/wiki/Github-Issues-Guidelines)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ osTicket codebase before embarking on an upgrade.
 
 To trigger the update process, fetch the osTicket tarball from either
 the osTicket [github](http://github.com/osTicket/osTicket/releases) page
-or from the [osTicket website](http://osticket.com). Extract the tarball
+or from the [osTicket website](https://osticket.com). Extract the tarball
 into the folder of your osTicket codebase. This can also be accomplished
 with the zip file, and a FTP client can of course be used to upload the new
 source code to your server.
@@ -88,10 +88,10 @@ View the UPGRADING.txt file for other todo items to complete your upgrade.
 
 Help
 ----
-Visit the [wiki](http://osticket.com/wiki/Home) or the
-[forum](http://osticket.com/forums/). And if you'd like professional help
+Visit the [Documentation](https://docs.osticket.com/) or the
+[forum](https://forum.osticket.com/). And if you'd like professional help
 managing your osTicket installation,
-[commercial support](http://osticket.com/support/) is available.
+[commercial support](https://osticket.com/support/) is available.
 
 Contributing
 ------------
@@ -104,7 +104,7 @@ conversation of integrating your new feature into osTicket.
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/osticket-official/localized.png)](http://i18n.osticket.com/project/osticket-official)
 
 The interface for osTicket is now completely translatable. Language packs
-are available on the [download page](http://osticket.com/download). If you
+are available on the [download page](https://osticket.com/download). If you
 do not see your language there, join the [Crowdin](http://i18n.osticket.com)
 project and request to have your language added. Languages which reach 100%
 translated are are significantly reviewed will be made available on the

--- a/include/client/footer.inc.php
+++ b/include/client/footer.inc.php
@@ -3,7 +3,7 @@
     <div id="footer">
         <p><?php echo __('Copyright &copy;'); ?> <?php echo date('Y'); ?> <?php
         echo Format::htmlchars((string) $ost->company ?: 'osTicket.com'); ?> - <?php echo __('All rights reserved.'); ?></p>
-        <a id="poweredBy" href="http://osticket.com" target="_blank"><?php echo __('Helpdesk software - powered by osTicket'); ?></a>
+        <a id="poweredBy" href="https://osticket.com" target="_blank"><?php echo __('Helpdesk software - powered by osTicket'); ?></a>
     </div>
 <div id="overlay"></div>
 <div id="loading">

--- a/include/i18n/en_US/help/tips/emails.template.yaml
+++ b/include/i18n/en_US/help/tips/emails.template.yaml
@@ -34,7 +34,7 @@ language:
         Template Set</span>. Language packs are available on osTicket.com.
     links:
       - title: osTicket Language Packs
-        href: http://osticket.com/download
+        href: https://osticket.com/download
 
 status:
     title: Status

--- a/include/i18n/en_US/help/tips/install.yaml
+++ b/include/i18n/en_US/help/tips/install.yaml
@@ -28,7 +28,7 @@ default_lang:
         be installed for this language.</p>
     links:
       - title: osTicket Language Packs
-        href: http://osticket.com/download?product=langs
+        href: https://osticket.com/download/#ostLang
 
 first_name:
     title: First Name

--- a/include/i18n/en_US/organization.yaml
+++ b/include/i18n/en_US/organization.yaml
@@ -9,10 +9,10 @@
 - name: osTicket
   fields:
     address:|
-        420 Desoto Street
+        1120 5th Street
         Alexandria, LA 71301
     phone: (318) 290-3674
-    website: http://osticket.com
+    website: https://osticket.com
     notes: >
         Not only do we develop the software, we also use it to manage
         support for osTicket. Let us help you quickly implement and leverage

--- a/include/i18n/en_US/templates/email/task.alert.yaml
+++ b/include/i18n/en_US/templates/email/task.alert.yaml
@@ -36,6 +36,6 @@ body: |
     href="%{task.staff_link}">login</a> to the support system</div>
     <em style="font-size: small">Your friendly Customer Support System</em>
     <br>
-    <a href="http://osticket.com/"><img width="126" height="19"
+    <a href="https://osticket.com/"><img width="126" height="19"
         style="width: 126px; " alt="Powered By osTicket"
         src="cid:b56944cb4722cc5cda9d1e23a3ea7fbc"/></a>

--- a/include/i18n/en_US/templates/email/task.transfer.alert.yaml
+++ b/include/i18n/en_US/templates/email/task.transfer.alert.yaml
@@ -26,6 +26,6 @@ body: |
     <em style="font-size: small; ">Your friendly Customer Support
     System</em>
     <br>
-    <a href="http://osticket.com/"><img width="126" height="19"
+    <a href="https://osticket.com/"><img width="126" height="19"
         alt="Powered By osTicket" style="width: 126px;"
         src="cid:b56944cb4722cc5cda9d1e23a3ea7fbc"/></a>

--- a/include/i18n/en_US/templates/email/ticket.alert.yaml
+++ b/include/i18n/en_US/templates/email/ticket.alert.yaml
@@ -45,6 +45,6 @@ body: |
     href="%{ticket.staff_link}">login</a> to the support ticket system</div>
     <em style="font-size: small">Your friendly Customer Support System</em>
     <br>
-    <a href="http://osticket.com/"><img width="126" height="19"
+    <a href="https://osticket.com/"><img width="126" height="19"
         style="width: 126px; " alt="Powered By osTicket"
         src="cid:b56944cb4722cc5cda9d1e23a3ea7fbc"/></a>

--- a/include/i18n/en_US/templates/email/transfer.alert.yaml
+++ b/include/i18n/en_US/templates/email/transfer.alert.yaml
@@ -28,6 +28,6 @@ body: |
     <em style="font-size: small; ">Your friendly Customer Support
     System</em>
     <br>
-    <a href="http://osticket.com/"><img width="126" height="19"
+    <a href="https://osticket.com/"><img width="126" height="19"
         alt="Powered By osTicket" style="width: 126px;"
         src="cid:b56944cb4722cc5cda9d1e23a3ea7fbc"/></a>

--- a/include/i18n/en_US/templates/ticket/installed.yaml
+++ b/include/i18n/en_US/templates/ticket/installed.yaml
@@ -17,8 +17,8 @@ message: |
     Thank you for choosing osTicket.
     </p><p>
     Please make sure you join the <a
-    href="http://osticket.com/forums">osTicket forums</a> and our <a
-    href="http://osticket.com/updates">mailing list</a> to stay up to date
+    href="https://forum.osticket.com">osTicket forums</a> and our <a
+    href="https://osticket.com">mailing list</a> to stay up to date
     on the latest news, security alerts and updates. The osTicket forums are
     also a great place to get assistance, guidance, tips, and help from
     other osTicket users.  In addition to the forums, the osTicket wiki
@@ -34,7 +34,7 @@ message: |
     </p><p>
     If the idea of managing and upgrading this osTicket installation is
     daunting, you can try osTicket as a hosted service at <a
-    href="http://www.supportsystem.com">http://www.supportsystem.com/</a> --
+    href="https://supportsystem.com">https://supportsystem.com/</a> --
     no installation required and we can import your data!  With
     SupportSystem's turnkey infrastructure, you get osTicket at its best,
     leaving you free to focus on your customers without the burden of making
@@ -43,7 +43,7 @@ message: |
     Cheers,
     </p><p>
     -<br/>
-    osTicket Team http://osticket.com/
+    osTicket Team https://osticket.com/
     </p><p>
     <strong>PS.</strong> Don't just make customers happy, make happy
     customers!

--- a/include/i18n/en_US/templates/ticket/upgraded.yaml
+++ b/include/i18n/en_US/templates/ticket/upgraded.yaml
@@ -16,19 +16,19 @@ message: |
     (https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes) for more information about
     changes and new features.
     </p><p>
-    Be sure to join the <a href="http://osticket.com/forums">osTicket
-    forums</a> and our <a href="http://osticket.com/updates">mailing
+    Be sure to join the <a href="https://forum.osticket.com">osTicket
+    forums</a> and our <a href="https://osticket.com">mailing
     list</a> to stay up to date on announcements, security updates and
     alerts! Your contribution to osTicket community will be appreciated!
     </p><p>
     The osTicket team is committed to providing support to all users through
     our free online resources and a full range of commercial support
     packages and services. For more information, or to discuss your needs,
-    please contact us today at http://osticket.com/support/. Any feedback
+    please contact us today at https://osticket.com/support/. Any feedback
     will be appreciated!
     </p><p>
     If managing and upgrading this osTicket installation is daunting, you
-    can try osTicket as a hosted service at http://www.supportsystem.com/ --
+    can try osTicket as a hosted service at https://supportsystem.com/ --
     no upgrading ever, and we can import your data!  With SupportSystem's
     turnkey infrastructure, you get osTicket at its best, leaving you free
     to focus on your customers without the burden of making sure the
@@ -36,5 +36,5 @@ message: |
     </p><p>
     -<br/>
     osTicket Team<br/>
-    http://osticket.com/
+    https://osticket.com/
     </p>

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -74,7 +74,7 @@ else {
     $cv = $tv[0] == 'v' ? $tv : $gv;
 ?>
       <a class="green button action-button pull-right"
-         href="http://osticket.com/download?cv=<?php echo $cv; ?>"><i class="icon-rocket"></i>
+         href="https://osticket.com/download?cv=<?php echo $cv; ?>"><i class="icon-rocket"></i>
         <?php echo __('Upgrade'); ?></a>
 <?php if ($lv) { ?>
       <strong> — <?php echo str_replace(

--- a/include/upgrader/aborted.inc.php
+++ b/include/upgrader/aborted.inc.php
@@ -6,7 +6,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
     <h1 style="color:#FF7700;"><?php echo __('Upgrade Aborted!');?></h1>
     <div id="intro">
         <p><strong><?php echo __('Upgrade aborted due to errors. Any errors at this stage are fatal.');?></strong></p>
-        <p><?php echo sprintf(__('Please note the error(s), if any, when %1$s seeking help %2$s.'),'<a target="_blank" href="http://osticket.com/support/">','</a>');?><p>
+        <p><?php echo sprintf(__('Please note the error(s), if any, when %1$s seeking help %2$s.'),'<a target="_blank" href="https://osticket.com/support/">','</a>');?><p>
         <?php
         if($upgrader && ($errors=$upgrader->getErrors())) {
             if($errors['err'])
@@ -23,13 +23,13 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
         <p><b><?php echo sprintf(__('For details - please view %s or check your email.'),
             sprintf('<a href="logs.php">%s</a>', __('System Logs')));?></b></p>
         <br>
-        <p><?php echo sprintf(__('Please refer to the %1$s Upgrade Guide %2$s for more information.'), '<a target="_blank" href="http://osticket.com/wiki/Upgrade_and_Migration">', '</a>');?></p>
+        <p><?php echo sprintf(__('Please refer to the %1$s Upgrade Guide %2$s for more information.'), '<a target="_blank" href="https://docs.osticket.com/en/latest/Getting%20Started/Upgrade%20and%20Migration.html">', '</a>');?></p>
     </div>
-    <p><strong><?php echo __('Need Help?');?></strong> <?php echo sprintf(__('We provide %1$s professional upgrade services %2$s and commercial support.'), '<a target="_blank" href="http://osticket.com/support/professional_services.php"><u>','</u></a>'); echo sprintf(__('%1$s Contact us %2$s today for <u>expedited</u> help.'), '<a target="_blank" href="http://osticket.com/support/">','</a>');?></p>
+    <p><strong><?php echo __('Need Help?');?></strong> <?php echo sprintf(__('We provide %1$s professional upgrade services %2$s and commercial support.'), '<a target="_blank" href="https://osticket.com/support/"><u>','</u></a>'); echo sprintf(__('%1$s Contact us %2$s today for <u>expedited</u> help.'), '<a target="_blank" href="https://osticket.com/contact-us/">','</a>');?></p>
   </div>
   <div class="sidebar">
     <h3><?php echo __('What to do?');?></h3>
-    <p><?php echo sprintf(__('Restore your previous version from backup and try again or %1$s seek help %2$s.'), '<a target="_blank" href="http://osticket.com/support/">','</a>');?></p>
+    <p><?php echo sprintf(__('Restore your previous version from backup and try again or %1$s seek help %2$s.'), '<a target="_blank" href="https://osticket.com/support/">','</a>');?></p>
   </div>
   <div class="clear"></div>
 </div>

--- a/include/upgrader/prereq.inc.php
+++ b/include/upgrader/prereq.inc.php
@@ -41,7 +41,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
             <p>1. <?php echo __('Remember to back up your osTicket database');?></p>
             <p>2. <?php echo sprintf(__('Refer to %1$s Upgrade Guide %2$s for the latest tips'), '<a href="https://docs.osticket.com/en/latest/Getting%20Started/Upgrade%20and%20Migration.html" target="_blank">', '</a>');?></p>
             <p>3. <?php echo __('If you experience any problems, you can always restore your files/database backup.');?></p>
-            <p>4. <?php echo sprintf(__('We can help. Feel free to %1$s contact us %2$s for professional help.'), '<a href="http://osticket.com/support/" target="_blank">', '</a>');?></p>
+            <p>4. <?php echo sprintf(__('We can help. Feel free to %1$s contact us %2$s for professional help.'), '<a href="https://osticket.com/support/" target="_blank">', '</a>');?></p>
 
     </div>
     <div class="clear"></div>

--- a/include/upgrader/rename.inc.php
+++ b/include/upgrader/rename.inc.php
@@ -15,7 +15,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
                 <li><b><?php echo __('FTP');?>:</b><br> </li>
                 <li><b><?php echo __('Cpanel');?>:</b><br> </li>
             </ul>
-            <p><?php echo sprintf(__('Please refer to the %1$s Upgrade Guide %2$s for more information.'), '<a target="_blank" href="http://osticket.com/wiki/Upgrade_and_Migration">', '</a>');?></p>
+            <p><?php echo sprintf(__('Please refer to the %1$s Upgrade Guide %2$s for more information.'), '<a target="_blank" href="https://docs.osticket.com/en/latest/Getting%20Started/Upgrade%20and%20Migration.html">', '</a>');?></p>
             <div id="bar">
                 <form method="post" action="upgrade.php">
                     <?php csrf_token(); ?>
@@ -27,7 +27,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
     <div class="sidebar">
             <h3><?php echo __('Need Help?');?></h3>
             <p>
-            <?php echo __('If you are looking for a greater level of support, we provide <u>professional upgrade</u> and commercial support with guaranteed response times and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs. <a target="_blank" href="http://osticket.com/support">Learn More!</a>'); ?>
+            <?php echo __('If you are looking for a greater level of support, we provide <u>professional upgrade</u> and commercial support with guaranteed response times and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs. <a target="_blank" href="https://osticket.com/support">Learn More!</a>'); ?>
             </p>
     </div>
     <div class="clear"></div>

--- a/include/upgrader/upgrade.inc.php
+++ b/include/upgrader/upgrade.inc.php
@@ -43,7 +43,7 @@ $action=$upgrader->getNextAction();
             <p>1. <?php echo __("Be patient. The upgrade process will take a couple of seconds.");?></p>
 
             <p>2. <?php echo __('If you experience any problems, you can always restore your files/database backup.');?></p>
-            <p>3. <?php echo sprintf(__('We can help. Feel free to %1$s contact us %2$s for professional help.'), '<a href="http://osticket.com/support" target="_blank">', '</a>');?></p>
+            <p>3. <?php echo sprintf(__('We can help. Feel free to %1$s contact us %2$s for professional help.'), '<a href="https://osticket.com/support" target="_blank">', '</a>');?></p>
         </div>
     </div>
     <div class="clear"></div>

--- a/setup/inc/file-missing.inc.php
+++ b/setup/inc/file-missing.inc.php
@@ -15,7 +15,7 @@ if(!defined('SETUPINC')) die('Kwaheri!');
                 <li><b><?php echo __('FTP');?>:</b><br> </li>
                 <li><b><?php echo __('Cpanel');?>:</b><br> </li>
             </ul>
-            <p><?php echo sprintf(__('If sample config file is missing - please make sure you uploaded all files in \'upload\' folder or refer to the %1$s Installation Guide %2$s'),'<a target="_blank" href="http://osticket.com/wiki/Installation">','</a>');?></p>
+            <p><?php echo sprintf(__('If sample config file is missing - please make sure you uploaded all files in \'upload\' folder or refer to the %1$s Installation Guide %2$s'),'<a target="_blank" href="https://docs.osticket.com/en/latest/Getting%20Started/Installation.html">','</a>');?></p>
             <div id="bar">
                 <form method="post" action="install.php">
                     <input type="hidden" name="s" value="config">
@@ -26,6 +26,6 @@ if(!defined('SETUPINC')) die('Kwaheri!');
     <div id="sidebar">
             <h3><?php echo __('Need Help?');?></h3>
             <p>
-            <?php echo __('If you are looking for a greater level of support, we provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs.');?> <a target="_blank" href="http://osticket.com/support"><?php echo __('Learn More!');?></a>
+            <?php echo __('If you are looking for a greater level of support, we provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs.');?> <a target="_blank" href="https://osticket.com/support"><?php echo __('Learn More!');?></a>
             </p>
     </div>

--- a/setup/inc/file-perm.inc.php
+++ b/setup/inc/file-perm.inc.php
@@ -31,6 +31,6 @@ if(!defined('SETUPINC')) die('Kwaheri!');
     <div id="sidebar">
             <h3><?php echo __('Need Help?');?></h3>
             <p>
-            <?php echo __('If you are looking for a greater level of support, we provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs.');?> <a target="_blank" href="http://osticket.com/support"><?php echo __('Learn More!');?></a>
+            <?php echo __('If you are looking for a greater level of support, we provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs.');?> <a target="_blank" href="https://osticket.com/support"><?php echo __('Learn More!');?></a>
             </p>
     </div>

--- a/setup/inc/file-unclean.inc.php
+++ b/setup/inc/file-unclean.inc.php
@@ -7,12 +7,12 @@ if(!defined('SETUPINC')) die('Kwaheri!');
              <p><?php echo sprintf(__('Configuration file already changed - which could mean osTicket is already installed or the config file is corrupted. If you are trying to upgrade osTicket, then go to %s Admin Panel %s.'), '<a href="../scp/admin.php" >', '</a>');?></p>
 
              <p><?php echo __('If you believe this is in error, please try replacing the config file with a unchanged template copy and try again or get technical help.');?></p>
-             <p><?php echo sprintf(__('Refer to the %s Installation Guide %s on the wiki for more information.'), '<a target="_blank" href="http://osticket.com/wiki/Installation">', '</a>');?></p>
+             <p><?php echo sprintf(__('Refer to the %s Installation Guide %s on the wiki for more information.'), '<a target="_blank" href="https://docs.osticket.com/en/latest/Getting%20Started/Installation.html">', '</a>');?></p>
             </div>
     </div>
     <div id="sidebar">
             <h3><?php echo __('Need Help?');?></h3>
             <p>
-            <?php echo __('We provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team.');?> <a target="_blank" href="http://osticket.com/support"><?php echo __('Learn More!');?></a>
+            <?php echo __('We provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team.');?> <a target="_blank" href="https://osticket.com/support"><?php echo __('Learn More!');?></a>
             </p>
     </div>

--- a/setup/inc/footer.inc.php
+++ b/setup/inc/footer.inc.php
@@ -2,7 +2,7 @@
             <div class="clear"></div>
         </div> <!-- content -->
     </div> <!-- wizard -->
-    <div id="footer" class="centered">Copyright &copy; <?php echo date('Y'); ?> <a target="_blank" href="http://osticket.com">osTicket.com</a></div>
+    <div id="footer" class="centered">Copyright &copy; <?php echo date('Y'); ?> <a target="_blank" href="https://osticket.com">osTicket.com</a></div>
 
     <script type="text/javascript" src="../js/jquery-3.4.0.min.js"></script>
     <script type="text/javascript" src="../js/jstz.min.js"></script>

--- a/setup/inc/header.inc.php
+++ b/setup/inc/header.inc.php
@@ -28,7 +28,7 @@ if (($lang = Internationalization::getCurrentLanguage())
                    foreach($wizard['menu'] as $k=>$v)
                     echo sprintf('<a target="_blank" href="%s">%s</a> &mdash; ',$v,$k);
                    ?>
-                    <a target="_blank" href="http://osticket.com/contact-us"><?php echo __('Contact Us');?></a>
+                    <a target="_blank" href="https://osticket.com/contact-us"><?php echo __('Contact Us');?></a>
                 </li>
             </ul>
             <div class="flags">

--- a/setup/inc/install-done.inc.php
+++ b/setup/inc/install-done.inc.php
@@ -31,11 +31,11 @@ $url=URL;
                 <tr>
                     <td width="50%">
                         <strong><?php echo __('osTicket Forums');?>:</strong><Br>
-                        <a href="#">http://osticket.com/forum/</a>
+                        <a href="#">https://forum.osticket.com/</a>
                     </td>
                     <td width="50%">
-                        <strong><?php echo __('osTicket Community Wiki');?>:</strong><Br>
-                        <a href="#">http://osticket.com/wiki/</a>
+                        <strong><?php echo __('osTicket Documentation');?>:</strong><Br>
+                        <a href="#">https://docs.osticket.com/</a>
                     </td>
                 </tr>
             </table>
@@ -43,7 +43,7 @@ $url=URL;
     </div>
     <div id="sidebar">
             <h3><?php echo __("What's Next?");?></h3>
-            <p><b><?php echo __('Post-Install Setup');?></b>: <?php echo sprintf(__('You can now log in to %1$s Admin Panel %2$s with the username and password you created during the install process. After a successful log in, you can proceed with post-install setup.'), '<a href="../scp/admin.php" target="_blank">','</a>'); echo sprintf(__('For complete and upto date guide see %1$s osTicket wiki %2$s'), '<a href="http://osticket.com/wiki/Post-Install_Setup_Guide" target="_blank">', '</a>');?></p>
+            <p><b><?php echo __('Post-Install Setup');?></b>: <?php echo sprintf(__('You can now log in to %1$s Admin Panel %2$s with the username and password you created during the install process. After a successful log in, you can proceed with post-install setup.'), '<a href="../scp/admin.php" target="_blank">','</a>'); echo sprintf(__('For complete and upto date guide see %1$s osTicket wiki %2$s'), '<a href="https://docs.osticket.com/en/latest/Getting%20Started/Post-Installation.html" target="_blank">', '</a>');?></p>
 
-            <p><b><?php echo __('Commercial Support Available');?></b>: <?php echo __("Don't let technical problems impact your osTicket implementation. Get guidance and hands-on expertise to address unique challenges and make sure your osTicket runs smoothly, efficiently, and securely.");?> <a target="_blank" href="http://osticket.com/support"><?php echo __('Learn More!');?></a></p>
+            <p><b><?php echo __('Commercial Support Available');?></b>: <?php echo __("Don't let technical problems impact your osTicket implementation. Get guidance and hands-on expertise to address unique challenges and make sure your osTicket runs smoothly, efficiently, and securely.");?> <a target="_blank" href="https://osticket.com/support"><?php echo __('Learn More!');?></a></p>
    </div>

--- a/setup/inc/install-prereq.inc.php
+++ b/setup/inc/install-prereq.inc.php
@@ -53,6 +53,6 @@ if(!defined('SETUPINC')) die('Kwaheri!');
     <div id="sidebar">
             <h3><?php echo __('Need Help?');?></h3>
             <p>
-            <?php echo __('If you are looking for a greater level of support, we provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs.');?> <a target="_blank" href="http://osticket.com/support"><?php echo __('Learn More!');?></a>
+            <?php echo __('If you are looking for a greater level of support, we provide <u>professional installation services</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs.');?> <a target="_blank" href="https://osticket.com/support"><?php echo __('Learn More!');?></a>
             </p>
     </div>

--- a/setup/inc/install.inc.php
+++ b/setup/inc/install.inc.php
@@ -120,7 +120,7 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):array('prefix'=>'ost_','dbho
             </form>
     </div>
     <div>
-        <p><strong><?php echo __('Need Help?');?></strong> <?php echo __('We provide <u>professional installation services</u> and commercial support.');?> <a target="_blank" href="http://osticket.com/support"><?php echo __('Learn More!');?></a></p>
+        <p><strong><?php echo __('Need Help?');?></strong> <?php echo __('We provide <u>professional installation services</u> and commercial support.');?> <a target="_blank" href="https://osticket.com/support"><?php echo __('Learn More!');?></a></p>
     </div>
     <div id="overlay"></div>
     <div id="loading">

--- a/setup/inc/subscribe.inc.php
+++ b/setup/inc/subscribe.inc.php
@@ -43,6 +43,6 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):$_SESSION['info'];
                 <?php echo __('Once again, thank you for choosing osTicket as your new customer support platform! ');?>
             </p>
             <p>
-               <?php echo __('Launching a new customer support platform can be a daunting task. Let us get you started! We provide professional support services to help get osTicket up and running smoothly for your organization.');?> <a target="_blank" href="http://osticket.com/support/professional_services.php"><?php echo __('Learn More!');?></a>
+               <?php echo __('Launching a new customer support platform can be a daunting task. Let us get you started! We provide professional support services to help get osTicket up and running smoothly for your organization.');?> <a target="_blank" href="https://osticket.com/services/professional-support/"><?php echo __('Learn More!');?></a>
             </p>
     </div>

--- a/setup/install.php
+++ b/setup/install.php
@@ -27,8 +27,8 @@ $wizard=array();
 $wizard['title']=__('osTicket Installer');
 $wizard['tagline']=sprintf(__('Installing osTicket %s'),$installer->getVersionVerbose());
 $wizard['logo']='logo.png';
-$wizard['menu']=array(__('Installation Guide')=>'http://osticket.com/wiki/Installation',
-        __('Get Professional Help')=>'http://osticket.com/support');
+$wizard['menu']=array(__('Installation Guide')=>'https://docs.osticket.com/en/latest/Getting%20Started/Installation.html',
+        __('Get Professional Help')=>'https://osticket.com/support');
 
 if($_POST && $_POST['s']) {
     $errors = array();


### PR DESCRIPTION
This updates all the old, outdated osTicket links in the software. This includes things like the forum URL, the support URL, the Installation Guide URL, etc.