### PR TITLE
Don't require refresh for inline edit

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -618,34 +618,32 @@ function refer($tid, $target=null) {
                       __($field->getLabel())
                       )
                   );
-                  if ($field instanceof FileUploadField)
+              if ($field instanceof FileUploadField)
                   $field->save();
 
-                  if (!$clean) {
-                      if (get_class($field) == 'DateTime' || get_class($field) == 'DatetimeField')
-                      $clean = Format::datetime((string) $field->getClean());
-                      elseif ($field instanceof FileUploadField) {
-                          $answer =  $field->getAnswer();
-                          $clean = $answer->display() ?: '&mdash;' . __('Empty') .  '&mdash;';
-                      } elseif ($field instanceof DepartmentField) {
-                          $id = $field->getClean();
-                          $clean = Dept::objects()->filter(array('id' => $id))->values_flat('name')->first();
-                          $clean = $clean[0];
-                      } else
-                      $clean = is_array($field->getClean()) ? implode($field->getClean(), ',') : (string) $field->getClean();
-                  }
+              if (get_class($field) == 'DateTime' || get_class($field) == 'DatetimeField')
+                  $clean = Format::datetime((string) $field->getClean());
+              elseif ($field instanceof FileUploadField) {
+                  $answer =  $field->getAnswer();
+                  $clean = $answer->display() ?: '&mdash;' . __('Empty') .  '&mdash;';
+              } elseif ($field instanceof DepartmentField) {
+                  $id = $field->getClean();
+                  $clean = Dept::objects()->filter(array('id' => $id))->values_flat('name')->first();
+                  $clean = $clean[0];
+              } else
+                  $clean = is_array($field->getClean()) ? implode($field->getClean(), ',') : (string) $field->getClean();
 
-                  $clean = is_array($clean) ? $clean[0] : $clean;
+              $clean = is_array($clean) ? $clean[0] : $clean;
 
-                  if (!$field instanceof FileUploadField && strlen($clean) > 200)
+              if (!$field instanceof FileUploadField && strlen($clean) > 200)
                   $clean = Format::truncate($clean, 200);
 
-                  Http::response(201, $this->json_encode(['value' =>
-                  $clean ?: '&mdash;' . __('Empty') .  '&mdash;', 'id' => $fid, 'msg' => $msg]));
-              }
+              Http::response(201, $this->json_encode(['value' =>
+              $clean ?: '&mdash;' . __('Empty') .  '&mdash;', 'id' => $fid, 'msg' => $msg]));
+          }
               $form->addErrors($errors);
               $info['error'] = $errors['err'] ?: __('Unable to update field');
-          }
+      }
 
       include STAFFINC_DIR . 'templates/field-edit.tmpl.php';
   }

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2692,6 +2692,222 @@ class ThreadEntryField extends FormField {
     }
 }
 
