### PR TITLE
Issue: Edit Task Fields

### DIFF
--- a/include/staff/templates/task-edit.tmpl.php
+++ b/include/staff/templates/task-edit.tmpl.php
@@ -29,13 +29,15 @@ if ($info['error']) {
     <div>
     <?php
     if ($forms) {
-        foreach ($forms as $form)
+        foreach ($forms as $form) {
+            $form->addMissingFields();
             echo $form->getForm(false, array('mode' => 'edit'))->asTable(
                     __('Task Information'),
                     array(
                         'draft-namespace' => $namespace,
                         )
                     );
+        }
     }
     ?>
     </div>


### PR DESCRIPTION
This commit fixes an issue where you were unable to edit custom fields if they were added to a task form after a task had been created.