### PR TITLE
feature: Configurable iFrame Whitelist

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -452,6 +452,12 @@ class OsticketConfig extends Config {
         return str_replace(array(', ', ','), array(' ', ' '), $this->get('allow_iframes')) ?: "'self'";
     }
 
+    function getIframeWhitelist() {
+        $whitelist = array_filter(explode(',', str_replace(' ', '', $this->get('embedded_domain_whitelist'))));
+
+        return !empty($whitelist) ? $whitelist : null;
+    }
+
     function getACL() {
         if (!($acl = $this->get('acl')))
             return null;
@@ -1185,6 +1191,7 @@ class OsticketConfig extends Config {
         $f['default_dept_id']=array('type'=>'int',   'required'=>1, 'error'=>__('Default Department is required'));
         $f['autolock_minutes']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter lock time in minutes'));
         $f['allow_iframes']=array('type'=>'cs-url',   'required'=>0, 'error'=>__('Enter comma separated list of urls'));
+        $f['embedded_domain_whitelist']=array('type'=>'cs-domain',   'required'=>0, 'error'=>__('Enter comma separated list of domains'));
         $f['acl']=array('type'=>'ipaddr',   'required'=>0, 'error'=>__('Enter comma separated list of IP addresses'));
         //Date & Time Options
         $f['time_format']=array('type'=>'string',   'required'=>1, 'error'=>__('Time format is required'));
@@ -1258,6 +1265,7 @@ class OsticketConfig extends Config {
             'enable_richtext' => isset($vars['enable_richtext']) ? 1 : 0,
             'files_req_auth' => isset($vars['files_req_auth']) ? 1 : 0,
             'allow_iframes' => Format::sanitize($vars['allow_iframes']),
+            'embedded_domain_whitelist' => Format::sanitize($vars['embedded_domain_whitelist']),
             'acl' => Format::sanitize($vars['acl']),
             'acl_backend' => Format::sanitize((int) $vars['acl_backend']) ?: 0,
         ));

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -1184,7 +1184,7 @@ class OsticketConfig extends Config {
         $f['helpdesk_title']=array('type'=>'string',   'required'=>1, 'error'=>__('Helpdesk title is required'));
         $f['default_dept_id']=array('type'=>'int',   'required'=>1, 'error'=>__('Default Department is required'));
         $f['autolock_minutes']=array('type'=>'int',   'required'=>1, 'error'=>__('Enter lock time in minutes'));
-        $f['allow_iframes']=array('type'=>'cs-domain',   'required'=>0, 'error'=>__('Enter comma separated list of domains'));
+        $f['allow_iframes']=array('type'=>'cs-url',   'required'=>0, 'error'=>__('Enter comma separated list of urls'));
         $f['acl']=array('type'=>'ipaddr',   'required'=>0, 'error'=>__('Enter comma separated list of IP addresses'));
         //Date & Time Options
         $f['time_format']=array('type'=>'string',   'required'=>1, 'error'=>__('Time format is required'));

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -290,6 +290,7 @@ class Format {
     }
 
     function safe_html($html, $options=array()) {
+        global $cfg;
 
         $options = array_merge(array(
                     // Balance html tags
@@ -326,10 +327,16 @@ class Format {
             'deny_attribute' => 'id',
             'schemes' => 'href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, telnet; *:file, http, https; src: cid, http, https, data',
             'hook_tag' => function($e, $a=0) { return Format::__html_cleanup($e, $a); },
-            'elements' => '*+iframe',
-            'spec' =>
-            'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo|player.vimeo)\.com/`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : '').',allowfullscreen',
         );
+
+        // iFrame Whitelist
+        $whitelist = $cfg->getIframeWhitelist();
+        if (!empty($whitelist)) {
+            $config['elements'] = '*+iframe';
+            $config['spec'] = 'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?('
+                .implode('|', $whitelist)
+                .')/?`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : '').',allowfullscreen';
+        }
 
         return Format::html($html, $config);
     }

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -123,7 +123,7 @@ class Validator {
                 if(!is_numeric($this->input[$k]) || (strlen($this->input[$k])!=5))
                     $this->errors[$k]=$field['error'];
                 break;
-            case 'cs-domain': // Comma separated list of domains
+            case 'cs-url': // Comma separated list of urls
                 if($values=explode(',', $this->input[$k]))
                     foreach($values as $v)
                         if(!preg_match_all(

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -123,6 +123,14 @@ class Validator {
                 if(!is_numeric($this->input[$k]) || (strlen($this->input[$k])!=5))
                     $this->errors[$k]=$field['error'];
                 break;
+            case 'cs-domain': // Comma separated list of domains
+                if($values=explode(',', $this->input[$k]))
+                    foreach($values as $v)
+                        if(!preg_match_all(
+                                '/^([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+$/',
+                                ltrim($v)))
+                            $this->errors[$k]=$field['error'];
+                break;
             case 'cs-url': // Comma separated list of urls
                 if($values=explode(',', $this->input[$k]))
                     foreach($values as $v)

--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -135,6 +135,21 @@ acl:
                 <td>Applies ACL to only Staff Panel and Admin Panel.</td></tr>
         </tbody></table>
 
+embedded_domain_whitelist:
+    title: Embedded Domain Whitelist
+    content: >
+        Enter a comma separated list of domains to be whitelisted for iFrames used
+        in the system. Do not input <code>http(s)</code> or <code>www</code> with
+        the domain; only the domain name will be accepted. This is used when you
+        would like to embed content in the system (eg. YouTube video) via Client
+        Portal, Knowledgebase, etc. If you add an iFrame with a non-whitelisted
+        domain, the system will remove the iFrame automatically. By default the
+        system allows YouTube, Vimeo, DailyMotion, and Microsoft Stream.
+        <br><br>
+        <b>Example:</b>
+        <br>
+        domain.tld, sub.domain.tld
+
 # Date and time options
 date_time_options:
     title: Date &amp; Time Options

--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -102,9 +102,9 @@ collision_avoidance:
         Enter <span class="doc-desc-opt">0</span> to disable the lockout feature.
 
 allow_iframes:
-    title: Allow iFrames
+    title: Allow System iFrame
     content: >
-        Enter comma separated list of domains for the system to be framed
+        Enter comma separated list of urls/domains for the system to be framed
         in. If left empty, the system will default to 'self'. This accepts
         domain wildcards, HTTP/HTTPS URL scheme, and port numbers.
         <br><br>

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -132,10 +132,14 @@ $gmtime = Misc::gmtime();
             </td>
         </tr>
         <tr>
-            <td><?php echo __('Allow iFrames'); ?>:</td>
-            <td><input type="text" size="40" name="allow_iframes" value="<?php echo $config['allow_iframes']; ?>">
-                &nbsp;<font class="error">&nbsp;<?php echo $errors['allow_iframes']; ?></font>
+            <td><?php echo __('Allow System iFrame'); ?>:</td>
+            <td><input type="text" size="40" name="allow_iframes" value="<?php echo $config['allow_iframes']; ?>"
+                    placeholder="eg. https://domain.tld, *.domain.tld">
                 <i class="help-tip icon-question-sign" href="#allow_iframes"></i>
+            <?php if ($errors['allow_iframes']) { ?>
+                <br>
+                <font class="error">&nbsp;<?php echo $errors['allow_iframes']; ?></font>
+            <?php } ?>
             </td>
         </tr>
         <tr>

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -143,6 +143,18 @@ $gmtime = Misc::gmtime();
             </td>
         </tr>
         <tr>
+            <td><?php echo __('Embedded Domain Whitelist'); ?>:</td>
+            <td><input type="text" size="40" name="embedded_domain_whitelist"
+                    value="<?php echo $config['embedded_domain_whitelist']; ?>"
+                    placeholder="eg. domain.tld, sub.domain.tld">
+                <i class="help-tip icon-question-sign" href="#embedded_domain_whitelist"></i>
+            <?php if ($errors['embedded_domain_whitelist']) { ?>
+                <br>
+                <font class="error">&nbsp;<?php echo $errors['embedded_domain_whitelist']; ?></font>
+            <?php } ?>
+            </td>
+        </tr>
+        <tr>
             <td><?php echo __('ACL'); ?>:</td>
             <td><input type="text" size="40" name="acl" value="<?php echo $config['acl']; ?>"
                     placeholder="eg. 192.168.1.1, 192.168.2.2, 192.168.3.3">


### PR DESCRIPTION
This adds a new feature called iFrame Whitelist that offers the ability to configure what domains you want to be whitelisted for iFrames used in the system. Basically, if you want to insert an iFrame in the system you'll have to whitelist the domain first. If you insert an iFrame with a non-whitelisted domain the system will remove the iFrame upon saving. This keeps current functionality where by default the system allows YouTube, Vimeo, and Daily Motion.

In addition, this renames the `Allow iFrames` setting to `Allow System iFrame` as this better fits the use-case. This also updates the Help Tip information to include the new title and expands on what you can input (ie. URLs). Lastly, this renames the validator for the `Allow System iFrame` setting from `cs-domain` to `cs-url` as it technically validates a comma separated list of URLs (not just domains).