### PR TITLE
Ticket Merge/Link Defaults

### DIFF
--- a/include/i18n/en_US/role.yaml
+++ b/include/i18n/en_US/role.yaml
@@ -19,6 +19,8 @@
   permissions: [
     ticket.create,
     ticket.edit,
+    ticket.merge,
+    ticket.link,
     ticket.assign,
     ticket.release,
     ticket.transfer,
@@ -45,6 +47,8 @@
   permissions: [
     ticket.create,
     ticket.edit,
+    ticket.merge,
+    ticket.link,
     ticket.assign,
     ticket.release,
     ticket.transfer,
@@ -67,6 +71,8 @@
 
   permissions: [
     ticket.create,
+    ticket.merge,
+    ticket.link,
     ticket.assign,
     ticket.release,
     ticket.transfer,


### PR DESCRIPTION
This commit makes it so that the Ticket Merge and Link roles are enabled by default on fresh installs.