### PR TITLE
Allow Repeatable Once Entries

### DIFF
--- a/include/class.schedule.php
+++ b/include/class.schedule.php
@@ -204,6 +204,10 @@ class Schedule extends VerySimpleModel {
             $keys = array_intersect_key($vars, array_flip(
                         ['repeats', 'day', 'week', 'month']));
             $keys['schedule_id'] = $this->getId();
+            //  Once entries can repeat on different dates
+            if ($keys['repeats'] == 'never')
+                $keys['starts_on'] = $vars['starts_on'];
+
             $entries= ScheduleEntry::objects()
                 ->filter($keys);
             if ($vars['id'])


### PR DESCRIPTION
This commit fixes a bug where you could have only one "once" entry in a schedule by allowing it on different dates.

Addresses issue #5198 