### PR TITLE
Export revisited

### DIFF
--- a/include/ajax.export.php
+++ b/include/ajax.export.php
@@ -16,7 +16,8 @@ class ExportAjaxAPI extends AjaxController {
                 Http::response(201, $this->json_encode([
                             'status' => 'ready',
                             'href' => sprintf('export.php?id=%s',
-                                $exporter->getId())]));
+                                $exporter->getId()),
+                            'filename' => $exporter->getFilename()]));
             else // Export is not ready... checkback in a few
                 Http::response(200, $this->json_encode([
                         'status' => 'notready']));

--- a/include/ajax.export.php
+++ b/include/ajax.export.php
@@ -1,0 +1,27 @@
+<?php
+require_once INCLUDE_DIR . 'class.export.php';
+
+class ExportAjaxAPI extends AjaxController {
+
+    function check($id) {
+        global $thisstaff;
+
+        if (!$thisstaff)
+            Http::response(403, 'Agent login is required');
+        elseif (!($exporter=Exporter::load($id)) || !$exporter->isAvailable())
+            Http::response(404, 'No such export');
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            if ($exporter->isReady())
+                Http::response(201, $this->json_encode([
+                            'status' => 'ready',
+                            'href' => sprintf('export.php?id=%s',
+                                $exporter->getId())]));
+            else // Export is not ready... checkback in a few
+                Http::response(200, $this->json_encode([
+                        'status' => 'notready']));
+        }
+
+        include STAFFINC_DIR . 'templates/export.tmpl.php';
+    }
+}

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1650,20 +1650,12 @@ function refer($tid, $target=null) {
                     'interval' => $interval];
                 // Create desired exporter
                 $exporter = new CsvExporter($options);
-                // Register the export in the session
-                Exporter::register($exporter);
-                // Flush response / return export id and check interval
-                Http::flush(201, $this->json_encode(['eid' =>
-                            $exporter->getId(), 'interval' => $interval]));
+                // Acknowledge the export
+                $exporter->ack();
                 // Phew... now we're free to do the export
-                session_write_close(); // Release session for other requests
-                ignore_user_abort(1);  // Leave us alone bro!
-                @set_time_limit(0);    // Useless when safe_mode is on
                 // Ask the queue to export to the exporter
                 $queue->export($exporter);
