### PR TITLE
issue: Dashboard No Help Topics Error

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -148,6 +148,8 @@ class OverviewReport {
         $event = function ($name) use ($event_ids) {
             return $event_ids[$name];
         };
+        $dash_headers = array(__('Opened'),__('Assigned'),__('Overdue'),__('Closed'),__('Reopened'),
+                              __('Deleted'),__('Service Time'),__('Response Time'));
 
         list($start, $stop) = $this->getDateRange();
         $times = ThreadEvent::objects()
@@ -227,6 +229,9 @@ class OverviewReport {
             $header = function($row) { return Topic::getLocalNameById($row['topic_id'], $row['topic__topic']); };
             $pk = 'topic_id';
             $topics = Topic::getHelpTopics(false, Topic::DISPLAY_DISABLED);
+            if (empty($topics))
+                return array("columns" => array_merge($headers, $dash_headers),
+                      "data" => array());
             $stats = $stats
                 ->values('topic_id', 'topic__topic', 'topic__flags')
                 ->filter(array('dept_id__in' => $thisstaff->getDepts(), 'topic_id__gt' => 0, 'topic_id__in' => array_keys($topics)))
@@ -291,9 +296,7 @@ class OverviewReport {
                 number_format($T['ServiceTime'], 1),
                 number_format($T['ResponseTime'], 1));
         }
-        return array("columns" => array_merge($headers,
-                        array(__('Opened'),__('Assigned'),__('Overdue'),__('Closed'),__('Reopened'),
-                              __('Deleted'),__('Service Time'),__('Response Time'))),
+        return array("columns" => array_merge($headers, $dash_headers),
                      "data" => $rows);
     }
 }


### PR DESCRIPTION
This addresses an issue reported on the Forum where visiting the Agent Dashboard with no Help Topics in the system completely breaks the Dashboard view and throws a database error `You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') GROUP BY A1.topic_id' at line 1`. This is due to the statistics code assuming we will always have `$topics` but this is not always the case, as some people rock their helpdesk without a single Help Topic. This adds a check to see if `$topics` is empty and if so, we return the appropriate headers with an empty array as the plot data. This will avoid the database error and show the appropriate Dashboard view with no statistics listed under "Topics" tab.