### PR TITLE
issue: Complete Thread Var Padding (Outlook)

### DIFF
--- a/include/client/templates/thread-export.tmpl.php
+++ b/include/client/templates/thread-export.tmpl.php
@@ -83,6 +83,7 @@ $entries->filter(array('type__in' => array_keys($entryTypes)))->order_by("{$orde
                         </div>
                     </td>
                 </tr>
+                <tr><td>&nbsp;</td></tr>
             <?php
             } ?>
         </tbody>


### PR DESCRIPTION
This addresses issue #5007 where when using the complete thread variable there is no padding between thread messages in Outlook desktop app and makes the thread hard to follow. Outlook does not respect some CSS rules that are accepted in most (if not all) modern email clients. Since we can’t use normal CSS the workaround is to add a blank table row (with a single space) so that it forces "padding" between the end of a message and the start of another.

**Before**
<img width="242" alt="Screen Shot 2019-09-23 at 13 01 04" src="https://user-images.githubusercontent.com/11823401/65450499-dcf73480-de02-11e9-8472-05731f1c4e63.png">

**After**
<img width="295" alt="Screen Shot 2019-09-23 at 12 51 36" src="https://user-images.githubusercontent.com/11823401/65450511-e1bbe880-de02-11e9-9505-17524e1d790a.png">