### PR TITLE
Inline Edit Fields With Data Integrity

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1332,7 +1332,6 @@ class FormField {
     }
 
     function getEditForm($source=null) {
-
         $fields = array(
                 'field' => $this,
                 'comments' => new TextareaField(array(

--- a/include/staff/templates/dynamic-form.tmpl.php
+++ b/include/staff/templates/dynamic-form.tmpl.php
@@ -84,7 +84,7 @@ if (isset($options['entry']) && $options['mode'] == 'edit') { ?>
                     ?>" data-entry-id="<?php echo $field->getAnswer()->get('entry_id');
                     ?>"> <i class="icon-trash"></i> </a></div><?php
                 }
-                if ($a && !$a->getValue() && $field->isRequiredForClose()) {
+                if ($a && !$a->getValue() && $field->isRequiredForClose() && get_class($field) != 'BooleanField') {
     ?><i class="icon-warning-sign help-tip warning"
         data-title="<?php echo __('Required to close ticket'); ?>"
         data-content="<?php echo __('Data is required in this field in order to close the related ticket'); ?>"

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -649,6 +649,13 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
                     }
                     else
                       echo $v;
+
+                    $a = $field->getAnswer();
+                    $hint = ($field->isRequiredForClose() && $a && !$a->getValue() && get_class($field) != 'BooleanField') ?
+                        sprintf('<i class="icon-warning-sign help-tip warning field-label" data-title="%s" data-content="%s"
+                        /></i>', __('Required to close ticket'),
+                        __('Data is required in this field in order to close the related ticket')) : '';
+                    echo $hint;
                   ?>
               </a>
             <?php


### PR DESCRIPTION
This commit adds the 'Required to close tickets' warning to inline edit fields if they are configured with the Data Integrity box checked (Require entry to close a thread)

Required Fields Without Data:
![Screen Shot 2019-11-21 at 9 29 38 AM](https://user-images.githubusercontent.com/22985133/69351800-7abf8200-0c41-11ea-8077-236555c8cd80.png)


Required Fields With Data:
![Screen Shot 2019-11-20 at 3 09 15 PM](https://user-images.githubusercontent.com/22985133/69278465-01c01c00-0ba8-11ea-9043-59c767a8e3ef.png)
