### PR TITLE
issue: Umlauts In Subject

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -43,6 +43,11 @@ class Format {
     }
 
     function mimedecode($text, $encoding='UTF-8') {
+        // Handle poorly or completely un-encoded header values (
+        if (function_exists('mb_detect_encoding'))
+            if (($src_enc = mb_detect_encoding($text))
+                    && (strcasecmp($src_enc, 'ASCII') !== 0))
+                return Charset::transcode($text, $src_enc, $encoding);
 
         if(function_exists('imap_mime_header_decode')
                 && ($parts = imap_mime_header_decode($text))) {


### PR DESCRIPTION
This addresses an issue where Piping email to osTicket and having Umlauts in the Subject line causes the Subject to be malformed. This is due to the `mimedecode()` method for class Format which is used by the API to transcode the Subject line in emails. This adds a check to see if the `mb_detect_encoding()` method exists so we can detect the value's encoding. If it exists and we can detect the value's encoding the system will transcode the text from the detected encoding to UTF-8. If we cannot detect the encoding the text will continue through the other encoding checks.