### PR TITLE
allow for yyyy year notation in custom date format

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -43,8 +43,8 @@ class OverviewReport {
         $format =  $format ?: $this->format;
         if ($translate) {
             $format = str_replace(
-                    array('y', 'Y', 'm'),
-                    array('yy', 'yyyy', 'mm'),
+                    array('yyyy','y', 'Y', 'm'),
+                    array('yy','yy', 'yyyy', 'mm'),
                     $format);
         }
 


### PR DESCRIPTION
This allows the settings of custom dates to use the 'yyyy' year notation for a 4 digit year instead of 'y' which is slightly less intuative.

Without this patch, using the yyyy year notation in custom configurations will result in the scp dashboard reports date selector switching from 2019 to 2020 as the system reads the first two digits of the returned value. 

