### PR TITLE
issue: Spaces In Username

### DIFF
--- a/login.php
+++ b/login.php
@@ -48,7 +48,7 @@ if ($_POST) {
 if ($_POST && isset($_POST['luser'])) {
     if (!$_POST['luser'])
         $errors['err'] = __('Valid username or email address is required');
-    elseif (($user = UserAuthenticationBackend::process($_POST['luser'],
+    elseif (($user = UserAuthenticationBackend::process(trim($_POST['luser']),
             $_POST['lpasswd'], $errors))) {
         if ($user instanceof ClientCreateRequest) {
             if ($cfg && $cfg->isClientRegistrationEnabled()) {


### PR DESCRIPTION
This addresses issue #5122 where having a space at the beginning and/or end of the login Username/Email on the Client Portal the system will return `Access Denied`. This is due to the system not trimming the rogue spaces. This adds `trim()` around the Username/Email so that the spaces are removed and login will be successful.