### PR TITLE
Update class.api.php, Changed Signature of parse()

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -427,8 +427,8 @@ class ApiJsonDataParser extends JsonDataParser {
 include_once "class.mailparse.php";
 class ApiEmailDataParser extends EmailDataParser {
 
-    function parse($stream) {
-        return $this->fixup(parent::parse($stream));
+    function parse($stream, $tidy = false) {
+        return $this->fixup(parent::parse($stream, $tidy = false));
     }
 
     function fixup($data) {


### PR DESCRIPTION
This resolves an php 7.2 error!

Warning:  Declaration of ApiJsonDataParser::parse($stream) should be compatible with JsonDataParser::parse($stream, $tidy = false) in /home/xxx/www.xxx.de/include/class.api.php on line 0
