### PR TITLE
Make message variable (%{message}) optional

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4162,9 +4162,9 @@ implements RestrictedAccess, Threadable, Searchable {
 
             $msg = $ticket->replaceVars($msg->asArray(),
                 array(
-                    'message'   => $message,
-                    'signature' => $signature,
+                    'message'   => $message ?: '',
                     'response'  => $response ?: '',
+                    'signature' => $signature,
                     'recipient' => $ticket->getOwner(), //End user
                     'staff'     => $thisstaff,
                 )


### PR DESCRIPTION
Make message variable optional for new tickets opened by agents. This is necessary for help topics with issue details disabled.