### PR TITLE
issue: Redactor Reset Buttons

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -416,16 +416,16 @@ $(function() {
                 if (file)
                     file.remove();
                 if (el.attr('data-draft-id')) {
-                    el.redactor('plugin.draft.delete');
+                    el.redactor('plugin.draft.deleteDraft');
                     el.attr('data-draft-id', '');
                 }
                 else {
                     try {
-                        el.redactor('module.source.set', '');
+                        el.redactor('source.setCode', '');
                     }
                     catch (error) {
                         el.redactor(); //reinitialize redactor
-                        el.redactor('module.source.set', '');
+                        el.redactor('source.setCode', '');
                     }
                 }
             });


### PR DESCRIPTION
This addresses an issue where since the Redactor upgrade the Reset buttons do not work anymore. This is due to the code referencing old plugin/module code that either no longer exists or has changed names. This updates the reset button code to reference the new Redactor plugin/module methods.