### PR TITLE
issue: Ticket Filter Assignment Event

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2708,7 +2708,7 @@ implements RestrictedAccess, Threadable, Searchable {
         return $this->assignToStaff($assignee, $form->getComments(), false);
     }
 
-    function assignToStaff($staff, $note, $alert=true) {
+    function assignToStaff($staff, $note, $alert=true, $user=null) {
 
         if(!is_object($staff) && !($staff = Staff::lookup($staff)))
             return false;
@@ -2725,12 +2725,12 @@ implements RestrictedAccess, Threadable, Searchable {
         else
             $data['staff'] = $staff->getId();
 
-        $this->logEvent('assigned', $data);
+        $this->logEvent('assigned', $data, $user);
 
         return true;
     }
 
-    function assignToTeam($team, $note, $alert=true) {
+    function assignToTeam($team, $note, $alert=true, $user=null) {
 
         if(!is_object($team) && !($team = Team::lookup($team)))
             return false;
@@ -2744,7 +2744,7 @@ implements RestrictedAccess, Threadable, Searchable {
             $this->setStaffId(0);
 
         $this->onAssign($team, $note, $alert);
-        $this->logEvent('assigned', array('team' => $team->getId()));
+        $this->logEvent('assigned', array('team' => $team->getId()), $user);
 
         return true;
     }
@@ -4330,11 +4330,12 @@ implements RestrictedAccess, Threadable, Searchable {
             else {
                 // Auto assign staff or team - auto assignment based on filter
                 // rules. Both team and staff can be assigned
+                $username = __('Ticket Filter');
                 if ($vars['staffId'])
-                     $ticket->assignToStaff($vars['staffId'], false);
+                     $ticket->assignToStaff($vars['staffId'], false, true, $username);
                 if ($vars['teamId'])
                     // No team alert if also assigned to an individual agent
-                    $ticket->assignToTeam($vars['teamId'], false, !$vars['staffId']);
+                    $ticket->assignToTeam($vars['teamId'], false, !$vars['staffId'], $username);
             }
         }
 


### PR DESCRIPTION
This addresses #5035 where the ticket Assignment Event show the Ticket Owner's name or "SYSTEM" as the assigner when tickets are created via Client Portal, API, or Email Fetching. This updates the event to include "Ticket Filter" as the assigner if the assignment was triggered by a Ticket Filter Action. This makes for more accurate events and is very useful for statistics/debugging. This keeps current functionality of Agents creating tickets shows the creating Agent's name as the assigner. This also adds a new parameter to `assignToAgent()` and `assignToTeam()` called `$user` (defaults to null) that allows us to pass different usernames/user objects for the events. This makes the two methods versatile so if we add new ways to assign to Staff/Teams in the future we can pass the new name/object with no issues.