### PR TITLE
European Date Format Issue

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -608,6 +608,7 @@ $.translate_format = function(str) {
         'yyyy': '`',
         'yyy':  '`',
         'yy':   'y',
+        'y':    'yy',
         '`':    'yy'
     };
     // Change PHP formats to datepicker ones


### PR DESCRIPTION
This commit fixes an issue where if your date format is dd/MM/y h:mm a, the date picker will show the wrong year because the dates were not translating correctly between PHP and JS.