### PR TITLE
issue: Check $cfg iFrame

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -330,7 +330,8 @@ class Format {
         );
 
         // iFrame Whitelist
-        $whitelist = $cfg->getIframeWhitelist();
+        if ($cfg)
+            $whitelist = $cfg->getIframeWhitelist();
         if (!empty($whitelist)) {
             $config['elements'] = '*+iframe';
             $config['spec'] = 'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?('


### PR DESCRIPTION
This addresses an issue where we don’t check if `$cfg` exists before using it. This adds a check for `$cfg` before we use it to avoid fatal errors.