### PR TITLE
Add GTID compatibility

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -286,10 +286,31 @@ class DynamicForm extends VerySimpleModel {
     }
 
     static function buildDynamicDataView($cdata) {
-        $sql = 'CREATE TABLE IF NOT EXISTS `'.$cdata['table'].'` (PRIMARY KEY
-                ('.$cdata['object_id'].')) DEFAULT CHARSET=utf8 AS '
-             .  static::getCrossTabQuery( $cdata['object_type'], $cdata['object_id']);
-        db_query($sql);
+        $table = $cdata['table'];
+
+        $sql = 'SHOW TABLES LIKE "'.$table.'"';
+        $res = db_query($sql);
+        $exists = (mysqli_num_rows($res) > 0);
+        if ($exists) {  // Nothing to do
+            return;
+        }
+
+        // This rather complicated structure using temporary table is to make the code GTID compatible.
+        // GTID-based replication does not allow CREATE TABLE ... SELECT
+        // See https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html
+        $ret = true;
+        // To make temp table compatible with mysqli using persistent connections
+        $rand = substr(md5(microtime()), rand(0,26),5);
+        $tmptable = $table.'_'.$rand;
+        $ret = $ret && db_query('CREATE TEMPORARY TABLE `'.$tmptable.'`'
+                .'(PRIMARY KEY ('.$cdata['object_id'].')) DEFAULT CHARSET=utf8 AS '
+                .static::getCrossTabQuery($cdata['object_type'], $cdata['object_id']));  // create temp table with data and structure
+        $ret = $ret && db_query('CREATE TABLE IF NOT EXISTS `'.$table.'` LIKE `'.$tmptable.'`');  // create structure
+        $ret = $ret && db_query('INSERT `'.$table.'` SELECT * FROM `'.$tmptable.'`');  // copy data
+        $ret = $ret && db_query('DROP TEMPORARY TABLE IF EXISTS `'.$tmptable.'`');  // remove temp table
+        if (!$ret) {
+            throw new Exception(__('buildDynamicDataView: failed to create temporary table'));
+        }
     }
 
     static function dropDynamicDataView($table) {


### PR DESCRIPTION
GTID-based replication does not allow `CREATE TABLE ... SELECT`
See https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html

This PR change the routine to perform the operation using a temporary table, instead of a `CREATE TABLE ... SELECT`.

To verify the result, start MySQL using these params:
```--gtid-mode=ON --enforce-gtid-consistency=ON --log-bin --server-id=0```

Current osTicket will fail when running MySQL using these params, but with PR it will work and the result are the same (i.e. __cdata table is populated in the same way).