### PR TITLE
issue: In-Reply-To Header

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -330,6 +330,9 @@ class Mailer {
 
                 $entry = null;
                 switch (true) {
+                case $recipients instanceof MailingList:
+                    $entry = $thread->getLastEmailMessage();
+                    break;
                 case $recipients instanceof TicketOwner:
                 case $recipients instanceof Collaborator:
                     $entry = $thread->getLastEmailMessage(array(


### PR DESCRIPTION
This addresses an issue raised in #5111 where the `in-reply-to` header is not sent with outgoing emails. This is due to the `$recipients` variable being an instance of `MailingList` which is not handled correctly in `class.mailer.php`. This adds a new case to handle `MailingList` directly.