### PR TITLE
Added REST API endpoints to further manage tickets, users, and organi…

### DIFF
--- a/api/api_tester.php
+++ b/api/api_tester.php
@@ -1,0 +1,126 @@
+<!DOCTYPE HTML>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>OS Ticket API tester</title>
+    </head>
+    <body>
+        <div>
+            <ol id='output'></ol>
+        </div>
+        <script>
+            var api='B2C040470AC3B3AD237272F9AEABF224';
+
+            function testApi(test, method, url, data) {
+                var msg='<h4>'+test+'</h4><p>'+method+' '+url+'</p><p>params:</p><pre><code>'+(data?JSON.stringify(data, null, 2):null)+'</code></pre>';
+                if(data && ['POST','PUT'].indexOf(method)==-1) {
+                    url=url+'?'+Object.keys(data).map(function(key) {return key + '=' + data[key]}).join('&');
+                    data=null;
+                }
+                else data=JSON.stringify(data);
+                var request = new XMLHttpRequest();
+                request.open(method, url, false);
+                request.setRequestHeader("X-API-Key", api);
+                request.send(data);
+                try {
+                    var dataOut=JSON.parse(request.responseText);
+                } catch (e) {
+                    if(request.responseText) console.log('invalid response', request.responseText);
+                    dataOut=null;
+                }
+                msg+='<p>Status: '+request.statusText+' ('+request.status+')</p><p>Response:</p><pre><code>'+JSON.stringify(dataOut, null, 2)+'</code></pre><br>';
+                var li = document.createElement("li");
+                li.innerHTML=msg;
+                document.getElementById('output').appendChild(li);
+                return dataOut;
+            }
+
+            function getOrgData(prefix) {
+                return {
+                    name: 'ABC Company'+(typeof prefix !== 'undefined'?'_'+prefix:''),
+                    address: '123 main street',
+                    phone: '4254441212X123',
+                    notes: 'Mynotes',
+                    website: 'website.com',
+                };
+            }
+            function getUserData(orgId, prefix) {
+                var userData= {
+                    email: 'John.Doe'+(typeof prefix !== 'undefined'?'_'+prefix:'')+'@gmail.com',
+                    phone: '(425) 444-1212 X123',
+                    notes: 'Some Notes',
+                    name: 'John Doe',
+                    password: 'thepassword',
+                    timezone: 'America/Los_Angeles',
+                };
+                if (typeof orgId !== 'undefined') {
+                    userData.org_id=orgId;
+                }
+                return userData
+            }
+            function getTicketData(user, type) {
+                var ticketData={
+                    message: "My original message",
+                    //message: "data:text/html, My original message",
+                    name: user.name,
+                    subject: "Testing API",
+                    topicId: 2,
+                };
+                if (type='id') {
+                    ticketData.userId=user.id;
+                }
+                else {
+                    ticketData.email=user.email;
+                }
+                return ticketData
+            }
+
+            //Test endpoints
+            var org1=testApi('Create organization', 'POST', '/api/scp/organizations.json', getOrgData());
+            testApi('Create organization with existing name', 'POST', '/api/scp/organizations.json', getOrgData());
+            testApi('Get organization', 'GET', '/api/scp/organizations.json/'+org1.id);
+            var user1=testApi('Create user', 'POST', '/api/scp/users.json', getUserData(org1.id));
+            testApi('Create user with existing email', 'POST', '/api/scp/users.json', getUserData(org1.id));
+            var user2=testApi('Create second user', 'POST', '/api/scp/users.json', getUserData(org1.id, 2));
+            testApi('Get organization users', 'GET', '/api/scp/organizations.json/users/'+org1.id);
+            testApi('Delete organization and delete users', 'DELETE', '/api/scp/organizations.json/'+org1.id, {deleteUsers: 1});
+            testApi('Delete organization with invalid ID', 'DELETE', '/api/scp/organizations.json/'+org1.id);
+            testApi('Get user with invalid ID', 'GET', '/api/scp/users.json/'+user1.id);
+            testApi('Delete user with invalid ID', 'DELETE', '/api/scp/users.json/'+user1.id);
+
+            var user3=testApi('Create user without an organization', 'POST', '/api/scp/users.json', getUserData());
+            testApi('Delete user', 'DELETE', '/api/scp/users.json/'+user3.id);
+
+            var org2=testApi('Create organization', 'POST', '/api/scp/organizations.json', getOrgData());
+            var user4=testApi('Create user', 'POST', '/api/scp/users.json', getUserData(org2.id));
+            testApi('Delete organization but do not delete users', 'DELETE', '/api/scp/organizations.json/'+org2.id);
+            testApi('Get organization with invalid ID', 'GET', '/api/scp/organizations.json/'+org2.id);
+            testApi('Get user', 'GET', '/api/scp/users.json/'+user4.id);
+
+            var ticket1=testApi('Create Ticket using user email', 'POST', '/api/tickets.json', getTicketData(user4, 'email'));
+            var ticket2=testApi('Create Ticket using user ID', 'POST', '/api/tickets.json', getTicketData(user4, 'id'));
+            testApi('Create Ticket using invalid user email', 'POST', '/api/tickets.json', getTicketData(user2, 'email'));
+            testApi('Create Ticket using invalid user ID', 'POST', '/api/tickets.json', getTicketData(user2, 'id'));
+
+            testApi('Close Ticket using user email', 'DELETE', '/api/tickets.json/'+ticket1.id, {email: user4.email});
+            testApi('Reopen Ticket using user email', 'POST', '/api/tickets.json/'+ticket1.id, {email: user4.email});
+
+            testApi('Close Ticket using user ID', 'DELETE', '/api/tickets.json/'+ticket1.id, {userId: user4.id});
+            testApi('Reopen Ticket using user ID', 'POST', '/api/tickets.json/'+ticket1.id, {userId: user4.id});
+
+            testApi('Update Ticket using user email', 'PUT', '/api/tickets.json/'+ticket1.id, {email: user4.email, "message": "My updated message using email"});
+            testApi('Update Ticket using user ID', 'PUT', '/api/tickets.json/'+ticket1.id, {userId: user4.id, "message": "My updated message using userId"});
+            testApi('Update Ticket using invalid user email', 'PUT', '/api/tickets.json/'+ticket1.id, {email: user2.email, "message": "My updated message using email"});
+            testApi('Update Ticket using invalid user user ID', 'PUT', '/api/tickets.json/'+ticket1.id, {userId: user2.id, "message": "My updated message using userId"});
+
+            testApi('Get Tickets using user email', 'GET', '/api/tickets.json', {email: user4.email});
+            testApi('Get Tickets using user ID', 'GET', '/api/tickets.json', {userId: user4.id});
+            testApi('Get Ticket', 'GET', '/api/tickets.json/'+ticket1.id);
+
+            testApi('Delete user', 'DELETE', '/api/scp/users.json/'+user4.id);
+            testApi('Get Ticket with invalid ID', 'GET', '/api/tickets.json/'+ticket1.id);
+
+            testApi('Get Topics', 'GET', '/api/topics.json');
+        </script>
+    </body>
+</html>

