### PR TITLE
Feature :: Auto Close for v1.14

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -220,6 +220,8 @@ class OsticketConfig extends Config {
         'ticket_lock' => 2, // Lock on activity
         'max_open_tickets' => 0,
         'files_req_auth' => 1,
+        'autoclose_duration' => 72,
+        'autoclose_status_id' => 0,
     );
 
     function __construct($section=null) {

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -720,6 +720,14 @@ class OsticketConfig extends Config {
          return $this->get('max_open_tickets');
     }
 
+    function getAutoCloseStatusId() {
+        return $this->get('autoclose_status_id');
+    }
+
+    function getAutoCloseDuration() {
+        return $this->get('autoclose_duration');
+    }
+ 
     function getMaxFileSize() {
         return $this->get('max_file_size');
     }
@@ -1324,6 +1332,8 @@ class OsticketConfig extends Config {
         $f['default_ticket_status_id'] = array('type'=>'int', 'required'=>1, 'error'=>__('Selection required'));
         $f['default_priority_id']=array('type'=>'int',   'required'=>1, 'error'=>__('Selection required'));
         $f['max_open_tickets']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter valid numeric value'));
+        $f['autoclose_status_id'] = array('type'=>'int', 'required'=>1, 'error'=>__('Selection required'));
+        $f['autoclose_duration']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter valid numeric value'));
 
 
         if($vars['enable_captcha']) {
@@ -1378,6 +1388,8 @@ class OsticketConfig extends Config {
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],
+            'autoclose_duration'=>$vars['autoclose_duration'],
+            'autoclose_status_id'=>$vars['autoclose_status_id'],
             'default_ticket_queue'=>$vars['default_ticket_queue'],
         ));
     }

--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -28,6 +28,7 @@ class Cron {
     function TicketMonitor() {
         require_once(INCLUDE_DIR.'class.ticket.php');
         Ticket::checkOverdue(); //Make stale tickets overdue
+        Ticket::AutoClose(); //Auto Close tickets
         // Cleanup any expired locks
         require_once(INCLUDE_DIR.'class.lock.php');
         Lock::cleanup();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4553,6 +4553,34 @@ implements RestrictedAccess, Threadable, Searchable {
             $ticket->markOverdue();
 
     }
+    
+    // Close tickets based on Ticket Auto-Close from config
+    static function AutoClose() {
+        global $cfg;
+        
+        $grace = $cfg->getAutoCloseDuration();
+        $graceStatusId = $cfg->getAutoCloseStatusId();
+        
+        if($graceStatusId != 0){ 
+            if($grace == 1){
+                $plural = 'hour';
+                } else {
+                $plural = 'hours';
+            }
+            
+            // select all tickets marked as selected status from config page where updated is older than ($grace) hours ago
+            $autoclose = static::objects()
+                  ->filter(array(
+                      'status_id' => $graceStatusId,
+                      'updated__lt' => SqlFunction::NOW()->minus(SqlInterval::HOUR($grace))
+                      ))
+                   ->limit(100);
+
+            foreach ($autoclose as $ticket)
+                  $ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$grace.' '.$plural.' of no activity.',$errors, false);
+        }
+    }
+    //END Close tickets based on Ticket Auto-Close from config
 
     static function agentActions($agent, $options=array()) {
         if (!$agent)

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -74,6 +74,19 @@ maximum_open_tickets:
         <br><br>
         Enter <span class="doc-desc-opt">0 </span> if you prefer to disable this limitation.
 
+autoclose_status:
+    title: Ticket Auto-Close Status
+    content: >
+        The Auto Close function will use this status to find tickets 
+        that will be marked <b>Closed</b> after the <b>Ticket Auto-Close Duration</b>.
+
+autoclose_duration:
+    title: Ticket Auto-Close Duration
+    content: >
+        Enter the number of Hours before a ticket marked with the 
+        <b>Ticket Auto-Close Status</b> selected above will be 
+        Auto-Closed by the system.
+
 email_ticket_priority:
     title: Email Ticket Priority
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -197,6 +197,45 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td width="180">
+                <?php echo __('Ticket Auto-Close Status'); ?>:
+            </td>
+            <td>
+                <span>
+                <select name="autoclose_status_id">
+		<option value="0">&mdash; <?php echo __('Disabled');?> &mdash;</option>
+                <?php
+                $criteria = array('states' => array('open','closed'));
+                foreach (TicketStatusList::getStatuses($criteria) as $status) {
+                    $name = $status->getName();
+                if (!($isenabled = $status->isEnabled()))
+                        $name.=' '.__('(disabled)');
+                    echo sprintf('<option value="%d" %s %s>%s</option>',
+                            $status->getId(),
+                            ($config['autoclose_status_id'] ==
+                             $status->getId() && $isenabled)
+                             ? 'selected="selected"' : '',
+                             $isenabled ? '' : 'disabled="disabled"',
+                             $name
+                            );
+                }
+                ?>
+                </select>
+                &nbsp;
+                <span class="error">*&nbsp;<?php echo $errors['autoclose_status_id']; ?></span>
+                <i class="help-tip icon-question-sign" href="#autoclose_status"></i>
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td><?php echo __('Ticket Auto-Close Duration'); ?>:</td>
+            <td>
+                <input type="text" name="autoclose_duration" size=4 value="<?php echo $config['autoclose_duration']; ?>">&nbsp;Hour(s)&nbsp;
+                <font class="error">*&nbsp;<?php echo $errors['autoclose_duration']; ?></font>
+                <i class="help-tip icon-question-sign" href="#autoclose_duration"></i>
+            </td>
+        </tr>
+        <tr>
             <td><?php echo __('Human Verification');?>:</td>
             <td>
                 <input type="checkbox" name="enable_captcha" <?php echo $config['enable_captcha']?'checked="checked"':''; ?>>


### PR DESCRIPTION
This is a rebase PR for the Auto Close feature #3450. This PR will work with v1.10+ and also allows for admin to select the status from which will be used to automatically close tickets.

A change made to this PR migrated the code to ORM. Thanks @protich

Need help:
- [ ] set status using status name instead of id in AutoClose function
    `class.ticket.php` line 4580 `$ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$grace.' '.$plural.' of no activity.',$errors, false);`

![image](https://user-images.githubusercontent.com/5774055/66863168-70360c80-ef60-11e9-9349-4d8680b4cab4.png)

![image](https://user-images.githubusercontent.com/5774055/66863473-141fb800-ef61-11e9-8427-7abcdd1533e8.png)
