### PR TITLE
Feature: Mark as Answered permission option

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1273,7 +1273,7 @@ function refer($tid, $target=null) {
         if (!($ticket=Ticket::lookup($tid)))
             Http::response(404, __('No such ticket'));
 
-        if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_REPLY) && !$thisstaff->isManager())
+            if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_REPLY) && !$ticket->checkStaffPerm($thisstaff, Ticket::PERM_MARKANSWERED) && !$thisstaff->isManager())
             Http::response(403, __('Permission denied'));
 
         $errors = array();

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1273,7 +1273,7 @@ function refer($tid, $target=null) {
         if (!($ticket=Ticket::lookup($tid)))
             Http::response(404, __('No such ticket'));
 
-            if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_REPLY) && !$ticket->checkStaffPerm($thisstaff, Ticket::PERM_MARKANSWERED) && !$thisstaff->isManager())
+        if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_MARKANSWERED) && !$thisstaff->isManager())
             Http::response(403, __('Permission denied'));
 
         $errors = array();

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -102,6 +102,7 @@ implements RestrictedAccess, Threadable, Searchable {
     const PERM_TRANSFER = 'ticket.transfer';
     const PERM_REFER    = 'ticket.refer';
     const PERM_REPLY    = 'ticket.reply';
+    const PERM_MARKANSWERED = 'ticket.markanswered';
     const PERM_CLOSE    = 'ticket.close';
     const PERM_DELETE   = 'ticket.delete';
 
@@ -141,6 +142,11 @@ implements RestrictedAccess, Threadable, Searchable {
                 /* @trans */ 'Post Reply',
                 'desc'  =>
                 /* @trans */ 'Ability to post a ticket reply'),
+            self::PERM_MARKANSWERED => array(
+                'title' =>
+                /* @trans */ 'Mark as Answered',
+                'desc'  =>
+                /* @trans */ 'Ability to mark a ticket as Answered/Unanswered'),
             self::PERM_CLOSE => array(
                 'title' =>
                 /* @trans */ 'Close',

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -22,7 +22,7 @@ $mylock = ($lock && $lock->getStaffId() == $thisstaff->getId()) ? $lock : null;
 $id    = $ticket->getId();    //Ticket ID.
 $isManager = $dept->isManager($thisstaff); //Check if Agent is Manager
 $canRelease = ($isManager || $role->hasPerm(Ticket::PERM_RELEASE)); //Check if Agent can release tickets
-$canAnswer = ($isManager || $role->hasPerm(Ticket::PERM_REPLY)); //Check if Agent can mark as answered/unanswered
+$canMarkAnswered = ($isManager || $role->hasPerm(Ticket::PERM_MARKANSWERED)); //Check if Agent can mark as answered/unanswered
 
 //Useful warnings and errors the user might want to know!
 if ($ticket->isClosed() && !$ticket->isReopenable())
@@ -165,7 +165,7 @@ if($ticket->isOverdue())
                     <?php
                     }
                  }
-                 if($ticket->isOpen() && $canAnswer) {
+                 if($ticket->isOpen() && $canMarkAnswered) {
                     if($ticket->isAnswered()) { ?>
                     <li><a href="#tickets/<?php echo $ticket->getId();
                         ?>/mark/unanswered" class="ticket-action"


### PR DESCRIPTION
Some roles need the ability to mark a ticket as Answered/Unanswered but must not be able to reply directly to the customer. Both are controlled by the Post Reply permission. This seperates the two functions so they can be managed independently.

![2019-10-29_14-47-43](https://user-images.githubusercontent.com/11843864/67778526-3a624f00-fa5b-11e9-93e8-eb788484a5f0.png)