### PR TITLE
Overide the redactor to autosize to the full width of the container (…

### DIFF
--- a/css/redactor.css
+++ b/css/redactor.css
@@ -1041,6 +1041,7 @@
 
 .redactor-styles {
   margin: 0;
+  max-width:100% !important;  
   padding: 16px 18px;
   color: #333;
   font-family: "Trebuchet MS", "Helvetica Neue", Helvetica, Tahoma, sans-serif;


### PR DESCRIPTION
…allows the use of more screen real estate)

Override the max width of redactor limitation... so resizing your container redactor sizes accordingly....

![image](https://user-images.githubusercontent.com/55503152/69562656-8a272e00-0fa7-11ea-8d78-1c9bf24921e6.png)
