### PR TITLE
issue: Revert 453e815

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -59,6 +59,7 @@ class osTicket {
         if (!defined('DISABLE_SESSION') || !DISABLE_SESSION)
             $this->session = osTicketSession::start(SESSION_TTL); // start DB based session
 
+        $this->config = new OsticketConfig();
 
         $this->csrf = new CSRF('__CSRFToken__');
 
@@ -84,9 +85,6 @@ class osTicket {
     }
 
     function getConfig() {
-        if (!isset($this->config))
-            $this->config = new OsticketConfig();
-
         return $this->config;
     }
 


### PR DESCRIPTION
This addresses an issue where upgrading from v1.6 to a release on or after v1.12 will hang on login and eventually timeout. This is due to the system not being able to fetch the config which logs a db error which calls the config and continues the loop. For now, we need the config in the constructor so that the loop doesn't occur and we can continue to upgrade as normal.

TODO:
- For a permanent fix, we need to figure out why the loop occurs when not in the constructor and vice versa.