### PR TITLE
Dialog: Highlight tab with error(s)

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -713,7 +713,7 @@ $.dialog = function (url, codes, cb, options) {
                         $('#msg_notice, #msg_error', $popup).delay(5000).slideUp();
                         $('div.tab_content[id] div.error:not(:empty)', $popup).each(function() {
                           var div = $(this).closest('.tab_content');
-                          $('a[href^=#'+div.attr('id')+']').parent().addClass('error');
+                          $('a[href^="#'+div.attr('id')+'"]').parent().addClass('error');
                         });
                     }
                 }


### PR DESCRIPTION
This commit addresses javascript error that occurs - on error - on a dialog modal with tabbed content.