### PR TITLE
Increase the Usage of the Agent / Admin screen real estate

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -126,7 +126,7 @@ a time {
 
 
 #container {
-    width:960px;
+    width:95%;
     margin:0 auto 20px auto;
 }
 
@@ -726,7 +726,7 @@ a time {
 .jb-overflowmenu {
     position: relative;
     height:35px;
-    width: 960px;
+    width: 100%;
 }
 
 
@@ -1120,7 +1120,7 @@ table.dashboard-stats tbody:nth-child(2) tr:hover th {
     color:#000;
 }
 
-table { vertical-align:top; }
+table { vertical-align:top; width: 100%;}
 
 table.list {
     clear:both;
@@ -1467,6 +1467,7 @@ h3.title > .sub-title {
 
 .ticket_info {
     background:#F4FAFF;
+    width: 100%;
 }
 
 .ticket_info.custom-data thead th {


### PR DESCRIPTION
Osticket uses on a fraction of the actual screen real estate, this change allows you to use the width of your screen so you can see more...
It works using 95% ratio of the screen size and 100% of that size for the internal elements... can be applied to v1.12+ 

Only three line makes all of the difference one line will need to be added to /css/redactor.css (will suggest that change tooo)

![image](https://user-images.githubusercontent.com/55503152/69562029-45e75e00-0fa6-11ea-8e19-f95a60d9882b.png)
