### PR TITLE
Issue: Mass Process Add Users to Orgs

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -149,8 +149,10 @@ class UserModel extends VerySimpleModel {
     }
 
     function setOrganization($org, $save=true) {
-
-        $this->set('org', $org);
+        if ($org && $this->get('org'))
+            return false;
+        else
+            $this->set('org', $org);
 
         if ($save)
             $this->save();

--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -288,8 +288,11 @@ $(function() {
             $.dialog('ajax.php/orgs/lookup/form', 201, function(xhr, json) {
               var $form = $('form#users-list');
               try {
-                  var json = $.parseJSON(json),
-                      org_id = $form.find('#org_id');
+                  var org_id = $form.find('#org_id');
+
+                  if (typeof(json) != 'object')
+                    json = $.parseJSON(json);
+
                   if (json.id) {
                       org_id.val(json.id);
                       goBaby('setorg', true);
@@ -321,4 +324,3 @@ $(function() {
     };
 });
 </script>
-

--- a/scp/users.php
+++ b/scp/users.php
@@ -140,7 +140,7 @@ if ($_POST) {
                     $errors['err'] = __('Unable to manage any of the selected end users');
                 }
                 elseif ($_POST['count'] && $count != $_POST['count']) {
-                    $warn = __('Not all selected items were updated');
+                    $warn = sprintf(__('Successfully managed %s of %s selected end users'), $count, $_POST['count']);
                 }
                 elseif ($count) {
                     $msg = __('Successfully managed selected end users');


### PR DESCRIPTION
This commit fixes an issue where we could not add multiple users to an organization at a time due to an issue with trying to pass an object to parseJSON rather than a string.

If any of the selected users are already part of a different organization, their organization will NOT be changed.

It also fixes the Organization typeahead to search through parts of an organization name rather than having to type out the whole thing before returning the organization.