### PR TITLE
issue: Department Disable Auto Claim

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -862,7 +862,7 @@ implements TemplateVariable, Searchable {
         $this->flags = $vars['flags'] ?: 0;
 
         $this->setFlag(self::FLAG_ASSIGN_MEMBERS_ONLY, isset($vars['assign_members_only']));
-        $this->setFlag(self::FLAG_DISABLE_AUTO_CLAIM, isset($vars['disable_auto_claim']));
+        $this->setFlag(self::FLAG_DISABLE_AUTO_CLAIM, ($vars['disable_auto_claim'] == 1) ? true : false);
         $this->setFlag(self::FLAG_DISABLE_REOPEN_AUTO_ASSIGN, isset($vars['disable_reopen_auto_assign']));
 
         $filter_actions = FilterAction::objects()->filter(array('type' => 'dept', 'configuration' => '{"dept_id":'. $this->getId().'}'));


### PR DESCRIPTION
This addresses an issue reported on the Forum where unchecking the option `disable_auto_claim` in 1.14.x and saving will not actually uncheck the setting. This is due to a check introduced with (7cfc062) that sets the `disable_auto_claim` variable to an integer of `1` or `0`. This updates the `setFlag` method for `disable_auto_claim` to check if it's equal to `1`, if so it returns `true` otherwise it returns `false`.