### PR TITLE
issue: Department Referral Email

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -564,6 +564,11 @@ implements Searchable {
             $vars['thread-type'] = 'M';
         }
 
+        if ($mailinfo['system_emails']
+                && ($t = $this->getObject())
+                && $t instanceof Ticket)
+            $t->systemReferral($mailinfo['system_emails']);
+
         switch ($vars['thread-type']) {
         case 'M':
             $vars['message'] = $body;


### PR DESCRIPTION
This addresses an issue where a User sending an email message with a different Department as CC to the system will not refer the CC'ed Department until the email is fetched a second time. The old thinking was that since the User CC'ed the other Department the other Department should receive a copy of the email in their mailbox. When the system fetches the User's message from the original Department email it gets added to the thread but doesn't refer just yet. When the system fetches the copy of the message from the User in the other Department's email it will then refer the other Department. This is a problem especially when you are not fetching or forwarding from the other Department's email address. This updates `Thread::postEmail()` to include the check for `$mailinfo['system_emails']` and if set we refer the Department immediately.