### PR TITLE
Auto-refer tickets to assigned Agent on close

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -201,6 +201,7 @@ class OsticketConfig extends Config {
         'agent_name_format' =>  'full', # First Last
         'client_name_format' => 'original', # As entered
         'auto_claim_tickets'=>  true,
+        'auto_refer_closed' => true,
         'collaborator_ticket_visibility' =>  true,
         'require_topic_to_close' =>  false,
         'system_language' =>    'en_US',
@@ -992,6 +993,10 @@ class OsticketConfig extends Config {
         return $this->get('auto_claim_tickets');
     }
 
+    function autoReferTicketsOnClose() {
+         return $this->get('auto_refer_closed');
+    }
+
     function collaboratorTicketsVisibility() {
         return $this->get('collaborator_ticket_visibility');
     }
@@ -1371,6 +1376,7 @@ class OsticketConfig extends Config {
             'max_open_tickets'=>$vars['max_open_tickets'],
             'enable_captcha'=>isset($vars['enable_captcha'])?1:0,
             'auto_claim_tickets'=>isset($vars['auto_claim_tickets'])?1:0,
+            'auto_refer_closed' => isset($vars['auto_refer_closed']) ? 1 : 0,
             'collaborator_ticket_visibility'=>isset($vars['collaborator_ticket_visibility'])?1:0,
             'require_topic_to_close'=>isset($vars['require_topic_to_close'])?1:0,
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1443,7 +1443,7 @@ implements RestrictedAccess, Threadable, Searchable {
 
     // Ticket Status helper.
     function setStatus($status, $comments='', &$errors=array(), $set_closing_agent=true) {
-        global $thisstaff;
+        global $cfg, $thisstaff;
 
         if ($thisstaff && !($role=$this->getRole($thisstaff)))
             return false;
@@ -1474,7 +1474,7 @@ implements RestrictedAccess, Threadable, Searchable {
             return true;
 
         // Perform checks on the *new* status, _before_ the status changes
-        $ecb = null;
+        $ecb = $refer = null;
         switch ($status->getState()) {
             case 'closed':
                 // Check if ticket is closeable
@@ -1485,6 +1485,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 if ($errors)
                     return false;
 
+                $refer = $this->staff ?: $thisstaff;
                 $this->closed = $this->lastupdate = SqlFunction::NOW();
                 $this->duedate = null;
                 if ($thisstaff && $set_closing_agent)
@@ -1499,7 +1500,8 @@ implements RestrictedAccess, Threadable, Searchable {
             case 'open':
                 // TODO: check current status if it allows for reopening
                 if ($this->isClosed()) {
-                    $this->closed = $this->lastupdate = $this->reopened = SqlFunction::NOW();
+                    $this->closed = null;
+                    $this->lastupdate = $this->reopened = SqlFunction::NOW();
                     $ecb = function ($t) {
                         $t->logEvent('reopened', false, null, 'closed');
                     };
@@ -1517,6 +1519,10 @@ implements RestrictedAccess, Threadable, Searchable {
         $this->status = $status;
         if (!$this->save())
             return false;
+
+        // Refer thread to previously assigned or closing agent
+        if ($refer && $cfg->autoReferTicketsOnClose())
+            $this->thread->refer($refer);
 
         // Log status change b4 reload — if currently has a status. (On new
         // ticket, the ticket is opened and thereafter the status is set to

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -67,6 +67,7 @@ core:
     assigned_alert_team_lead: 0
     assigned_alert_team_members: 0
     auto_claim_tickets: 1
+    auto_refer_closed: 1
     collaborator_ticket_visibility: 1
     require_topic_to_close: 0
     show_related_tickets: 1

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -101,6 +101,15 @@ claim_tickets:
         Reopened tickets are always assigned to the last respondent unless auto
         assign on reopen is disabled on the Department level.
 
+auto_refer:
+    title: Auto-refer Tickets on Close
+    content: >
+        Enable this to auto-refer tickets to the assigned or closing
+        Agent when a ticket is closed.
+        <br><br>
+        This is necessary when you want to give agents with limited access
+        continued access to assigned tickets after they're closed.
+
 collaborator_ticket_visibility:
     title: Collaborator Tickets Visibility
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -206,6 +206,13 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td><?php echo __('Collaborator Tickets Visibility'); ?>:</td>
+            <td>
+                <input type="checkbox" name="collaborator_ticket_visibility" <?php echo $config['collaborator_ticket_visibility']?'checked="checked"':''; ?>>
+                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#collaborator_ticket_visibility"></i>
+            </td>
+        </tr>
+        <tr>
             <td><?php echo __('Claim on Response'); ?>:</td>
             <td>
                 <input type="checkbox" name="auto_claim_tickets" <?php echo $config['auto_claim_tickets']?'checked="checked"':''; ?>>
@@ -213,10 +220,11 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
-            <td><?php echo __('Collaborator Tickets Visibility'); ?>:</td>
+            <td><?php echo __('Auto-refer on Close'); ?>:</td>
             <td>
-                <input type="checkbox" name="collaborator_ticket_visibility" <?php echo $config['collaborator_ticket_visibility']?'checked="checked"':''; ?>>
-                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#collaborator_ticket_visibility"></i>
+                <input type="checkbox" name="auto_refer_closed" <?php echo $config['auto_refer_closed']?'checked="checked"':''; ?>>
+                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip
+                icon-question-sign" href="#auto_refer"></i>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
 This PR adds a setting to Admin Panel > Settings > Tickets to enable ability to auto-refer tickets, on close, to assigned or closing agent. This is necessary when you want to give agents with limited access continued access to assigned tickets after they're closed.

It also addresses a bug where `closed` date was set to `reopened` date when a closed ticket is reopen.