### PR TITLE
Issue: Task Collaborator Display

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -492,7 +492,7 @@ else
                                 $thread->getNumCollaborators());
 
                     echo sprintf('<span><a class="collaborators preview"
-                            href="#thread/%d/collaborators/1"><span id="t%d-recipients">%s</span></a></span>',
+                            href="#thread/%d/collaborators/1"> %s &nbsp;<span id="t%d-recipients">%s</span></a></span>',
                             $thread->getId(),
                             __('Collaborators'),
                             $thread->getId(),


### PR DESCRIPTION
Part of the span for collaborators was left out, so it threw off the sprintf as well as the display.