+class TopicField extends ChoiceField {
+    var $topics;
+    var $_choices;
+
+    function getTopics() {
+        if (!isset($this->topics))
+            $this->topics = Topic::objects();
+
+        return $this->topics;
+    }
+
+    function getTopic($id) {
+        if ($this->getTopics() &&
+                ($s=$this->topics->findFirst(array('id' => $id))))
+            return $s;
+
+        return Topic::lookup($id);
+    }
+
+    function getWidget($widgetClass=false) {
+        $default = $this->get('default');
+        $widget = parent::getWidget($widgetClass);
+        if ($widget->value instanceof Topic)
+            $widget->value = $widget->value->getId();
+        elseif (!isset($widget->value) && $default)
+            $widget->value = $default;
+        return $widget;
+    }
+
+    function hasIdValue() {
+        return true;
+    }
+
+    function getChoices($verbose=false) {
+        if (!isset($this->_choices)) {
+            $choices = array('' => '— '.__('Default').' —');
+            foreach ($this->getTopics() as $t)
+                $choices[$t->getId()] = $t->getName();
+            $this->_choices = $choices;
+        }
+
+        return $this->_choices;
+    }
+
+    function parse($id) {
+        return $this->to_php(null, $id);
+    }
+
+    function to_php($value, $id=false) {
+        if ($value instanceof Topic)
+            return $value;
+        if (is_array($id)) {
+            reset($id);
+            $id = key($id);
+        }
+        elseif (is_array($value))
+            list($value, $id) = $value;
+        elseif ($id === false)
+            $id = $value;
+
+        return $this->getTopic($id);
+    }
+
+    function to_database($topic) {
+        return ($topic instanceof Topic)
+            ? array($topic->getName(), $topic->getId())
+            : $topic;
+    }
+
+    function display($topic, &$styles=null) {
+        if (!$topic instanceof Topic)
+            return parent::display($topic);
+
+        return Format::htmlchars($topic->getName());
+    }
+
+    function toString($value) {
+        if (!($value instanceof Topic) && is_numeric($value))
+            $value = $this->getSLA($value);
+        return ($value instanceof Topic) ? $value->getName() : $value;
+    }
+
+    function whatChanged($before, $after) {
+        return FormField::whatChanged($before, $after);
+    }
+
+    function searchable($value) {
+        return null;
+    }
+
+    function getKeys($value) {
+        return ($value instanceof Topic) ? array($value->getId()) : null;
+    }
+
+    function asVar($value, $id=false) {
+        return $this->to_php($value, $id);
+    }
+
+    function getConfiguration() {
+        global $cfg;
+
+        $config = parent::getConfiguration();
+        if (!isset($config['default']))
+            $config['default'] = $cfg->getDefaultTopicId();
+        return $config;
+    }
+}
+
+class SLAField extends ChoiceField {
+    var $slas;
+    var $_choices;
+
+    function getSLAs() {
+        if (!isset($this->slas))
+            $this->slas = SLA::objects();
+
+        return $this->slas;
+    }
+
+    function getSLA($id) {
+        if ($this->getSLAs() &&
+                ($s=$this->slas->findFirst(array('id' => $id))))
+            return $s;
+
+        return SLA::lookup($id);
+    }
+
+    function getWidget($widgetClass=false) {
+        $default = $this->get('default');
+        $widget = parent::getWidget($widgetClass);
+        if ($widget->value instanceof SLA)
+            $widget->value = $widget->value->getId();
+        elseif (!isset($widget->value) && $default)
+            $widget->value = $default;
+        return $widget;
+    }
+
+    function hasIdValue() {
+        return true;
+    }
+
+    function getChoices($verbose=false) {
+        if (!isset($this->_choices)) {
+            $choices = array('' => '— '.__('Default').' —');
+            foreach ($this->getSLAs() as $s)
+                $choices[$s->getId()] = $s->getName();
+            $this->_choices = $choices;
+        }
+
+        return $this->_choices;
+    }
+
+    function parse($id) {
+        return $this->to_php(null, $id);
+    }
+
+    function to_php($value, $id=false) {
+        if ($value instanceof SLA)
+            return $value;
+        if (is_array($id)) {
+            reset($id);
+            $id = key($id);
+        }
+        elseif (is_array($value))
+            list($value, $id) = $value;
+        elseif ($id === false)
+            $id = $value;
+
+        return $this->getSLA($id);
+    }
+
+    function to_database($sla) {
+        return ($sla instanceof SLA)
+            ? array($sla->getName(), $sla->getId())
+            : $sla;
+    }
+
+    function display($sla, &$styles=null) {
+        if (!$sla instanceof SLA)
+            return parent::display($sla);
+
+        return Format::htmlchars($sla->getName());
+    }
+
+    function toString($value) {
+        if (!($value instanceof SLA) && is_numeric($value))
+            $value = $this->getSLA($value);
+        return ($value instanceof SLA) ? $value->getName() : $value;
+    }
+
+    function whatChanged($before, $after) {
+        return FormField::whatChanged($before, $after);
+    }
+
+    function searchable($value) {
+        return null;
+    }
+
+    function getKeys($value) {
+        return ($value instanceof SLA) ? array($value->getId()) : null;
+    }
+
+    function asVar($value, $id=false) {
+        return $this->to_php($value, $id);
+    }
+
+    function getConfiguration() {
+        global $cfg;
+
+        $config = parent::getConfiguration();
+        if (!isset($config['default']))
+            $config['default'] = $cfg->getDefaultSLAId();
+        return $config;
+    }
+}
+
 class PriorityField extends ChoiceField {
 
     var $priorities;
@@ -3015,67 +3231,6 @@ FormField::addFieldTypes(/*@trans*/ 'Dynamic Fields', function() {
         'department' => array(__('Department'), 'DepartmentField'),
     );
 });
