### PR TITLE
Queues:  Agents with no team assignment

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1291,6 +1291,7 @@ class AssigneeChoiceField extends ChoiceField {
             $Q->negate();
         case 'includes':
             $teams = $agents = array();
+            $matches = count($value);
             foreach ($value as $id => $ST) {
                 switch ($id[0]) {
                 case 'M':
@@ -1300,10 +1301,10 @@ class AssigneeChoiceField extends ChoiceField {
                     $agents[] = (int) substr($id, 1);
                     break;
                 case 'T':
-                    if (!$thisstaff || !($staffTeams = $thisstaff->getTeams()))
+                    if ($thisstaff && ($staffTeams = $thisstaff->getTeams()))
+                         $teams = array_merge($staffTeams);
+                    elseif ($matches == 1)
                         return Q::any(['team_id' => null]);
-
-                    $teams = array_merge($staffTeams);
                     break;
                 case 't':
                     $teams[] = (int) substr($id, 1);


### PR DESCRIPTION
Commit d8b61e83 correctly addressed an issue with criteria for team assignment when an agent doesn't belong to a single team, BUT failed to consider cases that the criteria is part of a set of constraints. e.g Tickets assignee `includes - Me OR One of my Teams`

This commit adds a check to skip team constraint when multiple constraints are included and the Agent doesn't have team assignment.