--- a/api/http.php
+++ b/api/http.php
@@ -24,6 +24,28 @@ require_once INCLUDE_DIR."class.dispatcher.php";
 
 $dispatcher = patterns('',
         url_post("^/tickets\.(?P<format>xml|json|email)$", array('api.tickets.php:TicketApiController','create')),
+
+        //Added Ticket Endpoints
+        url_get("^/tickets\.(?P<format>xml|json)/(?P<tid>\d+)$", array('api.tickets.php:TicketApiController','getTicket')),  //Do first!
+        url_get("^/tickets\.(?P<format>xml|json)", array('api.tickets.php:TicketApiController','getTickets')),
+        url_post("^/tickets\.(?P<format>xml|json)/(?P<tid>\d+)$", array('api.tickets.php:TicketApiController','reopenTicket')),
+        url_put("^/tickets\.(?P<format>xml|json)/(?P<tid>\d+)$", array('api.tickets.php:TicketApiController','updateTicket')),
+        url_delete("^/tickets\.(?P<format>xml|json)/(?P<tid>\d+)$", array('api.tickets.php:TicketApiController','closeTicket')),
+
+        //Added Topics Endpoints
+        url_get("^/topics\.(?P<format>xml|json)", array('api.tickets.php:TicketApiController','getTopics')),
+
+        //Added User Endpoints
+        url_get("^/scp/users\.(?P<format>xml|json)/(?P<uid>\d+)$", array('api.users.php:UserApiController','get')),
+        url_post("^/scp/users\.(?P<format>xml|json)$", array('api.users.php:UserApiController','create')),
+        url_delete("^/scp/users\.(?P<format>xml|json)/(?P<uid>\d+)$", array('api.users.php:UserApiController','delete')),
+
+        //Added Organization Endpoints
+        url_get("^/scp/organizations\.(?P<format>xml|json)/(?P<uid>\d+)$", array('api.organizations.php:OrganizationApiController','get')),
+        url_post("^/scp/organizations\.(?P<format>xml|json)$", array('api.organizations.php:OrganizationApiController','create')),
+        url_delete("^/scp/organizations\.(?P<format>xml|json)/(?P<uid>\d+)$", array('api.organizations.php:OrganizationApiController','delete')),
+        url_get("^/scp/organizations\.(?P<format>xml|json)/users/(?P<uid>\d+)$", array('api.organizations.php:OrganizationApiController','getUsers')),
+
         url('^/tasks/', patterns('',
                 url_post("^cron$", array('api.cron.php:CronApiController', 'execute'))
          ))
@@ -31,6 +53,11 @@ $dispatcher = patterns('',
 
 Signal::send('api', $dispatcher);
 
+//Change to only add staff for /scp API endpoints.  Needed to change ticket status so that user can be deleted.
+//Need to change this approach as it change's the user's session!
+$thisstaff = new ApiUser();
+
 # Call the respective function
 print $dispatcher->resolve($ost->get_path_info());
+
 ?>

--- a/include/api.organizations.php
+++ b/include/api.organizations.php
@@ -1,0 +1,73 @@
+<?php
+include_once INCLUDE_DIR.'class.api.php';
+include_once INCLUDE_DIR.'class.organization.php';
+class OrganizationApiController extends ApiController {
+
+    # Copied from TicketApiController.  Not fully implemented
+    function getRequestStructure($format, $data=null) {
+        return ['name','address','phone','website','notes'];
+    }
+    # Copied from TicketApiController.  Not implemented
+    function validate(&$data, $format, $strict=true) {
+        //Add as applicable.
+        return true;
+    }
+
+    public function get($format, $oid) {
+        if(!($key=$this->requireApiKey()) || !$key->canViewUser())
+            return $this->exerr(401, __('API key not authorized'));
+        if(!$org = Organization::lookup($oid))
+            return $this->exerr(400, __("Organization ID '$oid' does not exist"));
+        Http::response(200, $org->to_json(), 'application/json');
+        //$this->response(200, json_encode($org->getOrganizationApiEntity()));
+    }
+
+    public function create($format) {
+        if(!($key=$this->requireApiKey()) || !$key->canAddOrganization())
+            return $this->exerr(401, __('API key not authorized'));
+
+        $params = $this->getRequest($format);
+        $params=array_merge(array_fill_keys(['address','phone','website','notes'],null), $params);  //Optional properties
+        $params=array_intersect_key($params, array_flip($this->getRequestStructure($format)));      //Strip off unused properties
+        if ($missing=array_diff($this->getRequestStructure($format), array_keys($params))) {
+            return $this->exerr(400, __('Missing parameters '.implode(', ', $missing)));
+        }
+        if(Organization::lookup(['name'=>$params['name']])) {
+            return $this->exerr(400, __("Organization name '$params[name]' is already in use"));
+        }
+
+        if(!$org=Organization::fromVars($params)) {
+            return $this->exerr(400, __('Unknown organization creation error'));
+        }
+        Http::response(201, $org->to_json(), 'application/json');
+        //$this->response(201, json_encode($org->getOrgApiEntity()));
+    }
+
+    public function delete($format, $oid) {
+        if(!($key=$this->requireApiKey()) || !$key->canDeleteOrganization())
+            return $this->exerr(401, __('API key not authorized'));
+        // Organization::objects()->filter(['id__in' => [$oid]])
+        if(!$org = Organization::lookup($oid))
+            return $this->exerr(422, __("Organization ID '$oid' does not exist"));
+        if(!empty($_GET['deleteUsers'])) {  //delete users before deleting organization
+            foreach ($org->allMembers() as $user) {
+                $user->delete();
+            }
+        }
+        if(!$org->delete()){
+            return $this->exerr(500, __('Error deleting organization'));
+        }
+        $this->response(204, null);
+    }
+
+    public function getUsers($format, $oid) {
+        if(!($key=$this->requireApiKey()) || !$key->canViewOrganization())
+            return $this->exerr(401, __('API key not authorized'));
+        if(!$org = Organization::lookup($oid))
+            return $this->exerr(400, __("Organization ID '$oid' does not exist"));
+        foreach ($org->allMembers() as $user) {
+            $users[]=$user->getUserApiEntity();
+        }
+        $this->response(200, json_encode($users));
+    }
+}

--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -53,7 +53,7 @@ class TicketApiController extends ApiController {
 
             $supported['attachments']['*'][] = 'cid';
         }
-
+        $supported[]='userId';  //Just done to supress log warnings.  Figure out the "right" way to do this.
         return $supported;
     }
 
@@ -101,7 +101,7 @@ class TicketApiController extends ApiController {
     }
 
 
-    function create($format) {
+    public function create($format) {
 
         if(!($key=$this->requireApiKey()) || !$key->canCreateTickets())
             return $this->exerr(401, __('API key not authorized'));
@@ -112,13 +112,121 @@ class TicketApiController extends ApiController {
             $ticket = $this->processEmail();
         } else {
             # Parse request body
-            $ticket = $this->createTicket($this->getRequest($format));
+            $params=$this->getRequest($format);
+            if(empty($params['email'])) {
+                $user=$this->getUser($params);
+                $params['email']=$user->getEmail();
+                unset($params['userId']);
+            }
+            $ticket = $this->createTicket(array_merge($params, ['source'=>'api']));
         }
 
         if(!$ticket)
             return $this->exerr(500, __("Unable to create new ticket: unknown error"));
 
-        $this->response(201, $ticket->getNumber());
+        $this->response(201, json_encode($ticket->getTicketApiEntity()));
+    }
+
+    ######  Added Methods ############
+    //All methods assume dispatcher validates arguments as integers and handles errors (i.e. (?P<tid>\d+) ).
+    //Most tickets require userId or email in parameters (not necessarily for authentication, but to log who made a change)
+    //TBD whether camelcase or underscore property names are desired by osTicket.
+
+    public function getTickets($format) {
+        //Future:  Allow for optional filtering for name and topic ID
+        if(!($key=$this->requireApiKey()) || !$key->canViewTickets())
+            return $this->exerr(401, __('API key not authorized'));
+        $filter=['user_id' => isset($_GET['userId'])?$_GET['userId']:$this->getUser($_GET)->getId()];
+        if(isset($_GET['status_id'])) {
+            $filter['status_id']=$_GET['status_id'];
+        }
+        $tickets = [];
+        foreach(Ticket::objects()->filter($filter)->all() as $ticket) {
+            $tickets[]=$ticket->getTicketApiEntity();
+        }
+        $this->response(200, json_encode($tickets));
+    }
+
+    public function getTicket($format, $tid) {
+        //This API request does not need to provide user identifier.
+        if(!($key=$this->requireApiKey()) || !$key->canViewTickets())
+            return $this->exerr(401, __('API key not authorized'));
+        $this->response(200, json_encode($this->getByTicketId($tid)->getTicketApiEntity()));
+    }
+
+    public function closeTicket($format, $tid) {
+        if(!($key=$this->requireApiKey()) || !$key->canCloseTickets())
+            return $this->exerr(401, __('API key not authorized'));
+        $ticket = $this->getByTicketId($tid);
+        //$ticket->setStatusId(3);
+        //$currentStatus=$ticket->getStatus();
+        $status= TicketStatus::lookup(3);
+        $errors=[];//passed by reference
+        $ticket->setStatus($status, 'Closed by user', $errors);
+        $this->response(204, null);
+    }
+    public function reopenTicket($format, $tid) {
+        if(!($key=$this->requireApiKey()) || !$key->canReopenTickets())
+            return $this->exerr(401, __('API key not authorized'));
+        $ticket = $this->getByTicketId($tid);
+        $ticket->reopen();
+        $this->response(200, json_encode($ticket->getTicketApiEntity()));
+    }
+    public function updateTicket($format, $tid) {
+        if(!($key=$this->requireApiKey()) || !$key->canUpdateTickets())
+            return $this->exerr(401, __('API key not authorized'));
+        $params = $this->getRequest($format);
+        $user=$this->getUser($params);
+        $ticket = $this->getByTicketId($tid, $user);
+        $vars=[
+            'message'=>$params['message'],
+            'userId'=>$user->getId(),
+            'poster'=>$user->getFullName(),
+            'ip_address'=>$_SERVER['REMOTE_ADDR'] //Use web client's IP
+        ];
+        $response = $ticket->postMessage($vars, 'api');//Ticket::postMessage($vars, $origin='', $alerts=true)
+        $this->response(200, json_encode($ticket->getTicketApiEntity()));
+    }
+    public function getTopics($format) {
+        //This API request does not need to provide user identifier.
+        if(!($key=$this->requireApiKey()) || !$key->canViewTopics())
+            return $this->exerr(401, __('API key not authorized'));
+        $this->response(200, json_encode($this->createList(Topic::getPublicHelpTopics(), 'id', 'value')));
+    }
+    // Private methods to support new api methods.  Verify if existing osTicket methods should be used instead.
+    private function getByTicketId($ticketId) {
+        if(!$pk=Ticket::getIdByNumber($ticketId))
+            return $this->exerr(400, __("Ticket Number '$ticketId' does not exist"));
+        return $this->getByPrimaryId($pk);
+    }
+    private function getByPrimaryId($pk) {
+        if(!$ticket = Ticket::lookup($pk))
+            return $this->exerr(400, __("Ticket ID '$pk' does not exist"));
+        return $ticket;
+    }
+    private function getUser($params=[]) {
+        //userId or email must be provided in request parameters
+        if(!empty($params['userId'])){
+            if(!$user = TicketUser::lookupById($params['userId'])) {
+                return $this->exerr(400, __("Invalid user.  User ID does not exist."));
+            }
+        }
+        elseif(!empty($params['email'])){
+            if(!$user = TicketUser::lookupByEmail($params['email'])) {
+                return $this->exerr(400, __("Invalid user.  User email does not exist."));
+            }
+        }
+        else {
+            return $this->exerr(400, __("Either user ID or email must be provided in request"));
+        }
+        return $user;
+    }
+    private function createList($items, $idName, $valueName) {
+        $list=[];
+        foreach($items as $key=>$value) {
+            $list[]=[$idName=>$key, $valueName=>$value];
+        }
+        return $list;
     }
 
     /* private helper functions */

--- a/include/api.users.php
+++ b/include/api.users.php
@@ -1,0 +1,65 @@
+<?php
+include_once INCLUDE_DIR.'class.api.php';
+include_once INCLUDE_DIR.'class.user.php';
+class UserApiController extends ApiController {
+
+    # Copied from TicketApiController.  Not fully implemented
+    function getRequestStructure($format, $data=null) {
+        return ["email", "name", "org_id", "phone", "notes", "password", "timezone"];
+    }
+    # Copied from TicketApiController.  Not implemented
+    function validate(&$data, $format, $strict=true) {
+        //Add as applicable.
+        return true;
+    }
+
+    public function get($format, $uid) {
+        if(!($key=$this->requireApiKey()) || !$key->canViewUser())
+            return $this->exerr(401, __('API key not authorized'));
+        if(!$user = User::lookup($uid))
+            return $this->exerr(400, __("User ID '$uid' does not exist"));
+        //$this->response(200, $user->toJson());
+        $this->response(200, json_encode($user->getUserApiEntity()));
+    }
+
+    public function create($format) {
+        //see ajax.users.php addUser() and class.api.php for example
+        if(!($key=$this->requireApiKey()) || !$key->canAddUser())
+            return $this->exerr(401, __('API key not authorized'));
+        $params = $this->getRequest($format);
+        $params=array_merge(array_fill_keys(["org_id", "phone", "notes", "timezone"],null), $params);  //Optional properties
+        $params=array_intersect_key($params, array_flip($this->getRequestStructure($format)));      //Strip off unused properties
+        if ($missing=array_diff($this->getRequestStructure($format), array_keys($params))) {
+            return $this->exerr(400, __('Missing parameters '.implode(', ', $missing)));
+        }
+
+        if (!filter_var($params['email'], FILTER_VALIDATE_EMAIL)) {
+            return $this->exerr(400, __("Invalid email: $params[email]"));
+        }
+        if(User::lookup(['emails__address'=>$params['email']])) {
+            return $this->exerr(400, __("Email $params[email] is already in use"));
+        }
+        if(!$user=User::fromVars($params)) {
+            return $this->exerr(400, __('Unknown user creation error'));
+        }
+        $errors=[];
+        $params=array_merge($params,['username'=>$params['email'],'passwd1'=>$params['password'],'passwd2'=>$params['password'],'timezone'=>$params['timezone']]);
+        if(!$user->register($params, $errors)) {
+            return $this->exerr(400, __('User added but error attempting to register'));
+        }
+        $this->response(201, json_encode($user->getUserApiEntity()));
+        //$this->response(201, $user->to_json());
+    }
+
+    public function delete($format, $uid) {
+        if(!($key=$this->requireApiKey()) || !$key->canDeleteUser())
+            return $this->exerr(401, __('API key not authorized'));
+        if(!$user = User::lookup($uid))
+            return $this->exerr(400, __("User ID '$uid' does not exist"));
+        $user->deleteAllTickets();
+        if(!$user->delete()){
+            return $this->exerr(500, __('Error deleting user'));
+        }
+        $this->response(204, null);
+    }
+}

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -71,6 +71,44 @@ class API {
         return ($this->ht['can_create_tickets']);
     }
 
+    //Potentially future add ability to configure in gui.
+    function canViewTickets() {
+        return true;
+    }
+    function canUpdateTickets() {
+        return $this->canCreateTickets();
+    }
+    function canCloseTickets() {
+        return $this->canCreateTickets();
+    }
+    function canReopenTickets() {
+        return $this->canCreateTickets();
+    }
+    function canPostReplyToTickets() {
+        return $this->canCreateTickets();
+    }
+    function canViewTopics() {
+        return true;
+    }
+    function canViewUser() {
+        return true;
+    }
+    function canAddUser() {
+        return true;
+    }
+    function canDeleteUser() {
+        return true;
+    }
+    function canViewOrganization() {
+        return true;
+    }
+    function canAddOrganization() {
+        return true;
+    }
+    function canDeleteOrganization() {
+        return true;
+    }
+
     function canExecuteCron() {
         return ($this->ht['can_exec_cron']);
     }
@@ -381,7 +419,7 @@ class ApiXmlDataParser extends XmlDataParser {
 
 include_once "class.json.php";
 class ApiJsonDataParser extends JsonDataParser {
-    function parse($stream, $tidy=false) {
+    function parse($stream) {
         return $this->fixup(parent::parse($stream));
     }
     function fixup($current) {
@@ -448,6 +486,17 @@ class ApiEmailDataParser extends EmailDataParser {
             unset($data['priorityId']);
 
         return $data;
+    }
+}
+
+class ApiUser extends Staff {   //StaffSession
+    //StaffSession has additional methods: isValid, refreshSession, getSession, getSessionToken, getIP
+    function getRole($dept=null, $assigned=false) {
+        if(!$this->role) {
+            $roles=array_fill_keys(['ticket.create','ticket.delete','ticket.edit','user.create','user.delete','user.edit'],1);    //['user.create','user.delete','user.edit','user.manage','user.dir','org.create','org.delete','org.edit','faq.manage','emails.banlist']
+            $this->role = new Role(['permissions'=>json_encode($roles)]);
+        }
+        return $this->role;
     }
 }
 ?>

--- a/include/class.client.php
+++ b/include/class.client.php
@@ -129,6 +129,12 @@ implements EmailContact, ITicketUser, TemplateVariable {
         return new EndUser($user);
     }
 
+    static function lookupById($id) {
+        if (!($user=User::lookup(array('id' => $id))))
+            return null;
+        return new EndUser($user);
+    }
+
     function isOwner() {
         return $this instanceof TicketOwner;
     }

--- a/include/class.dispatcher.php
+++ b/include/class.dispatcher.php
@@ -193,4 +193,8 @@ function url_get($regex, $func, $args=false) {
 function url_delete($regex, $func, $args=false) {
     return url($regex, $func, $args, "DELETE");
 }
+
+function url_put($regex, $func, $args=false) {
+    return url($regex, $func, $args, "PUT");
+}
 ?>

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1743,6 +1743,42 @@ implements TemplateVariable {
     static function getTypes() {
         return self::$types;
     }
+
+    public function getThreadApiEntity() {
+        //Change this to utilize the "osticket" way of doing so
+        $name=$this->getPoster();
+        if($uId=$this->getUserId()) {
+            $user=['type'=>'user','id'=>$id,'name'=>$name];
+        }
+        elseif($uId=$this->getStaffId()){
+            $user=['type'=>'staff','id'=>$id,'name'=>$name];
+        }
+        elseif($name='SYSTEM'){
+            $user=['type'=>'system','id'=>null,'name'=>null];
+        }
+        else {
+            $user=['type'=>'unknown','id'=>null,'name'=>$name];
+        }
+        return [
+            "id" => $this->getId(),
+            "pid" => $this->getPid(),
+            "thread_id" => $this->getThreadId(),
+            "type" => $this->getType(),
+            "typeName" => $this->getTypeName(),
+            "editor" => $this-> getEditor(),
+            "source" => $this-> getSource(),
+            "format" => $this-> format,
+            "title" => $this->getTitle(),
+            "message"=> $this->getBody()->getClean(),
+            //"message"=>$this->getMessage(),
+            "attachmentUrls"=>$this->getAttachmentUrls(),
+            "timestamps"=>[
+                "created"=> $this->created ,
+                "updated" => $this->updated,
+            ],
+            "user"=>$user,
+        ];
+    }
 }
 
 RolePermission::register(/* @trans */ 'Tickets', ThreadEntry::getPermissions());

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4299,6 +4299,44 @@ EOF;
             }
         }
     }
+
+    public function getTicketApiEntity() {
+        //Change this to utilize the "osticket" way of doing so.
+        $threads = $this->getThreadEntries(['M', 'R', 'N']); //Message, Response, Note
+        $thread_entries = [];
+        foreach ($threads as $thread) {
+            $thread_entries[]=$thread->getThreadApiEntity();
+        }
+        //How should attachments be included in thread?
+        $topic=$this->getTopic();
+        $status=$this->getStatus();
+        $priority=$this->getPriority();
+        return [
+            'id' => $this->getNumber(),
+            'subject' => $this->getSubject(),
+            'topic' => ['id' => $topic->getId(), 'name' => $topic->getName()],
+            'status' => ['id' => $status->getId(), 'name' => $status->getName()],
+            'priority' => ['id' => $priority->getId(), 'name' => $priority->getTag()],
+            'department' => $this->getDeptName(),
+            'timestamps' => [
+                'create' => $this->getCreateDate(),
+                'due' => $this->getEstDueDate(),
+                'close' => $this->getCloseDate(),
+                'last_message' => $this->getLastMsgDate(),
+                'last_response' => $this->getLastRespDate(),
+            ],
+            'user' => [
+                'fullname'=>$this->getName()->getFull(),
+                'firstname'=>$this->getName()->getFirst(),
+                'lastname'=>$this->getName()->getLast(),
+                'email'=>$this->getEmail()->email,
+                'phone'=>$this->getPhoneNumber(),
+            ],
+            'source' => $this->getSource(),
+            'assigned_to' => $this->getAssignees(),
+            'threads' =>$thread_entries
+        ];
+    }
 }
 RolePermission::register(/* @trans */ 'Tickets', Ticket::getPermissions(), true);
 

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -351,6 +351,17 @@ implements TemplateVariable, Searchable {
             return $acct->getLanguage($flags);
     }
 
+    public function getUserApiEntity() {
+        //Add additional properties such as timezone,
+        //Change this to utilize the "osticket" way of doing so.  to_json() would work, but doesn't have enough properties.
+        return [
+            'id'  => $this->getId(),
+            'name' => Format::htmlchars($this->getName()),
+            'email' => (string) $this->getEmail(),
+            'phone' => (string) $this->getPhoneNumber()
+        ];
+    }
+
     function to_json() {
 
         $info = array(


### PR DESCRIPTION
Hi,

I plan on using osTicket as is for the scp admin side, but end users will submit their help requests directly from another app which will be added via the REST API.  In addition to just posting a ticket via the API, endpoints to view tickets, delete them, etc were added.  Also, to eliminate needing to add users and organizations in both the other app and osTicket, endpoints to do so were added to the osTicket API.

There were several which might work, but did not use the "osTicket way of doing things", and should be changed to do so.  I tried to comment these cases.

The api/api_tester.php file can be deleted and was just used to test the various endpoints.

I've never created a pull request and would appreciate hearing from you if it was received.

Thanks for creating osTicket!