### PR TITLE
i18n: KnowledgeBase Category and JS

### DIFF
--- a/include/client/footer.inc.php
+++ b/include/client/footer.inc.php
@@ -12,7 +12,7 @@
 </div>
 <?php
 if (($lang = Internationalization::getCurrentLanguage()) && $lang != 'en_US') { ?>
-    <script type="text/javascript" src="ajax.php/i18n/<?php
+    <script type="text/javascript" src="<?php echo ROOT_PATH; ?>ajax.php/i18n/<?php
         echo $lang; ?>/js"></script>
 <?php } ?>
 <script type="text/javascript">

--- a/include/client/kb-categories.inc.php
+++ b/include/client/kb-categories.inc.php
@@ -41,7 +41,7 @@
             <li><i></i>
             <div style="margin-left:45px">
             <h4><?php echo sprintf('<a href="faq.php?cid=%d">%s %s</a>',
-                $C->getId(), Format::htmlchars($C->getFullName()),
+                $C->getId(), Format::htmlchars($C->getLocalName()),
                 $count ? "({$count})": ''
                 ); ?></h4>
             <div class="faded" style="margin:10px 0">


### PR DESCRIPTION
This addresses #5120 where main (or Parent) FAQ Category Titles are not translated even though the child Category titles are translated correctly. This is due to to the system pulling the Full Name instead of the Local (translated) Name.

In #5120, the reporting party also mentioned that they receive an error of `script '/xxx/osTicket/kb/ajax.php' not found or unable to stat`.  This is due to the AJAX call being inside the KB directory, and `/kb/ajax.php` truly does not exist. This adds `ROOT_PATH` to the beginning of the AJAX call so that no matter where it is, it will point to the correct location.