### PR TITLE
queues: Revert commit cedd6121

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -68,7 +68,6 @@ class CustomQueue extends VerySimpleModel {
 
     const FLAG_INHERIT_EVERYTHING = 0x158; // Maskf or all INHERIT flags
 
-    var $filters;
     var $criteria;
     var $_conditions;
 
@@ -111,14 +110,6 @@ class CustomQueue extends VerySimpleModel {
 
     function getPath() {
         return $this->path ?: $this->buildPath();
-    }
-
-    function filter($filter) {
-        $this->filters[] = $filter;
-    }
-
-    function getFilters() {
-        return $this->filters ?: array();
     }
 
     function criteriaRequired() {
@@ -909,10 +900,6 @@ class CustomQueue extends VerySimpleModel {
     function getQuery($form=false, $quick_filter=null) {
         // Start with basic criteria
         $query = $this->getBasicQuery($form);
-
-        // Apply filers if any.
-        foreach ($this->getFilters() as $filter)
-            $query->filter($filter);
 
         // Apply quick filter
         if (isset($quick_filter)

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1091,12 +1091,7 @@ extends SavedSearch {
                    'staff_id' => $thisstaff->getId(),
                    'title' => __('Advanced Search'),
                 ));
-
-       // if instance of Q then assume filters otherwise it's criteria.
-       if ($config instanceof Q)
-           $queue->filter($config);
-       else
-           $queue->config = $config;
+       $queue->config = $config;
 
        return $queue;
     }

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -57,15 +57,14 @@ if (!$ticket) {
     if ($user
             && $_GET['a'] !== 'open'
     ) {
-        $Q = Q::any([
-            'user__emails__address' => $user->getDefaultEmailAddress(),
-            'user_id' => $user->id,
-        ]);
-
+        $criteria = [
+            ['user__emails__address', 'equal', $user->getDefaultEmailAddress()],
+            ['user_id', 'equal', $user->id],
+        ];
         if ($S = $_GET['status'])
             // The actual state is tracked by the key
-            $Q = Q::all(array('status__state' => $S, $Q));
-        $_SESSION['advsearch']['uid'] = $Q;
+            $criteria[] = ['status__state', 'includes', [$S => $S]];
+        $_SESSION['advsearch']['uid'] = $criteria;
         $queue_id = "adhoc,uid";
     }
     // Search for organization tickets


### PR DESCRIPTION
This PR reverts commit cedd6121 because it broke adhoc search queue naming (describe) shows on Recent Searches section.

The spirit of the initial change was correct but support of complex criteria wasn't needed after all due to difficulty supporting multiple organizations - something we will revisit in the future.