### PR TITLE
issue: Shared Mailbox Auth

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -54,10 +54,17 @@ class MailFetcher {
         if ($this->ht) {
             // Support Exchange shared mailbox auth
             // (eg. user@domain.com\shared@domain.com)
-            $usernames = explode('\\', $this->ht['username'], 2);
-            if (count($usernames) == 2) {
-                $this->authuser = $usernames[0];
-                $this->username = $usernames[1];
+            $usernames = explode('\\', $this->ht['username']);
+            $count = count($usernames);
+            if ($count == 3) {
+                $this->authuser = $usernames[0].'\\'.$usernames[1];
+                $this->username = $usernames[2];
+            } elseif ($count == 2) {
+                if (strpos($usernames[0], '@') !== false) {
+                    $this->authuser = $usernames[0];
+                    $this->username = $usernames[1];
+                } else
+                    $this->username = $usernames[0].'\\'.$usernames[1];
             } else {
                 $this->username = $this->ht['username'];
             }


### PR DESCRIPTION
This addresses an issue where using "Servername\user@domain.tld" for mailbox Login Username fails due to the Shared Mailbox Auth introduced here (ac9ea5b). We do not check the name to see if the first part of the string contains an @ symbol, indicating an email address. This updates the Shared Mailbox Auth check to look for 3 parts, if detected it will use the first two parts as the `authuser` and the second part as the `username`. This also checks for 2 parts, if detected it will check the first part for @ symbol and if one is present will use the first part as the `authuser` and the second part as the `username`. Otherwise it will use both parts as the `username`. If there are more than three parts or just one part, the entire string is used as the `username`.

#### Examples:
| String                                             | authuser                       | username                       |
|----------------------------------------------------|--------------------------------|--------------------------------|
| user@domain.tld                                |                                | user@domain.tld            |
| user@domain.tld\shared@domain.tld            | user@domain.tld            | shared@domain.tld            |
| Servername\user@domain.tld                     |                                | Servername\user@domain.tld |
| Servername\user@domain.tld\shared@domain.tld | Servername\user@domain.tld | shared@domain.tld            |