### PR TITLE
Ticket Merge Parent Status

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2555,6 +2555,9 @@ implements RestrictedAccess, Threadable, Searchable {
                 $child->setMergeType($options['combine']);
                 $child->setStatus(intval($options['statusId']), false, $errors, true, true); //force close status for children
 
+                if ($options['parentStatusId'])
+                    $parent->setStatus(intval($options['parentStatusId']));
+
                 if ($options['delete-child'] || $options['move-tasks']) {
                     if ($tasks = Task::objects()
                         ->filter(array('object_id' => $child->getId()))

--- a/include/i18n/en_US/help/tips/tickets.queue.yaml
+++ b/include/i18n/en_US/help/tips/tickets.queue.yaml
@@ -90,6 +90,12 @@ child_status:
     content: >
         All Child Tickets will be set to a closed status since thread entries will all be moved to the Parent Ticket.
 
+parent_status:
+    title: Parent Ticket Status
+    content: >
+        If you choose to set a Parent Status, the Parent Ticket will be changed to the status you select.
+        The Ticket on top of the list will be the Parent Ticket.
+
 reply_types:
     title: Reply Types
     content: >

--- a/include/staff/templates/merge-tickets.tmpl.php
+++ b/include/staff/templates/merge-tickets.tmpl.php
@@ -101,7 +101,7 @@ foreach ($tickets as $t) {
 &nbsp;&nbsp;&nbsp;
     <label class="inline checkbox">
         <?php echo __('Child Status');?>
-        <select id="statusId" name="statusId">
+        <select id="childStatusId" name="childStatusId">
         <?php
         $states = array('closed');
         foreach (TicketStatusList::getStatuses(
@@ -114,6 +114,27 @@ foreach ($tickets as $t) {
         ?>
         </select>
         <i class="help-tip icon-question-sign" href="#child_status"></i>
+    </label>
+</div>
+<br/>
+<div id="parent-status">
+&nbsp;&nbsp;&nbsp;
+    <label class="inline checkbox">
+        <?php echo __('Parent Status');?>
+        <select id="parentStatusId" name="parentStatusId">
+        <option value="">— Select —</option>
+        <?php
+        $states = array('open', 'closed');
+        foreach (TicketStatusList::getStatuses(
+                    array('states' => $states)) as $s) {
+            if (!$s->isEnabled()) continue;
+            echo sprintf('<option value="%d">%s</option>',
+                    $s->getId(),
+                    $s->getLocalName());
+        }
+        ?>
+        </select>
+        <i class="help-tip icon-question-sign" href="#parent_status"></i>
     </label>
 </div>
 <br/>


### PR DESCRIPTION
This commit gives agents the option to change the status of the Parent ticket when doing a merge. To do this, they must choose the desired status for 'Parent Status'. If no status is chosen, the Parent Ticket will remain in its current status.

![Screen Shot 2019-11-21 at 9 22 32 AM](https://user-images.githubusercontent.com/22985133/69351188-80689800-0c40-11ea-9f37-429b634687e7.png)



This change was requested in Issue #5194.