### PR TITLE
Datetime Formats

### DIFF
--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -40,7 +40,7 @@ class ConfigAjaxAPI extends AjaxController {
         $config=array(
               'lock_time'       => $cfg->getTicketLockMode() == Lock::MODE_DISABLED ? 0 : ($cfg->getLockTime()*60),
               'html_thread'     => (bool) $cfg->isRichTextEnabled(),
-              'date_format'     => $cfg->getDateFormat(true),
+              'date_format'     => Format::dtfmt_php2js($cfg->getDateFormat(true)),
               'lang'            => $lang,
               'short_lang'      => $sl,
               'has_rtl'         => $rtl,

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -334,14 +334,38 @@ class OsticketConfig extends Config {
     }
 
     /* Date & Time Formats */
-    function getTimeFormat() {
+    function getTimeFormat($propogate=false) {
+        global $cfg;
+
         if ($this->get('date_formats') == 'custom')
             return $this->get('time_format');
+
+        if ($propogate) {
+            $format = 'h:i a'; // Default
+            if (class_exists('IntlDateFormatter')) {
+                $formatter = new IntlDateFormatter(
+                    Internationalization::getCurrentLocale(),
+                    IntlDateFormatter::NONE,
+                    IntlDateFormatter::SHORT,
+                    $this->getTimezone(),
+                    IntlDateFormatter::GREGORIAN
+                );
+                $format = $formatter->getPattern();
+            }
+            // Check if we're forcing 24 hrs format
+            if ($cfg && $cfg->isForce24HourTime() && $format)
+                $format = trim(str_replace(array('a', 'h'), array('', 'H'),
+                            $format));
+            return $format;
+        }
+
         return '';
     }
+
     function isForce24HourTime() {
         return $this->get('date_formats') == '24';
     }
+
     /**
      * getDateFormat
      *
@@ -368,10 +392,8 @@ class OsticketConfig extends Config {
                 );
                 return $formatter->getPattern();
             }
-            else {
-                // Use a standard
-                return 'y-M-d';
-            }
+            // Use a standard
+            return 'y-M-d';
         }
         return '';
     }
@@ -379,6 +401,11 @@ class OsticketConfig extends Config {
     function getDateTimeFormat() {
         if ($this->get('date_formats') == 'custom')
             return $this->get('datetime_format');
+
+        if (class_exists('IntlDateFormatter'))
+            return sprintf('%s %s', $this->getDateFormat(true),
+                    $this->getTimeFormat(true));
+
         return '';
     }
 

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -612,11 +612,6 @@ class Format {
         $timezone = $datetime->getTimeZone();
         // Use IntlDateFormatter if available
         if (class_exists('IntlDateFormatter')) {
-
-            if ($cfg && $cfg->isForce24HourTime())
-                $format = str_replace(array('a', 'h'), array('', 'H'),
-                        $format);
-
             $options += array(
                     'pattern' => $format,
                     'timezone' => $timezone->getName());
@@ -633,6 +628,9 @@ class Format {
         // Change format to strftime format otherwise us a fallback format
         $format = self::getStrftimeFormat($format) ?: $options['strftime']
             ?:  '%x %X';
+        if ($cfg && $cfg->isForce24HourTime())
+            $format = str_replace('X', 'R', $format);
+
         return strftime($format, $timestamp);
     }
 
@@ -794,6 +792,35 @@ class Format {
             },
             $format
         );
+    }
+
+    // Translate php date / time formats to js equivalent
+    function dtfmt_php2js($format) {
+
+        $codes = array(
+        // Date
+        'DD' => 'oo',
+        'D' => 'o',
+        'EEEE' => 'DD',
+        'EEE' => 'D',
+        'MMMM' => '||',
+        'MMM' => '|',
+        'MM' => 'mm',
+        'M' =>  'm',
+        '||' => 'MM',
+        '|' => 'M',
+        'yyyy' => 'YY',
+        'yyy' => 'YY',
+        'yy' =>  'Y',
+        'y' => 'yy',
+        'YY' =>  'yy',
+        'Y' => 'y',
+        // Time
+        'a' => 'tt',
+        'H' => 'HH',
+        );
+
+        return str_replace(array_keys($codes), array_values($codes), $format);
     }
 
     // Thanks, http://stackoverflow.com/a/2955878/1025836

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4415,7 +4415,8 @@ class DatetimePickerWidget extends Widget {
 
         $config = $this->field->getConfiguration();
         $timezone = $this->field->getTimezone();
-
+        $dateFormat = $cfg->getDateFormat(true);
+        $timeFormat = $cfg->getTimeFormat(true);
         if (!isset($this->value) && ($default=$this->field->get('default')))
             $this->value = $default;
 
@@ -4432,14 +4433,14 @@ class DatetimePickerWidget extends Widget {
                 // Convert to user's timezone for update.
                 $datetime->setTimezone($timezone);
 
-            // Get the date
+            // Get formatted date
             $this->value = Format::date($datetime->getTimestamp(), false,
                         false, $timezone ? $timezone->getName() : 'UTC');
-
-            // TODO: Fix timeformat based on config. For now we're forcing
-            // hh:mm tt
+            // Get formatted time
             if ($config['time']) {
-                 $this->value .=$datetime->format(' h:i a');
+                 $this->value .=' '.Format::time($datetime->getTimestamp(),
+                         false, $timeFormat, $timezone ?
+                         $timezone->getName() : 'UTC');
             }
 
         } else {
@@ -4482,14 +4483,15 @@ class DatetimePickerWidget extends Widget {
                                 controlType: 'select',\n
                                 timeInput: true,\n
                                 timeFormat: \"%s\",\n",
-                                "hh:mm tt");
+                                Format::dtfmt_php2js($timeFormat));
                     }
                     ?>
                     numberOfMonths: 2,
                     showButtonPanel: true,
                     buttonImage: './images/cal.png',
                     showOn:'both',
-                    dateFormat: $.translate_format('<?php echo $cfg->getDateFormat(true); ?>')
+                    dateFormat: '<?php echo
+                        Format::dtfmt_php2js($dateFormat); ?>'
                 });
             });
         </script>

--- a/js/osticket.js
+++ b/js/osticket.js
@@ -182,30 +182,6 @@ getConfig = (function() {
     };
 })();
 
-$.translate_format = function(str) {
-    var translation = {
-        'DD':   'oo',
-        'D':    'o',
-        'EEEE': 'DD',
-        'EEE':  'D',
-        'MMMM': '||',   // Double replace necessary
-        'MMM':  '|',
-        'MM':   'mm',
-        'M':    'm',
-        '||':   'MM',
-        '|':    'M',
-        'yyyy': '`',
-        'yyy':  '`',
-        'yy':   'y',
-        '`':    'yy'
-    };
-    // Change PHP formats to datepicker ones
-    $.each(translation, function(php, jqdp) {
-        str = str.replace(php, jqdp);
-    });
-    return str;
-};
-
 $.sysAlert = function (title, msg, cb) {
     var $dialog =  $('.dialog#alert');
     if ($dialog.length) {

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -265,7 +265,7 @@ var scp_prep = function() {
             showButtonPanel: true,
             buttonImage: './images/cal.png',
             showOn:'both',
-            dateFormat: $.translate_format(c.date_format||'m/d/Y')
+            dateFormat: c.date_format || 'm/d/Y'
         });
 
     });
@@ -593,30 +593,6 @@ $(document).ajaxSend(function(event, xhr, settings) {
 jQuery.fn.exists = function() { return this.length>0; };
 
 $.pjax.defaults.timeout = 30000;
-$.translate_format = function(str) {
-    var translation = {
-        'DD':   'oo',
-        'D':    'o',
-        'EEEE': 'DD',
-        'EEE':  'D',
-        'MMMM': '||',   // Double replace necessary
-        'MMM':  '|',
-        'MM':   'mm',
-        'M':    'm',
-        '||':   'MM',
-        '|':    'M',
-        'yyyy': '`',
-        'yyy':  '`',
-        'yy':   'y',
-        'y':    'yy',
-        '`':    'yy'
-    };
-    // Change PHP formats to datepicker ones
-    $.each(translation, function(php, jqdp) {
-        str = str.replace(php, jqdp);
-    });
-    return str;
-};
 $(document).keydown(function(e) {
 
     if (e.keyCode == 27 && !$('#overlay').is(':hidden')) {


### PR DESCRIPTION
This PR addresses two issues related to date / time format.

* 24 hrs format, when selected, is now used system-wide even on thread entries
* PHP-to-JS date / time format translation is now down in the backend - bug on year format fixed.