### PR TITLE
format: Clickable URLs

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -465,7 +465,7 @@ class Format {
             function($match) {
                 // Scan for things that look like URLs
                 return preg_replace_callback(
-                    '`(?<!>)(((f|ht)tp(s?)://|(?<!//)www\.)([-+~%/.\w]+)(?:[-?#+=&;%@.\w]*)?)'
+                    '`(?<!>)(((f|ht)tp(s?)://|(?<!//)www\.)([-+~%/.\w]+)(?:[-?#+=&;%@.\w\[\]\/]*)?)'
                    .'|(\b[_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,63})`',
                     function ($match) {
                         if ($match[1]) {


### PR DESCRIPTION
This addresses issue #5176 where some Plaintext URLs are not completely clickable. This is due to the regex check for clickable URLs not including a few characters. This adds `[`, `]`, and `/` as matchable characters so urls like `https://test.com/cart/add?route=marketplace/extension/info&product[123]=3` will be completely clickable.