### PR TITLE
issue: PHP 7.3 New Agent Set Password

### DIFF
--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -37,7 +37,7 @@ class StaffAjaxAPI extends AjaxController {
           $clean = $form->getClean();
           try {
               // Validate password
-              PasswordPolicy::checkPassword($clean['passwd1']);
+              PasswordPolicy::checkPassword($clean['passwd1'], null);
               if ($id == 0) {
                   // Stash in the session later when creating the user
                   $_SESSION['new-agent-passwd'] = $clean;


### PR DESCRIPTION
This addresses an issue reported on the Forum where creating a new Agent and setting a password hangs when using PHP 7.3. This is due to too few arguments passed to `PasswordPolicy::checkPassword()`. This updates the call to include a second argument of `null` so the method is satisfied and we can continue with checking the password.