### PR TITLE
Issue: Undefined Constant Warning

### DIFF
--- a/include/staff/tpl.inc.php
+++ b/include/staff/tpl.inc.php
@@ -1,7 +1,7 @@
 <?php
 $info=Format::htmlchars(($errors && $_POST)?$_POST:$_REQUEST);
 
-if (is_a($template, EmailTemplateGroup)) {
+if (is_a($template, 'EmailTemplateGroup')) {
     // New template implementation
     $id = 0;
     $tpl_id = $template->getId();


### PR DESCRIPTION
For the is_a function, the class name should be in quotation marks to avoid the warning in PHP 7.3