### PR TITLE
i18n: OpenSSL Error

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -534,7 +534,7 @@ abstract class Plugin {
     static function isVerified($phar) {
         static $pubkey = null;
 
-        if (!class_exists('Phar'))
+        if (!class_exists('Phar') || !extension_loaded('openssl'))
             return self::VERIFY_EXT_MISSING;
         elseif (!file_exists(INCLUDE_DIR . '/plugins/updates.pem'))
             return self::VERIFY_NO_KEY;


### PR DESCRIPTION
This addresses issue #5095 where installing a Language Pack and visiting the Dashboard > Information page without OpenSSL installed/configured will throw a fatal error of `Call to undefined function openssl_pkey_get_public()`. This is due to no check for the `openssl` extension before the dependant method is called. This adds a check so that if OpenSSL is not available we can return a useful error code of `VERIFY_EXT_MISSING` (which is error code `2`) and continue without disrupting the content.