### PR TITLE
Datatimepicker: Time format

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -817,6 +817,7 @@ class Format {
         'Y' => 'y',
         // Time
         'a' => 'tt',
+        'HH' => 'H',
         'H' => 'HH',
         );
 


### PR DESCRIPTION
This commit addresses an issue where time format in 24 hrs, in some locales, resulted in double hours.