### PR TITLE
Custom Priority Field Blank

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2972,10 +2972,14 @@ class PriorityField extends ChoiceField {
         return $this->getPriority($id);
     }
 
-    function to_database($prio) {
-        return ($prio instanceof Priority)
-            ? array($prio->getDesc(), $prio->getId())
-            : array($prio[key($prio)],key($prio));
+    function to_database($value) {
+        if ($value instanceof Priority)
+            return array($value->getDesc(), $value->getId());
+
+        if (is_array($value))
+            return array(current($value), key($value));
+
+        return $value;
     }
 
     function display($prio, &$styles=null) {


### PR DESCRIPTION
If no value is saved to a custom Priority field, we need to make sure we don't try to treat a null value as an array. We should instead just return the null priority.