### PR TITLE
issue: Attachment Filter

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -91,7 +91,9 @@ class TicketApiController extends ApiController {
                     $file['id'] = $F->getId();
                 }
                 catch (FileUploadError $ex) {
-                    $file['error'] = $file['name'] . ': ' . $ex->getMessage();
+                    $name = $file['name'];
+                    $file = array();
+                    $file['error'] = $name . ': ' . $ex->getMessage();
                 }
             }
             unset($file);

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -845,7 +845,9 @@ class MailFetcher {
                         $file['id'] = $f->getId();
                 }
                 catch (FileUploadError $ex) {
-                    $file['error'] = $file['name'] . ': ' . $ex->getMessage();
+                    $name = $file['name'];
+                    $file = array();
+                    $file['error'] = $name . ': ' . $ex->getMessage();
                 }
 
                 $vars['attachments'][] = $file;


### PR DESCRIPTION
This addresses issue #5123 where fetched Emails do not reject attachments that are not allowed. This is due to setting a File ID inside of an array called `$file[]` but not unsetting it when the attachment hits an FileUploadError. This updates class MailFetch to set the file array back to empty so that the ID is cleared and the error is added correctly which rejects the attachment.