### PR TITLE
Authentication for usernames with "\" not working without this fix

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -55,12 +55,24 @@ class MailFetcher {
             // Support Exchange shared mailbox auth
             // (eg. user@domain.com\shared@domain.com)
             $usernames = explode('\\', $this->ht['username'], 2);
-            if (count($usernames) == 2) {
-                $this->authuser = $usernames[0];
-                $this->username = $usernames[1];
-            } else {
-                $this->username = $this->ht['username'];
-            }
+           if (count($usernames) == 3) 
+           {
+                $this->authuser = $usernames[0]."\\".$usernames[1];
+                $this->username = $usernames[2];
+           } 
+	   else 
+		if (count($usernames) == 2) 
+		{
+			$this->authuser = $usernames[0];
+			if(strpos($usernames[1],'@'))
+				$this->username = $usernames[1];
+			else
+				$this->authuser = $usernames[0]."\\".$usernames[1];
+		}
+		else
+		{
+			$this->username = $this->ht['username'];
+		}
 
             if(!strcasecmp($this->ht['protocol'],'pop')) //force pop3
                 $this->ht['protocol'] = 'pop3';


### PR DESCRIPTION
Osticket developers developed the possiblity of allowing you to logon to a mailbox and check a shared mailbox that mailbox it has permission on... but how they do this is look for the '\'in the Username Edit box and anything before it is the Auth User and After is the Shared mailbox User....

The best fix would be a new edit box  for the shared mailbox... but as that doesn't exist what I do is check the username for '\' character  then to accommodate the username I connect with "Server\Account"  I split the Values by the slashes as the original does but I check if there are three values, the third being the shared mailbox email address, the second I check for an @ sign if it exists its a shared mailbox, if not I append the first and the second with a slash to get the username I desire...

I recommend this fix to the Developers... Or putting in a separate field for the share mailbox.