-                $exporter->close();
-                // Sleep 3 times the interval to allow time for file download
-                sleep($interval*3);
+                $exporter->finalize();
                 // Email the export if it exists
                 $exporter->email($thisstaff);
                 // Delete the file.

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1646,11 +1646,12 @@ function refer($tid, $target=null) {
 
             try {
                 $interval = 5;
+                $options = ['filename' => $filename,
+                    'interval' => $interval];
                 // Create desired exporter
-                $exporter = new CsvExporter();
+                $exporter = new CsvExporter($options);
                 // Register the export in the session
-                Exporter::register($exporter, ['filename' => $filename,
-                        'interval' => $interval]);
+                Exporter::register($exporter);
                 // Flush response / return export id and check interval
                 Http::flush(201, $this->json_encode(['eid' =>
                             $exporter->getId(), 'interval' => $interval]));

--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -105,7 +105,7 @@ extends InstrumentedList {
 
     function getId() { return $this->key['object_id']; }
     function getType() { return $this->key['type']; }
-
+    function getMimeType() { return $this->getType(); }
     /**
      * Drop attachments whose file_id values are not in the included list,
      * additionally, add new files whose IDs are in the list provided.

--- a/include/class.file.php
+++ b/include/class.file.php
@@ -996,4 +996,56 @@ class OneSixAttachments extends FileStorageBackend {
     }
 }
 FileStorageBackend::register('6', 'OneSixAttachments');
+
+// FileObject - wrapper for SplFileObject class
+class FileObject extends SplFileObject {
+
+    protected $_filename;
+
+    function __construct($file, $mode='r') {
+        parent::__construct($file, $mode);
+    }
+
+    /* This allows us to set REAL file name as opposed to basename of the
+     * FS file in question
+     */
+    function setFilename($filename) {
+        $this->_filename = $filename;
+    }
+
+    function getFilename() {
+        return $this->_filename ?: parent::getFilename();
+    }
+
+    /*
+     * Set mime type - well formated mime is expected.
+     */
+    function setMimeType($type) {
+        $this->_mimetype = $type;
+    }
+
+    function getMimeType() {
+        if (!isset($this->_mimetype)) {
+            // Try to to auto-detect mime type
+            $finfo = new finfo(FILEINFO_MIME);
+            $this->_mimetype = $finfo->buffer($this->getContents(),
+                    FILEINFO_MIME_TYPE);
+        }
+
+        return $this->_mimetype;
+    }
+
+    function getContents() {
+        $this->fseek(0);
+        return $this->fread($this->getSize());
+    }
+
+    /*
+     * XXX: Needed for mailer attachments interface
+     */
+    function getData() {
+        return $this->getContents();
+    }
+}
+
 ?>

--- a/include/class.file.php
+++ b/include/class.file.php
@@ -75,12 +75,12 @@ class AttachmentFile extends VerySimpleModel {
         return $this->type;
     }
 
-    function getBackend() {
-        return $this->bk;
+    function getMimeType() {
+        return $this->getType();
     }
 
-    function getMime() {
-        return $this->getType();
+    function getBackend() {
+        return $this->bk;
     }
 
     function getSize() {

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -42,6 +42,10 @@ class Format {
         return $size;
     }
 
+    function filename($filename) {
+        return preg_replace('/[^a-zA-Z0-9\-\._]/', '-', $filename);
+    }
+
     function mimedecode($text, $encoding='UTF-8') {
 
         if(function_exists('imap_mime_header_decode')

--- a/include/class.http.php
+++ b/include/class.http.php
@@ -49,6 +49,23 @@ class Http {
         }
     }
 
+    /*
+     *  Flush the content to requester without exiting
+     *
+     */
+    function flush($code, $content, $contentType='text/html', $charset='UTF-8') {
+        self::response($code, null, $contentType, $charset);
+        header('Cache-Control: no-cache, must-revalidate');
+        header('Content-Length: '.strlen($content)."\r\n\r\n");
+        print $content;
+        // Flush the request buffer
+        while(@ob_end_flush());
+        flush();
+        // Terminate the request
+        if (function_exists('fastcgi_finish_request'))
+            fastcgi_finish_request();
+    }
+
     function redirect($url,$delay=0,$msg='') {
 
         $iis = strpos($_SERVER['SERVER_SOFTWARE'], 'IIS') !== false;

--- a/include/staff/templates/export.tmpl.php
+++ b/include/staff/templates/export.tmpl.php
@@ -1,0 +1,70 @@
+<?php
+
+if (!$info[':title'])
+    $info[':title'] = __('Export');
+?>
+<h3 class="drag-handle"><?php echo $info[':title']; ?></h3>
+<b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
+<div class="clear"></div>
+<hr/>
+<?php
+if ($errors['err']) {
+    echo sprintf('<p id="msg_error">%s</p>', $info['error']);
+}
+
+$action = $info[':action'] ?: ('#');
+?>
+<div style="display:block; margin:5px;">
+<form method="get" name="export" id="exportchecker"
+    action="<?php echo $action; ?>">
+    <div>
+    <h3  style="color:#000;">
+    <i class="icon-spinner icon-spin icon-2x"></i>&nbsp;&nbsp;
+    <?php echo __('Please wait while we generate the export'); ?></h3>
+    </div>
+    <br>
+    <div style="margin-top:10px;">
+    <?php
+    echo sprintf(
+            __("We know you're busy, you can close this popup and the export will be sent to %s"),
+            $thisstaff->getEmail());
+    ?>
+    </div>
+    <hr>
+    <p class="full-width">
+        <span class="buttons pull-right">
+            <input type="button" name="cancel" class="close"
+            value="<?php echo __('Yes, Email Me'); ?>">
+        </span>
+     </p>
+</form>
+</div>
+<div class="clear"></div>
+<script>
++function() {
+    var $popup = $('.dialog#popup');
+    var interval = setInterval(function() {
+        $.ajax({
+            type: 'POST',
+            url: '<?php echo sprintf('ajax.php/export/%s/check',
+                    $exporter->getId()); ?>',
+            dataType: 'json',
+            cache: false,
+            success: function (resp, status, xhr)  {
+                if (xhr.status == 201) {
+                    clearInterval(interval);
+                    $('a.close', $popup).trigger('click');
+                    window.location.href = resp.href;
+                }
+            },
+            error: function (xhr) {
+                clearInterval(interval);
+            }
+        });
+    }, <?php echo ($exporter->getInterval()*1000); ?>);
+
+    $('input.close, a.close', $popup).on('click', function () {
+        clearInterval(interval);
+     });
+}();
+</script>

--- a/include/staff/templates/export.tmpl.php
+++ b/include/staff/templates/export.tmpl.php
@@ -54,7 +54,12 @@ $action = $info[':action'] ?: ('#');
                 if (xhr.status == 201) {
                     clearInterval(interval);
                     $('a.close', $popup).trigger('click');
-                    window.location.href = resp.href;
+                    var aElement = document.createElement('a');
+                    aElement.href = resp.href;
+                    aElement.target = '_blank';
+                    aElement.download = resp.filename;
+                    aElement.click();
+                    aElement.remove();
                 }
             },
             error: function (xhr) {

--- a/include/staff/templates/queue-export.tmpl.php
+++ b/include/staff/templates/queue-export.tmpl.php
@@ -24,7 +24,14 @@ if (isset($cache['fields']) && $fields)
 <h3 class="drag-handle"><?php echo Format::htmlchars($qname); ?></h3>
 <a class="close" href=""><i class="icon-remove-circle"></i></a>
 <hr/>
-<form action="#tickets/export/<?php echo $queue->getId(); ?>" method="post" name="export">
+<?php
+if (isset($errors['err'])) { ?>
+<div id="msg_error" class="error-banner"><?php echo
+Format::htmlchars($errors['err']); ?></div>
+<?php
+} ?>
+<form action="#tickets/export/<?php echo $queue->getId(); ?>" method="post"
+name="queue-export" id="queue-export">
   <div style="overflow-y: auto; height:400px; margin-bottom:5px;">
   <table class="table">
       <tbody>
@@ -127,6 +134,5 @@ if (isset($cache['fields']) && $fields)
         $('span#fields-count', f).html(<?php echo count($fields); ?>);
         $('div#save-changes', f).hide();
     });
-
 }();
 </script>

--- a/include/staff/templates/queue-tickets.tmpl.php
+++ b/include/staff/templates/queue-tickets.tmpl.php
@@ -278,23 +278,11 @@ foreach ($tickets as $T) {
 <?php
         echo __('Page').':'.$pageNav->getPageLinks().'&nbsp;';
         ?>
-        <a href="#tickets/export/<?php echo $queue->getId(); ?>" id="queue-export" class="no-pjax"
+        <a href="#tickets/export/<?php echo $queue->getId(); ?>"
+        id="queue-export" class="no-pjax export"
             ><?php echo __('Export'); ?></a>
         <i class="help-tip icon-question-sign" href="#export"></i>
     </div>
 <?php
     } ?>
 </form>
-<script type="text/javascript">
-$(function() {
-    $(document).on('click', 'a#queue-export', function(e) {
-        e.preventDefault();
-        var url = 'ajax.php/'+$(this).attr('href').substr(1)
-        $.dialog(url, 201, function (xhr) {
-            window.location.href = '?a=export&queue=<?php echo $queue->getId(); ?>';
-            return false;
-         });
-        return false;
-    });
-});
-</script>

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -230,6 +230,9 @@ $dispatcher = patterns('',
         url_post('^(?P<namespace>[\w.]+)$', 'createDraft'),
         url_get('^images/browse$', 'getFileList')
     )),
+    url('^/export/', patterns('ajax.export.php:ExportAjaxAPI',
+        url('^(?P<id>\w+)/check$', 'check')
+    )),
     url('^/note/', patterns('ajax.note.php:NoteAjaxAPI',
         url_get('^(?P<id>\d+)$', 'getNote'),
         url_post('^(?P<id>\d+)$', 'updateNote'),

--- a/scp/autocron.php
+++ b/scp/autocron.php
@@ -21,19 +21,11 @@ ignore_user_abort(1);//Leave me a lone bro!
 $data=sprintf ("%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%",
         71,73,70,56,57,97,1,0,1,0,128,255,0,192,192,192,0,0,0,33,249,4,1,0,0,0,0,44,0,0,0,0,1,0,1,0,0,2,2,68,1,0,59);
 
-header('Content-type:  image/gif');
-header('Cache-Control: no-cache, must-revalidate');
-header('Content-Length: '.strlen($data));
-header('Connection: Close');
-print $data;
-// Flush the request buffer
-while(@ob_end_flush());
-flush();
-//Terminate the request
-if (function_exists('fastcgi_finish_request'))
-    fastcgi_finish_request();
+// Flush the gif image
+Http::flush(201, $data, 'image/gif');
 
-ob_start(); //Keep the image output clean. Hide our dirt.
+// Keep the image output clean. Hide our dirt.
+ob_start();
 //TODO: Make cron DB based to allow for better time limits. Direct calls for now sucks big time.
 //We DON'T want to spawn cron on every page load...we record the lastcroncall on the session per user
 $sec=time()-$_SESSION['lastcroncall'];

--- a/scp/export.php
+++ b/scp/export.php
@@ -1,0 +1,26 @@
+<?php
+/*********************************************************************
+    export.php
+
+    Export downloader
+
+    Peter Rotich <peter@osticket.com>
+    Copyright (c)  2019 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+require('staff.inc.php');
+require_once(INCLUDE_DIR.'class.export.php');
+
+// Look up export by ID.
+if (!$_GET['id'] || !($export=Exporter::load($_GET['id'])))
+    Http::response(404, __('Unknown or invalid export'));
+elseif (!$export->isReady())
+     Http::response(416, __('Export is not ready yet'));
+
+$export->download();
+?>

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1045,6 +1045,19 @@ $.changeHash = function(hash, quiet) {
   }
 };
 
+// Exports
+$(document).on('click', 'a.export', function(e) {
+    e.preventDefault();
+    var url = 'ajax.php/'+$(this).attr('href').substr(1)
+    $.dialog(url, 201, function (xhr) {
+        var resp = $.parseJSON(xhr.responseText);
+        var checker = 'ajax.php/export/'+resp.eid+'/check';
+        $.dialog(checker, 201, function (xhr) { });
+        return false;
+     });
+    return false;
+});
+
 // Forms — submit, stay on same tab
 $(document).on('submit', 'form', function() {
     if (!!$(this).attr('action') && $(this).attr('action').indexOf('#') == -1)

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -501,13 +501,8 @@ if($ticket) {
 } else {
     $inc = 'templates/queue-tickets.tmpl.php';
     if ($_REQUEST['a']=='open' &&
-            $thisstaff->hasPerm(Ticket::PERM_CREATE, false))
+            $thisstaff->hasPerm(Ticket::PERM_CREATE, false)) {
         $inc = 'ticket-open.inc.php';
-    elseif ($_REQUEST['a'] == 'export' && $queue) {
-        // XXX: Check staff access?
-        if (!$queue->export())
-            $errors['err'] = __('Unable to export results.')
-                .' '.__('Internal error occurred');
     } elseif ($queue) {
         // XXX: Check staff access?
         $quick_filter = @$_REQUEST['filter'];


### PR DESCRIPTION
This PR reimplements #5000 - to make it modular and reusable.

The PR generally revisits how export is done by introducing the concept of `Exporter` with the goal of replacing SQL based exports which are prone to memory and timeout issues.

Export data can be downloaded (wait required) or emailed to the staff (for the impatient).

- Queue Export Modal - Fields Selection

<img width="986" alt="Screen Shot 2019-08-29 at 11 42 22 AM" src="https://user-images.githubusercontent.com/31067/63959808-a6700900-ca52-11e9-9b15-0878fa0dd6b2.png">

- Export Modal - Closing the popup  (even without clicking email me) will result in emailed report.

<img width="985" alt="Screen Shot 2019-08-29 at 11 45 01 AM" src="https://user-images.githubusercontent.com/31067/63959852-c6073180-ca52-11e9-9002-5478bba53924.png">








**Pending Items**
- [X]  Make sure export `id` and `prefix` are file safe.
- [ ]  Make email template more informative but simple.