### PR TITLE
issue: Attachment Upload Configuration

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -40,7 +40,8 @@ $dispatcher = patterns('',
     url('^/form/', patterns('ajax.forms.php:DynamicFormsAjaxAPI',
         url_get('^help-topic/(?P<id>\d+)$', 'getClientFormsForHelpTopic'),
         url_post('^upload/(\d+)?$', 'upload'),
-        url_post('^upload/(\w+)?$', 'attach')
+        url_post('^upload/(\w+)?$', 'attach'),
+        url_post('^upload/(?P<object>ticket|task)/(\w+)$', 'attach')
     )),
     url('^/i18n/(?P<lang>[\w_]+)/', patterns('ajax.i18n.php:i18nAjaxAPI',
         url_get('(?P<tag>\w+)$', 'getLanguageFile')

--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -387,11 +387,20 @@ class DynamicFormsAjaxAPI extends AjaxController {
         );
     }
 
-    function attach() {
+    function attach($object=null) {
         global $thisstaff;
 
+        $filter = array('type__contains'=>'thread');
+        // Determine if for Ticket/Task/Custom
+        if ($object && is_string($object)) {
+            if ($object == 'ticket')
+                $filter['form_id'] = TicketForm::objects()->one()->id;
+            elseif ($object == 'task')
+                $filter['form_id'] = TaskForm::objects()->one()->id;
+        }
         $config = DynamicFormField::objects()
-            ->filter(array('type__contains'=>'thread'))
+            ->filter($filter)
+            ->order_by('id')
             ->first()->getConfiguration();
         $field = new FileUploadField();
         $field->_config = $config;

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -123,6 +123,7 @@ class DynamicForm extends VerySimpleModel {
             'title' => $this->getLocal('title'),
             'instructions' => $this->getLocal('instructions'),
             'id' => $this->getId(),
+            'type' => $this->type ?: null,
         ));
         return $form;
     }
@@ -1008,6 +1009,7 @@ class DynamicFormEntry extends VerySimpleModel {
                 'title' => $this->getTitle(),
                 'instructions' => $this->getInstructions(),
                 'id' => $this->form_id,
+                'type' => $this->getDynamicForm()->type ?: null,
                 );
             $this->_form = new CustomForm($fields, $source, $options);
         }

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -344,6 +344,8 @@ class Form {
 class SimpleForm extends Form {
     function __construct($fields=array(), $source=null, $options=array()) {
         parent::__construct($source, $options);
+        if (isset($options['type']))
+            $this->type = $options['type'];
         $this->setFields($fields);
     }
 
@@ -4651,6 +4653,17 @@ class FileUploadWidget extends Widget {
                 );
             }
         }
+         // Set default $field_id
+        $field_id = $this->field->get('id');
+        // Get Form Type
+        $type = $this->field->getForm()->type;
+        // Determine if for Ticket/Task/Custom
+        if ($type) {
+            if ($type == 'T')
+                $field_id = 'ticket/attach';
+            elseif ($type == 'A')
+                $field_id = 'task/attach';
+        }
 
         ?><div id="<?php echo $id;
             ?>" class="filedrop"><div class="files"></div>
@@ -4664,7 +4677,7 @@ class FileUploadWidget extends Widget {
         </div></div>
         <script type="text/javascript">
         $(function(){$('#<?php echo $id; ?> .dropzone').filedropbox({
-          url: 'ajax.php/form/upload/<?php echo $this->field->get('id') ?>',
+          url: 'ajax.php/form/upload/<?php echo $field_id; ?>',
           link: $('#<?php echo $id; ?>').find('a.manual'),
           paramname: 'upload[]',
           fallback_id: 'file-<?php echo $id; ?>',

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -61,6 +61,7 @@ $dispatcher = patterns('',
         url_delete('^answer/(?P<entry>\d+)/(?P<field>\d+)$', 'deleteAnswer'),
         url_post('^upload/(\d+)?$', 'upload'),
         url_post('^upload/(\w+)?$', 'attach'),
+        url_post('^upload/(?P<object>ticket|task)/(\w+)$', 'attach'),
         url_get('^(?P<id>\d+)/fields/view$', 'getAllFields')
     )),
     url('^/filter/', patterns('ajax.filter.php:FilterAjaxAPI',


### PR DESCRIPTION
This addresses an issue where we pull the `first()` Form Field configuration for attachments instead of determining if we are looking for the Ticket Attachment Configurations or the Task Attachment Configurations. For example, if you are creating a Ticket as a User and go to add an attachment if somehow your Task Details Form comes up first in the configuration lookup query we will apply the Task Attachment Configs instead of the Ticket Attachment Configs which is totally incorrect. This updates the lookup for attachment configurations on web uploads to be specific about what it’s looking for so it can get the correct configuration.