### PR TITLE
db: System Time Zone

### DIFF
--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -74,6 +74,7 @@ function db_connect($host, $user, $passwd, $options = array()) {
         'CHARACTER SET'         => 'utf8',
         'COLLATION_CONNECTION'  => 'utf8_general_ci',
         'SQL_MODE'              => '',
+        'TIME_ZONE'             => '@@global.time_zone',
     ), 'session');
     $__db->set_charset('utf8');
 


### PR DESCRIPTION
This addresses issue #5156 where using something like AWS RDS shows incorrect timezone for the database. In systems like AWS RDS you cannot set the `@@global.system_time_zone` variable to anything other than `UTC` which is a problem. This updates `db_connect` to set the session timezone to the global timezone for every connection. This will ensure the appropriate timezone is used in subsequent methods.