### PR TITLE
Upgrader Issue: Ticket Flags

### DIFF
--- a/include/upgrader/streams/core/8b923d61-9b5550da.patch.sql
+++ b/include/upgrader/streams/core/8b923d61-9b5550da.patch.sql
@@ -7,13 +7,29 @@
 *
 */
 
--- Add ticket_pid column to tickets
-ALTER TABLE `%TABLE_PREFIX%ticket`
-    ADD `ticket_pid` int(11) unsigned DEFAULT NULL AFTER `ticket_id`;
+-- At some point, a flags field was added to the Ticket table in the
+-- installer, but it was never added to a patch, so for some people
+-- that try to upgrade, they get an error that says it is unable to add
+-- the sort field after flags in the ticket table.
+-- Since MySQL has no concept of `ADD COLUMN IF NOT EXISTS`, this
+-- dynamic query will assist with adding the column if it doesn't exist.
+SET @s = (SELECT IF(
+    (SELECT COUNT(*)
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = '%TABLE_PREFIX%ticket'
+        AND table_schema = DATABASE()
+        AND column_name = 'flags'
+    ) > 0,
+    "SELECT 1",
+    "ALTER TABLE `%TABLE_PREFIX%ticket` ADD `flags` int(11) unsigned NOT NULL default '0' AFTER `lock_id`"
+));
+PREPARE stmt FROM @s;
+EXECUTE stmt;
 
--- Add sort column to tickets
+-- Add sort and ticket_pid column to tickets
 ALTER TABLE `%TABLE_PREFIX%ticket`
-    ADD `sort` int(11) unsigned NOT NULL DEFAULT '0' AFTER `flags`;
+    ADD `sort` int(11) unsigned NOT NULL DEFAULT '0' AFTER `flags`,
+    ADD `ticket_pid` int(11) unsigned DEFAULT NULL AFTER `ticket_id`;
 
 -- Add extra column to thread entries
 ALTER TABLE `%TABLE_PREFIX%thread_entry`


### PR DESCRIPTION
This commit fixes an issue where the flags field was added to the Ticket table in the installer, but it was never added to the upgrader, so when trying to add a column after the flags field, there would be an error for people whose install was done before the flags field was introduced to the installer.