### PR TITLE
issue: CSV Patch Adv. Search Error

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1446,7 +1446,8 @@ class TextboxField extends FormField {
         parent::validateEntry($value);
         $config = $this->getConfiguration();
         $validators = array(
-            '' =>       array(array('Validator', 'is_formula'),
+            '' => '',
+            'formula' => array(array('Validator', 'is_formula'),
                 __('Content cannot start with the following characters: = - + @')),
             'email' =>  array(array('Validator', 'is_valid_email'),
                 __('Enter a valid email address')),
@@ -1469,6 +1470,10 @@ class TextboxField extends FormField {
         }
         if (!$value || !isset($validators[$valid]))
             return;
+        // If no validators are set and not an instanceof AdvancedSearchForm
+        // force formula validation
+        if (!$valid && !($this->getForm() instanceof AdvancedSearchForm))
+            $valid = 'formula';
         $func = $validators[$valid];
         $error = $func[1];
         if ($config['validator-error'])


### PR DESCRIPTION
This addresses an issue where the previous CSV security patch causes an error when creating an Advanced Search with criteria like `User / Email Address => contains => @domain.tld`. The system tries to validate the field and since `is_formula` is the default validation for TextboxFields the system sees `@domain.tld` criteria as a formula and throws the `Content cannot start with the following characters: = - + @` error. Advanced Searches do not need the `is_formula` validation as the fields are not exportable. This adds a check to see if the field's form is `AdvancedSearchForm` and if there is no `validator` set it gets set to `adv` which bypasses the validation.