### PR TITLE
issue: Revert  fefed14

### DIFF
--- a/include/cli/modules/deploy.php
+++ b/include/cli/modules/deploy.php
@@ -122,7 +122,7 @@ class Deployment extends Unpacker {
         }
 
         if (!$version)
-            $version = preg_replace('/^v(\d{1}\.\d{2}).*$/', '$1-git', exec('git describe'));
+            $version = exec('git describe');
 
         if (!$short || !$version)
             return false;


### PR DESCRIPTION
This addresses issue #5084 by partially reverting commit `fefed14`. In said commit, we updated `THIS_VERSION` to utilize `MAJOR_VERSION` which is fine. However, we also updated the deploy module to copy the same format. This interferes with the osTicket Version check by not including the entire subversion and not starting with a `v` (ie. `v1.12.3`). This reverts the copied format section of the commit so that `THIS_VERSION` will be the full, non-git version when deployed/packaged.