### PR TITLE
notes: Confirm Deletion

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1191,6 +1191,8 @@ $(document).on('click.note', '.quicknote .action.save-note', function() {
     return false;
 });
 $(document).on('click.note', '.quicknote .delete', function() {
+  if (!window.confirm(__('Confirm Deletion')))
+    return;
   var that = $(this),
       id = $(this).closest('.quicknote').data('id');
   $.ajax('ajax.php/note/' + id, {


### PR DESCRIPTION
This addresses 1/2 of issue #3573 where deleting Notes does not ask for confirmation which can be a huge problem if you accidentally click the trash can. This adds basic javascript confirmation to ensure you truly want to delete the note.