### PR TITLE
emoji: Strip From Subject

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -396,7 +396,7 @@ class ApiJsonDataParser extends JsonDataParser {
                 $value = (bool)$value;
             } elseif ($key == "message") {
                 // Allow message specified in RFC 2397 format
-                $data = Format::parseRfc2397($value, 'utf-8');
+                $data = Format::strip_emoticons(Format::parseRfc2397($value, 'utf-8'));
 
                 if (isset($data['type']) && $data['type'] == 'text/html')
                     $value = new HtmlThreadEntryBody($data['data']);

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1486,7 +1486,7 @@ class TextboxField extends FormField {
     }
 
     function parse($value) {
-        return Format::striptags($value);
+        return Format::strip_emoticons(Format::striptags($value));
     }
 
     function display($value) {

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1530,7 +1530,7 @@ implements TemplateVariable {
             'created' => SqlFunction::NOW(),
             'type' => $vars['type'],
             'thread_id' => $vars['threadId'],
-            'title' => Format::sanitize($vars['title'], true),
+            'title' => Format::strip_emoticons(Format::sanitize($vars['title'], true)),
             'format' => $vars['body']->getType(),
             'staff_id' => $vars['staffId'],
             'user_id' => $vars['userId'],


### PR DESCRIPTION
This addresses an issue reported on the Forum where emojis are not stripped from the subject line which causes either a blank subject or half-rendered subject. This adds `Format::strip_emoticons` to TextboxField::parse in class forms so all Textbox Fields (including Issue Summary) is stripped of Emojis (since we can't handle them at all). This is also added to ThreadEntry::create in class thread so that the ThreadEntry Titles have Emojis stripped as well.

This addresses an issue where we forgot about Emojis in the Issue Details of Tickets created via API. This adds `Format::strip_emoticons` to class api so that Emojis are stripped from the Issue Details for Tickets created via API.