### PR TITLE
issue: mPDF Print Tables

### DIFF
--- a/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -263,7 +263,7 @@ class ConfigVariables
 			'packTableData' => false,
 
 			'ignore_table_percents' => false,
-			'ignore_table_widths' => false,
+			'ignore_table_widths' => true,
 			// If table width set > page width, force resizing but keep relative sizes
 			// Also forces respect of cell widths set by %
 			'keep_table_proportions' => true,


### PR DESCRIPTION
This addresses an issue where printing a Ticket with a Table in one of the threads will cause the PDF to be malformed. This is due to mPDF config variable that was changed (most likely by `git checkout` or git conflicts). This sets the `ignore_table_widths` variable back to true so that tables will fit the PDF width.