### PR TITLE
Issue: Help Topic Number Format

### DIFF
--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -453,8 +453,8 @@ implements TemplateVariable, Searchable {
         $this->isactive = $vars['isactive'];
         $this->ispublic = $vars['ispublic'];
         $this->sequence_id = $vars['custom-numbers'] ? $vars['sequence_id'] : 0;
-        $this->number_format = $vars['custom-numbers'] ? $vars['number_format'] : '';
-        $this->flags = $vars['custom-numbers'] ? self::FLAG_CUSTOM_NUMBERS : $this->flags;
+        $this->number_format = $vars['number_format'];
+        $this->setFlag(self::FLAG_CUSTOM_NUMBERS, ($vars['custom-numbers']));
         $this->noautoresp = !!$vars['noautoresp'];
         $this->notes = Format::sanitize($vars['notes']);
 


### PR DESCRIPTION
This commit fixes an issue where we did not clear the FLAG_CUSTOM_NUMBERS flag when setting the ticket number format back to System Default for Help Topics. We also needed to set the number format to NULL rather than '' when clearing it out.