### PR TITLE
Ticket Link Fixes

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -379,7 +379,13 @@ class TicketsAjaxAPI extends AjaxController {
         $info = array();
         $errors = array();
 
-        if ($_POST['tids']) {
+        if ($_POST['dtids']) {
+            foreach($_POST['dtids'] as $key => $value) {
+                if (is_numeric($key) && $ticket = Ticket::lookup($value))
+                    $ticket->unlink();
+            }
+            return true;
+        } elseif ($_POST['tids']) {
             if ($parent = Ticket::merge($_POST))
                 Http::response(201, 'Successfully managed');
             else

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2419,7 +2419,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 $child = Ticket::lookup($child[0]);
                 $child->unlinkChild($parent);
             }
-        } else
+        } elseif ($child)
             $child->unlinkChild($parent);
 
         if (count(Ticket::getChildTickets($pid)) == 0) {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2461,6 +2461,11 @@ implements RestrictedAccess, Threadable, Searchable {
                             $changeParent = true;
                     }
 
+                    if ($ticket->getMergeType() == 'visual') {
+                        $ticket->setSort($key);
+                        $ticket->save();
+                    }
+
                     if ($parent && $parent->getId() != $ticket->getId()) {
                         if (($changeParent) || ($parent->isParent() && $ticket->getMergeType() == 'visual' && !$ticket->isChild()) || //adding to link/merge
                            (!$parent->isParent() && !$ticket->isChild())) { //creating fresh link/merge
@@ -2468,7 +2473,6 @@ implements RestrictedAccess, Threadable, Searchable {
                                $ticket->logEvent($eventName, array('ticket' => sprintf('Ticket #%s', $parent->getNumber()),  'id' => $parent->getId()));
                                if ($ticket->getPid() != $parent->getId())
                                    $ticket->setPid($parent->getId());
-                               $ticket->setSort($key);
                                $parent->setMergeType($tickets['combine'], true);
                                $ticket->setMergeType($tickets['combine']);
 


### PR DESCRIPTION
- Make sure we account for unlinking within a ticket using an AJAX call.
- The link form should allow agents to rearrange the tickets to display in the order they want.