### PR TITLE
issue: DB Error #1062

### DIFF
--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -148,7 +148,15 @@ extends InstrumentedList {
 
             $_inline = isset($file['inline']) ? $file['inline'] : $inline;
 
-            $att = $this->add(new Attachment(array(
+            // Check if Attachment exists
+            if ($F && $this->key)
+                $existing = Attachment::objects()->filter(array(
+                    'file__key' => $F->key,
+                    'object_id' => $this->key['object_id'],
+                    'type' => $this->key['type']
+                ))->first();
+
+            $att = $this->add(isset($existing) ? $existing : new Attachment(array(
                 'file_id' => $fileId,
                 'inline' => $_inline ? 1 : 0,
             )));


### PR DESCRIPTION
This addresses a long-time issue of the famous `DB Error #1062` when uploading an Inline File to a Draft. The issue is that the system does not check if an Attachment record exists before creating a new one. We create a new Attachment record, we go to save it, and the system errors out because that record already exists. This adds a check to see if the Attachment record already exists and if so we use that instead of creating a new one.