### PR TITLE
In-reply-to header in postReply

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3008,6 +3008,16 @@ implements RestrictedAccess, Threadable, Searchable {
             $attachments = $cfg->emailAttachments() ?
                 $response->getAttachments() : array();
 
+            $thread = $this->getThread();
+            $lastm = $thread->getLastEmailMessage();
+            if($lastm){
+                $mid = $lastm->getEmailMessageId();
+                if($mid){
+                    $options += array( 'inreplyto'=> $mid );
+                }
+            }
+
+            //$this->qdebug(print_r($lastm,true));
             //Send email to recepients
             $email->send($recipients, $msg['subj'], $msg['body'],
                     $attachments, $options);


### PR DESCRIPTION
This patch solves the issue of a missing In-reply-to-header. This header was unfortunately not sent, when, as an Agent you add a Reply to an existing Ticket.  The problem, for the user who recieves such email messages in their INBOX (outside osTicket), is that the messages are not displayed in proper thread-format.


