### PR TITLE
issue: Redactor z-index

### DIFF
--- a/css/redactor.css
+++ b/css/redactor.css
@@ -436,7 +436,8 @@
     display: none; }
 
 .redactor-toolbar-wrapper {
-  position: relative; }
+  position: relative;
+  z-index: 1; }
 
 .redactor-toolbar,
 .redactor-air {


### PR DESCRIPTION
This addresses an issue where the Action drop downs, if long enough, will appear behind the Redactor toolbar. This adds a `z-index` property of `1` to Redactor toolbar so it appears in the background.

**Before:**
<img width="960" alt="after" src="https://user-images.githubusercontent.com/11823401/70163973-fbd93900-1685-11ea-930b-90b0d4087df5.png">

**After:**
<img width="956" alt="before" src="https://user-images.githubusercontent.com/11823401/70163964-f54ac180-1685-11ea-9852-20fe332a3912.png">