### PR TITLE
install: Forum and Docs Links

### DIFF
--- a/setup/inc/install-done.inc.php
+++ b/setup/inc/install-done.inc.php
@@ -31,11 +31,11 @@ $url=URL;
                 <tr>
                     <td width="50%">
                         <strong><?php echo __('osTicket Forums');?>:</strong><Br>
-                        <a href="#">https://forum.osticket.com/</a>
+                        <a href="https://forum.osticket.com/" target="_blank">https://forum.osticket.com/</a>
                     </td>
                     <td width="50%">
                         <strong><?php echo __('osTicket Documentation');?>:</strong><Br>
-                        <a href="#">https://docs.osticket.com/</a>
+                        <a href="https://docs.osticket.com/" target="_blank">https://docs.osticket.com/</a>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
This addresses issue #5215 where the Post-Install page references the Forum and Docs site but the link doesn't work. This is due to the pound symbols being the `href`. This adds the links to the `href` attribute so the links actually link to the sites.