### PR TITLE
1.14.x Increase both client and Agent Screens to use full Width

### DIFF
--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -288,7 +288,7 @@ h2, .subject {
   background-color: #0299d2;
 }
 body {
-  background:#00034c;
+  background:#00034c !important;
   /* background: url('../images/page_bg.png') top left repeat-x #c8c8c8; */
 }
 #container {

--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -89,6 +89,7 @@ textarea {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  width:100%;
 }
 th,
 td {
@@ -287,11 +288,12 @@ h2, .subject {
   background-color: #0299d2;
 }
 body {
-  background: url('../images/page_bg.png') top left repeat-x #c8c8c8;
+  background:#00034c;
+  /* background: url('../images/page_bg.png') top left repeat-x #c8c8c8; */
 }
 #container {
   background: #fff;
-  width: 840px;
+  width: 95%;
   margin: 0 auto;
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
   -moz-box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
@@ -628,6 +630,7 @@ label.required, span.required {
 }
 #ticketForm > table {
     table-layout: fixed;
+	width: 98%;
 }
 #ticketForm > table td {
     width: 160px;
@@ -796,6 +799,7 @@ label.required, span.required {
   border: 1px solid #aaa;
   border-left: none;
   border-bottom: none;
+  width: 100%;
 }
 #ticketTable caption {
   padding: 5px;

--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -327,7 +327,7 @@ body {
 #nav {
   margin: 0 20px;
   padding: 2px 10px;
-  height: 20px;
+  height: 25px;
   background: url('../images/nav_bg.png') top left repeat-x;
   border-top: 1px solid #aaa;
   box-shadow: 0 3px 2px rgba(0, 0, 0, 0.4);

--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -294,6 +294,7 @@ body {
 #container {
   background: #fff;
   width: 95%;
+  min-width: 790px;
   margin: 0 auto;
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
   -moz-box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);

--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -212,6 +212,7 @@ h2, .subject {
   margin-bottom: 10px;
   border: 1px solid #f26522;
   background: url('../images/icons/alert.png') 10px 50% no-repeat #ffffdd;
+  box-sizing: content-box;
 }
 #msg_error {
   margin: 0;

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -58,6 +58,9 @@ if ($lang) {
     <script type="text/javascript" src="<?php echo ROOT_PATH; ?>js/redactor-plugins.js"></script>
     <script type="text/javascript" src="<?php echo ROOT_PATH; ?>js/redactor-osticket.js"></script>
     <script type="text/javascript" src="<?php echo ROOT_PATH; ?>js/select2.min.js"></script>
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <?php
     if($ost && ($headers=$ost->getExtraHeaders())) {
         echo "\n\t".implode("\n\t", $headers)."\n";

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -6,7 +6,7 @@ body {
           font-smoothing:antialiased;
 }
 body, html {
-    background:#eee;
+    background:#00034c;
     color:#000;
     font-size:14px;
     margin:0;
@@ -126,7 +126,8 @@ a time {
 
 
 #container {
-    width:960px;
+    width:95%;
+	min-width:1200px;
     margin:0 auto 20px auto;
 }
 
@@ -726,7 +727,7 @@ a time {
 .jb-overflowmenu {
     position: relative;
     height:35px;
-    width: 960px;
+    width: 100%;
 }
 
 
@@ -1120,7 +1121,7 @@ table.dashboard-stats tbody:nth-child(2) tr:hover th {
     color:#000;
 }
 
-table { vertical-align:top; }
+table { vertical-align:top; width: 100%;}
 
 table.list {
     clear:both;
@@ -1467,6 +1468,7 @@ h3.title > .sub-title {
 
 .ticket_info {
     background:#F4FAFF;
+	width: 100%;
 }
 
 .ticket_info.custom-data thead th {
@@ -3585,7 +3587,7 @@ input[type=checkbox] {
   padding: 0;
   margin:0;
   margin-right: 0.1em;
-  vertical-align: middle;
+  vertical-align: bottom;
   position: relative;
   top: -0.05em;
   *overflow: hidden;


### PR DESCRIPTION
Increase both client and Agent Screens to use full Width

Small Changes that make a world of difference...

Also added bootstrap to client header to allow a slightly nicer feel to the design...

Try it out let me know your thoughts....

Client View:
![image](https://user-images.githubusercontent.com/55503152/69729102-a9e06280-111d-11ea-9017-dbfd1aa705f7.png)


Agent View:
![image](https://user-images.githubusercontent.com/55503152/69729177-cbd9e500-111d-11ea-911c-29a07f35272a.png)