-
-
-class SLAField extends ChoiceField {
-    function getWidget($widgetClass=false) {
-        $widget = parent::getWidget($widgetClass);
-        if ($widget->value instanceof SLA)
-            $widget->value = $widget->value->getId();
-        return $widget;
-    }
-
-    function hasIdValue() {
-        return true;
-    }
-
-    function getChoices($verbose=false) {
-        global $cfg;
-
-        $choices = array();
-        if (($depts = SLA::getSLAs()))
-            foreach ($depts as $id => $name)
-                $choices[$id] = $name;
-
-        return $choices;
-    }
-
-    function parse($id) {
-        return $this->to_php(null, $id);
-    }
-
-    function to_php($value, $id=false) {
-        if (is_array($id)) {
-            reset($id);
-            $id = key($id);
-        }
-        return $id;
-    }
-
-    function to_database($sla) {
-        return ($sla instanceof SLA)
-            ? array($sla->getName(), $sla->getId())
-            : $sla;
-    }
-
-    function toString($value) {
-        return (string) $value;
-    }
-
-    function searchable($value) {
-        return null;
-    }
-
-    function getConfigurationOptions() {
-        return array(
-            'prompt' => new TextboxField(array(
-                'id'=>2, 'label'=>__('Prompt'), 'required'=>false, 'default'=>'',
-                'hint'=>__('Leading text shown before a value is selected'),
-                'configuration'=>array('size'=>40, 'length'=>40),
-            )),
-        );
-    }
-}
 
 class AssigneeField extends ChoiceField {
     var $_choices = null;
@@ -4087,7 +4242,6 @@ class PhoneNumberWidget extends Widget {
 
 class ChoicesWidget extends Widget {
     function render($options=array()) {
-
         $mode = null;
         if (isset($options['mode']))
             $mode = $options['mode'];
@@ -4095,10 +4249,10 @@ class ChoicesWidget extends Widget {
             $mode = $this->field->options['render_mode'];
 
         if ($mode == 'view') {
-            if (!($val = (string) $this->field))
-                $val = sprintf('<span class="faded">%s</span>', __('None'));
-
-            echo $val;
+            $val = (string) $this->field;
+            echo sprintf('<span id="field_%s" %s >%s</span>', $this->id,
+                    $val ? '': 'class="faded"',
+                    $val ?: __('None'));
             return;
         }
 

--- a/include/class.sla.php
+++ b/include/class.sla.php
@@ -240,6 +240,10 @@ implements TemplateVariable {
         return $row ? $row[0] : 0;
     }
 
+    function __toString() {
+        return $this->getName();
+    }
+
     static function create($vars=false, &$errors=array()) {
         $sla = new static($vars);
         $sla->created = SqlFunction::NOW();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -614,11 +614,17 @@ implements RestrictedAccess, Threadable, Searchable {
     }
 
     function getPriority() {
-
         if (($a = $this->getAnswer('priority')))
             return $a->getValue();
 
         return null;
+    }
+
+    function getPriorityField() {
+        if (($a = $this->getAnswer('priority')))
+            return $a->getField();
+
+        return TicketForm::getInstance()->getField('priority');
     }
 
     function getPhoneNumber() {
@@ -1088,13 +1094,10 @@ implements RestrictedAccess, Threadable, Searchable {
         // Special fields
         switch ($fid) {
         case 'priority':
-            if (($a = $this->getAnswer('priority')))
-                return $a->getField();
-
-            return TicketForm::getInstance()->getField('priority');
+            return $this->getPriorityField();
             break;
         case 'sla':
-            return ChoiceField::init(array(
+            return SLAField::init(array(
                         'id' => $fid,
                         'name' => "{$fid}_id",
                         'label' => __('SLA Plan'),
@@ -1107,7 +1110,7 @@ implements RestrictedAccess, Threadable, Searchable {
             if ($topic = $this->getTopic())
                 $current = array($topic->getId());
             $choices = Topic::getHelpTopics(false, $topic ? (Topic::DISPLAY_DISABLED) : false, true, $current);
-            return ChoiceField::init(array(
+            return TopicField::init(array(
                         'id' => $fid,
                         'name' => "{$fid}_id",
                         'label' => __('Help Topic'),
@@ -3682,7 +3685,8 @@ implements RestrictedAccess, Threadable, Searchable {
                               $dt->setTimezone(new DateTimeZone($cfg->getDbTimezone()));
                               $val = $dt->format('Y-m-d H:i:s');
                           }
-                }
+                } elseif (is_object($val))
+                    $val = $val->getId();
 
                 $changes = array();
                 $this->{$fid} = $val;

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -61,6 +61,7 @@ if($ticket->isOverdue())
 
 ?>
 <div>
+    <div id="msg_notice" style="display: none;"><span id="msg-txt"><?php echo $msg ?: ''; ?></span></div>
     <div class="sticky bar">
        <div class="content">
         <div class="pull-right flush-right">
@@ -309,13 +310,13 @@ if($ticket->isOverdue())
                     <th width="100"><?php echo __('Status');?>:</th>
                     <?php
                          if ($role->hasPerm(Ticket::PERM_CLOSE)) {?>
-                    <td>
-                      <a class="tickets-action" data-dropdown="#action-dropdown-statuses" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Change Status'); ?>"
-                          data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-                          href="#statuses">
-                          <?php echo $ticket->getStatus(); ?>
-                      </a>
-                    </td>
+                         <td>
+                          <a class="tickets-action" data-dropdown="#action-dropdown-statuses" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Change Status'); ?>"
+                              data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
+                              href="#statuses">
+                              <?php echo $ticket->getStatus(); ?>
+                          </a>
+                        </td>
                       <?php } else { ?>
                           <td><?php echo ($S = $ticket->getStatus()) ? $S->display() : ''; ?></td>
                       <?php } ?>
@@ -323,12 +324,12 @@ if($ticket->isOverdue())
                 <tr>
                     <th><?php echo __('Priority');?>:</th>
                       <?php
-                         if ($role->hasPerm(Ticket::PERM_EDIT)) {?>
+                      if ($role->hasPerm(Ticket::PERM_EDIT)
+                        && ($pf = $ticket->getPriorityField())) { ?>
                            <td>
-                             <a class="ticket-action" id="inline-update" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
-                                 data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-                                 href="#tickets/<?php echo $ticket->getId(); ?>/field/priority/edit">
-                                 <?php echo $ticket->getPriority(); ?>
+                             <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
+                                 href="#tickets/<?php echo $ticket->getId();?>/field/<?php echo $pf->getId();?>/edit">
+                                 <span id="field_<?php echo $pf->getId(); ?>"><?php echo $pf->getAnswer()->display(); ?></span>
                              </a>
                            </td>
                       <?php } else { ?>
@@ -470,13 +471,13 @@ if($ticket->isOverdue())
                   <th><?php echo __('Source'); ?>:</th>
                   <td>
                   <?php
-                         if ($role->hasPerm(Ticket::PERM_EDIT)) {?>
-                    <a class="ticket-action" id="inline-update" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
-                        data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-
+                         if ($role->hasPerm(Ticket::PERM_EDIT)) {
+                             $source = $ticket->getField('source');?>
+                    <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
                         href="#tickets/<?php echo $ticket->getId(); ?>/field/source/edit">
+                        <span id="field_source">
                         <?php echo Format::htmlchars($ticket->getSource());
-                        ?>
+                        ?></span>
                     </a>
                       <?php
                          } else {
@@ -504,15 +505,14 @@ if($ticket->isOverdue())
                     <?php
                     if ($role->hasPerm(Ticket::PERM_ASSIGN)) {?>
                     <td>
-                                                    <a class="ticket-action" id="ticket-assign"
-                            data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
+                        <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
                             href="#tickets/<?php echo $ticket->getId(); ?>/assign">
-                            <?php
-                                if($ticket->isAssigned())
-                                    echo Format::htmlchars(implode('/', $ticket->getAssignees()));
-                                else
-                                    echo '<span class="faded">&mdash; '.__('Unassigned').' &mdash;</span>';
-                            ?>
+                            <span id="field_assign">
+                                <?php if($ticket->isAssigned())
+                                        echo Format::htmlchars(implode('/', $ticket->getAssignees()));
+                                      else
+                                        echo '<span class="faded">&mdash; '.__('Unassigned').' &mdash;</span>';
+                        ?></span>
                         </a>
                     </td>
                     <?php
@@ -547,15 +547,14 @@ if($ticket->isOverdue())
                     <th><?php echo __('SLA Plan');?>:</th>
                     <td>
                     <?php
-                         if ($role->hasPerm(Ticket::PERM_EDIT)) {?>
-                      <a class="ticket-action" id="inline-update" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
-                          data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-
+                         if ($role->hasPerm(Ticket::PERM_EDIT)) {
+                             $slaField = $ticket->getField('sla'); ?>
+                          <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
                           href="#tickets/<?php echo $ticket->getId(); ?>/field/sla/edit">
-                          <?php echo $sla?Format::htmlchars($sla->getName()):'<span class="faded">&mdash; '.__('None').' &mdash;</span>'; ?>
+                          <span id="field_sla"><?php echo $sla ?: __('None'); ?></span>
                       </a>
                       <?php } else { ?>
-                        <?php echo $sla?Format::htmlchars($sla->getName()):'<span class="faded">&mdash; '.__('None').' &mdash;</span>'; ?>
+                        <span id="field_sla"><?php echo $sla ?: __('None'); ?></span>
                       <?php } ?>
                     </td>
                 </tr>
@@ -564,14 +563,13 @@ if($ticket->isOverdue())
                 <tr>
                     <th><?php echo __('Due Date');?>:</th>
                     <?php
-                         if ($role->hasPerm(Ticket::PERM_EDIT)) {?>
+                         if ($role->hasPerm(Ticket::PERM_EDIT)) {
+                             $duedate = $ticket->getField('duedate'); ?>
                            <td>
-                      <a class="ticket-action" id="inline-update" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
-                          data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-
+                      <a class="inline-edit" data-placement="bottom"
                           href="#tickets/<?php echo $ticket->getId();
                            ?>/field/duedate/edit">
-                          <?php echo Format::datetime($ticket->getEstDueDate()); ?>
+                           <span id="field_duedate"><?php echo Format::datetime($ticket->getEstDueDate()); ?></span>
                       </a>
                     <td>
                       <?php } else { ?>
@@ -594,13 +592,15 @@ if($ticket->isOverdue())
                 <tr>
                     <th width="100"><?php echo __('Help Topic');?>:</th>
                       <?php
-                           if ($role->hasPerm(Ticket::PERM_EDIT)) {?>
+                           if ($role->hasPerm(Ticket::PERM_EDIT)) {
+                               $topic = $ticket->getField('topic'); ?>
                              <td>
-                        <a class="ticket-action" id="inline-update" data-placement="bottom"
+                        <a class="inline-edit" data-placement="bottom"
                             data-toggle="tooltip" title="<?php echo __('Update'); ?>"
-                            data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
                             href="#tickets/<?php echo $ticket->getId(); ?>/field/topic/edit">
-                            <?php echo $ticket->getHelpTopic() ?: __('None'); ?>
+                            <span id="field_topic">
+                                <?php echo $ticket->getHelpTopic() ?: __('None'); ?>
+                            </span>
                         </a>
                       </td>
                         <?php } else { ?>
@@ -652,31 +652,35 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
     foreach ($displayed as $a) {
         $id =  $a->getLocal('id');
         $label = $a->getLocal('label');
-        $v = $a->display() ?: '<span class="faded">&mdash;' . __('Empty') .  '&mdash; </span>';
+        $v = $a->display();
+        $class = $v ? '' : 'class="faded"';
+        $clean = $v ?: '&mdash;' . __('Empty') .  '&mdash;';
         $field = $a->getField();
         $isFile = ($field instanceof FileUploadField);
 ?>
         <tr>
             <td width="200"><?php echo Format::htmlchars($label); ?>:</td>
-            <td>
+            <td id="<?php echo sprintf('inline-answer-%s', $field->getId()); ?>">
             <?php if ($role->hasPerm(Ticket::PERM_EDIT)
                     && $field->isEditableToStaff()) {
-                    $isEmpty = strpos($v, '&mdash;');
-                    if ($isFile && !$isEmpty)
-                        echo $v.'<br>'; ?>
-              <a class="ticket-action" id="inline-update" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
-                  data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-                  href="#tickets/<?php echo $ticket->getId(); ?>/field/<?php echo $id; ?>/edit">
+                    $isEmpty = strpos($v, 'Empty');
+                    if ($isFile && !$isEmpty) {
+                        echo sprintf('<span id="field_%s" %s >%s</span><br>', $id,
+                            $class,
+                            $v ?: '<span class="faded">&mdash;' . __('Empty') .  '&mdash; </span>');
+                    }
+                         ?>
+                  <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
+                      href="#tickets/<?php echo $ticket->getId(); ?>/field/<?php echo $id; ?>/edit">
                   <?php
-                    if (is_string($v) && $isFile && !$isEmpty) {
+                    if ($isFile && !$isEmpty) {
                       echo "<i class=\"icon-edit\"></i>";
                     } elseif (strlen($v) > 200) {
-                      echo Format::truncate($v, 200);
+                      $clean = Format::truncate($v, 200);
+                      echo sprintf('<span id="field_%s" %s >%s</span>', $id, $class, $clean);
                       echo "<br><i class=\"icon-edit\"></i>";
-                    }
-                    else
-                      echo $v;
-                  ?>
+                    } else
+                        echo sprintf('<span id="field_%s" %s >%s</span>', $id, $class, $clean); ?>
               </a>
             <?php
             } else {
@@ -740,9 +744,6 @@ $tcount = $ticket->getThreadEntries($types) ? $ticket->getThreadEntries($types)-
 if ($errors['err'] && isset($_POST['a'])) {
     // Reflect errors back to the tab.
     $errors[$_POST['a']] = $errors['err'];
-} elseif($msg) { ?>
-    <div id="msg_notice"><?php echo $msg; ?></div>
-<?php
 } elseif($warn) { ?>
     <div id="msg_warning"><?php echo $warn; ?></div>
 <?php

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -151,7 +151,10 @@ if($ticket->isOverdue())
                 <?php
                  if ($role->hasPerm(Ticket::PERM_EDIT)) { ?>
                     <li><a class="change-user" href="#tickets/<?php
-                    echo $ticket->getId(); ?>/change-user"><i class="icon-user"></i> <?php
+                    echo $ticket->getId(); ?>/change-user"
+                    onclick="javascript:
+                        $('#response').redactor('draft.saveDraft');"
+                    ><i class="icon-user"></i> <?php
                     echo __('Change Owner'); ?></a></li>
                 <?php
                  }
@@ -313,7 +316,10 @@ if($ticket->isOverdue())
                          <td>
                           <a class="tickets-action" data-dropdown="#action-dropdown-statuses" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Change Status'); ?>"
                               data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-                              href="#statuses">
+                              href="#statuses"
+                              onclick="javascript:
+                                  $('#response').redactor('draft.saveDraft');"
+                              >
                               <?php echo $ticket->getStatus(); ?>
                           </a>
                         </td>
@@ -341,9 +347,12 @@ if($ticket->isOverdue())
                     <?php
                     if ($role->hasPerm(Ticket::PERM_TRANSFER)) {?>
                       <td>
-                        <a class="ticket-action" id="ticket-transfer" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Transfer'); ?>"
-                          data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
-                          href="#tickets/<?php echo $ticket->getId(); ?>/transfer"><?php echo Format::htmlchars($ticket->getDeptName()); ?>
+                          <a class="ticket-action" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Transfer'); ?>"
+                            data-redirect="tickets.php?id=<?php echo $ticket->getId(); ?>"
+                            href="#tickets/<?php echo $ticket->getId(); ?>/transfer"
+                            onclick="javascript:
+                                $('#response').redactor('draft.saveDraft');"
+                            ><?php echo Format::htmlchars($ticket->getDeptName()); ?>
                         </a>
                       </td>
                     <?php
@@ -363,6 +372,7 @@ if($ticket->isOverdue())
                     <th width="100"><?php echo __('User'); ?>:</th>
                     <td><a href="#tickets/<?php echo $ticket->getId(); ?>/user"
                         onclick="javascript:
+                            $('#response').redactor('draft.saveDraft');
                             $.userLookup('ajax.php/tickets/<?php echo $ticket->getId(); ?>/user',
                                     function (user) {
                                         $('#user-'+user.id+'-name').text(user.name);

--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -348,6 +348,29 @@ var ticket_onload = function($) {
         return false;
     });
 
+    $(document).off('.inline-edit');
+    $(document).on('click.inline-edit', 'a.inline-edit', function(e) {
+        e.preventDefault();
+        var url = 'ajax.php/'
+        +$(this).attr('href').substr(1)
+        +'?_uid='+new Date().getTime();
+        var $options = $(this).data('dialog');
+        $.dialog(url, [201], function (xhr) {
+            var obj = $.parseJSON(xhr.responseText);
+            if (obj.id && obj.value) {
+                $('#field_'+obj.id).html(obj.value);
+                if (obj.value.includes('Empty'))
+                    $('#field_'+obj.id).addClass('faded');
+                else
+                    $('#field_'+obj.id).removeClass('faded');
+                $('#msg-txt').text(obj.msg);
+                $('div#msg_notice').show();
+            }
+        }, $options);
+
+        return false;
+    });
+
     $(document).on('change', 'form[name=reply] select#emailreply', function(e) {
          var $cc = $('form[name=reply] tbody#cc_sec');
         if($(this).val() == 0)


### PR DESCRIPTION
If an Agent uses inline edit to modify a single field, rather than saving the value and refreshing the page, the value will now populate in the form without having to refresh. This is useful in the event that an agent has begun writing a response to the user and does an inline edit before the draft has had a chance to save, causing them to lose their draft.

This fixes issue #4985.