### PR TITLE
php: 5.6 Support

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -928,8 +928,8 @@ class TicketZipExporter {
     function download($options = array()) {
         global $thisstaff;
 
-        $notes = @$options['notes'] ?? false;
-        $tasks = @$options['tasks'] ?? false;
+        $notes = isset(@$options['notes']) ? @$options['notes'] : false;
+        $tasks = isset(@$options['tasks']) ? @$options['tasks'] : false;
 
         // TODO: Use a streaming ZIP library
         $zipfile = tempnam(sys_get_temp_dir(), 'zip');


### PR DESCRIPTION
This addresses an issue with v1.14 where `??` (null coalescing operator) in class Export throws a fatal error when using PHP 5.6. This is an issue especially for people who cannot upgrade PHP but want to take advantage of the latest osTicket codebase/features. This updates the null coalescing operator to an isset ternary operator to keep backwards compatibility with PHP 5.6.