### PR TITLE
Issue: Annul Closed Events

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1358,7 +1358,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 $this->clearOverdue(false);
 
                 $ecb = function($t) use ($status) {
-                    $t->logEvent('closed', array('status' => array($status->getId(), $status->getName())));
+                    $t->logEvent('closed', array('status' => array($status->getId(), $status->getName())), null, 'closed');
                     $t->deleteDrafts();
                 };
                 break;


### PR DESCRIPTION
This commit fixes an issue where if you were to change a Ticket to the Resolved status and then to Closed, the dashboard statistics would show that you had closed 2 Tickets even though both events were done on the same Ticket.

We should only count one closed event per Ticket.

This was reported in Issue #5018.