### PR TITLE
issue: Mbstring Extension Requirement

### DIFF
--- a/include/upgrader/prereq.inc.php
+++ b/include/upgrader/prereq.inc.php
@@ -17,7 +17,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
                 <li class="<?php echo $upgrader->check_php()?'yes':'no'; ?>">
                 <?php echo sprintf(__('%s or later'), 'PHP v'.SetupWizard::getPHPVersion()); ?> - (<small><b><?php echo PHP_VERSION; ?></b></small>)</li>
                 <li class="<?php echo $upgrader->check_mysql()?'yes':'no'; ?>">
-                <?php echo __('MySQLi extension for PHP'); ?>- (<small><b><?php
+                <?php echo __('MySQLi extension for PHP'); ?> - (<small><b><?php
                     echo extension_loaded('mysqli')?__('module loaded'):__('missing!'); ?></b></small>)</li>
                 <li class="<?php echo $upgrader->check_mysql_version()?'yes':'no'; ?>">
                 <?php echo sprintf(__('%s or later'), 'MySQL v'.SetupWizard::getMySQLVersion()); ?> - (<small><b><?php echo db_version(); ?></b></small>)</li>

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -495,9 +495,14 @@ if($ticket) {
             $f->filterFields(function($f) { return !$f->isStorable(); });
             $f->addMissingFields();
         }
-    } elseif($_REQUEST['a'] == 'print' && !$ticket->pdfExport($_REQUEST['psize'], $_REQUEST['notes'], $_REQUEST['events']))
-        $errors['err'] = __('Unable to export the ticket to PDF for print.')
-            .' '.__('Internal error occurred');
+    } elseif($_REQUEST['a'] == 'print')
+        if (!extension_loaded('mbstring'))
+            $errors['err'] = sprintf('%s %s',
+                'mbstring',
+                __('extension required to print ticket to PDF'));
+        elseif (!$ticket->pdfExport($_REQUEST['psize'], $_REQUEST['notes'], $_REQUEST['events']))
+            $errors['err'] = __('Unable to export the ticket to PDF for print.')
+                .' '.__('Internal error occurred');
 } else {
     $inc = 'templates/queue-tickets.tmpl.php';
     if ($_REQUEST['a']=='open' &&


### PR DESCRIPTION
This addresses an issue reported on the forum where printing a ticket in v1.12 and above requires `mbstring`. This updates the print call to check for the `mbstring` extension and if not loaded will fail with a detailed error `mbstring extension required to print ticket to PDF`.