### PR TITLE
Issue: Auto Referral

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -632,6 +632,15 @@ implements TemplateVariable, Searchable {
         return $row ? $row[0] : 0;
     }
 
+    static function getEmailIdById($id) {
+        $row = static::objects()
+            ->filter(array('id' => $id))
+            ->values_flat('email_id')
+            ->first();
+
+        return $row ? $row[0] : 0;
+    }
+
     function getNameById($id) {
         $names = Dept::getDepartments();
         return $names[$id];

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1319,12 +1319,14 @@ implements TemplateVariable {
 
     /* static */
     function logEmailHeaders($id, $mid, $header=false) {
+        $headerInfo = Mail_Parse::splitHeaders($header);
 
         if (!$id || !$mid)
             return false;
 
         $this->email_info = new ThreadEntryEmailInfo(array(
             'thread_entry_id' => $id,
+            'email_id' => Email::getIdByEmail($headerInfo['Delivered-To']),
             'mid' => $mid,
         ));
 
@@ -1996,6 +1998,12 @@ class ThreadEvent extends VerySimpleModel {
             'topic' => array(
                 'constraint' => array(
                     'topic_id' => 'Topic.topic_id',
+                ),
+                'null' => true,
+            ),
+            'event' => array(
+                'constraint' => array(
+                    'event_id' => 'Event.id',
                 ),
                 'null' => true,
             ),

--- a/include/upgrader/streams/core.sig
+++ b/include/upgrader/streams/core.sig
@@ -1,1 +1,1 @@
-4bd47d94b10bd8a6bab35c119dadf41f
+e7038ce9762843b6cfbe9fa2d98feaf3

--- a/include/upgrader/streams/core/4bd47d94-e7038ce9.cleanup.sql
+++ b/include/upgrader/streams/core/4bd47d94-e7038ce9.cleanup.sql
@@ -1,0 +1,8 @@
+-- Rename old thread_event table
+RENAME TABLE `%TABLE_PREFIX%thread_entry_email` TO `%TABLE_PREFIX%thread_entry_email_old`;
+
+-- Change tmp_table to thread_event
+RENAME TABLE `%TABLE_PREFIX%thread_entry_email_new` TO `%TABLE_PREFIX%thread_entry_email`;
+
+-- Drop old thread_event table
+DROP TABLE `%TABLE_PREFIX%thread_entry_email_old`;

--- a/include/upgrader/streams/core/4bd47d94-e7038ce9.patch.sql
+++ b/include/upgrader/streams/core/4bd47d94-e7038ce9.patch.sql
@@ -1,0 +1,24 @@
+/**
+ * @signature e7038ce9762843b6cfbe9fa2d98feaf3
+ * @version v1.15
+ * @title Add email_id to thread_entry_email
+ *
+ * This patch adds an email_id column to the thread_entry_email table
+ */
+ -- Create a blank temporary table with the new email_id column
+ CREATE TABLE `%TABLE_PREFIX%thread_entry_email_new` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `thread_entry_id` int(11) unsigned NOT NULL,
+  `email_id` int(11) unsigned DEFAULT NULL,
+  `mid` varchar(255) NOT NULL,
+  `headers` text,
+  PRIMARY KEY (`id`),
+  KEY `thread_entry_id` (`thread_entry_id`),
+  KEY `mid` (`mid`),
+  KEY `email_id` (`email_Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+ -- Finished with patch
+UPDATE `%TABLE_PREFIX%config`
+    SET `value` = 'e7038ce9762843b6cfbe9fa2d98feaf3'
+    WHERE `key` = 'schema_signature' AND `namespace` = 'core';

--- a/include/upgrader/streams/core/4bd47d94-e7038ce9.task.php
+++ b/include/upgrader/streams/core/4bd47d94-e7038ce9.task.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * Populate the temporary thread_entry_email table in batches
+ * to avoid an alter table statement to add the email_id column.
+ */
+ require_once INCLUDE_DIR.'class.migrater.php';
+ define('THREAD_ENTRY_EMAIL_NEW_TABLE', TABLE_PREFIX.'thread_entry_email_new');
+
+ class ThreadEntryEmailNew extends VerySimpleModel {
+    static $meta = array(
+        'table' => THREAD_ENTRY_EMAIL_NEW_TABLE,
+        'pk' => array('id'),
+    );
+ }
+
+ class ThreadEntryEmailMigration extends MigrationTask {
+     var $description = "Add an email_id column to the thread_entry_email table";
+     var $queue;
+     var $skipList;
+     var $errorList = array();
+     var $limit = 20000;
+
+     function sleep() {
+         return array('queue'=>$this->queue, 'skipList'=>$this->skipList);
+     }
+     function wakeup($stuff) {
+         $this->queue = $stuff['queue'];
+         $this->skipList = $stuff['skipList'];
+         while (!$this->isFinished())
+             $this->do_batch(30, $this->limit);
+     }
+
+     function run($max_time) {
+         $this->do_batch($max_time * 0.9, $this->limit);
+     }
+
+     function isFinished() {
+         return $this->getQueueLength() == 0;
+     }
+
+     function do_batch($time=30, $max=0) {
+         if(!$this->queueEvents($max) || !$this->getQueueLength())
+             return 0;
+
+         $this->setStatus("{$this->getQueueLength()} records remaining");
+
+         $count = 0;
+         $start = Misc::micro_time();
+         while ($this->getQueueLength() && (Misc::micro_time()-$start) < $time) {
+             if($this->next() && $max && ++$count>=$max) {
+                 break;
+             }
+         }
+
+         return $this->queueEvents($max);
+     }
+
+     function queueEvents($limit=0){
+         global $cfg, $ost;
+
+         # Since the queue is persistent - we want to make sure we get to empty
+         # before we find more events.
+         if(($qc=$this->getQueueLength()))
+             return $qc;
+
+         // Count how many rows are left
+         $sql = "SELECT COUNT(old.id)
+            FROM ". THREAD_ENTRY_EMAIL_TABLE." old
+            WHERE old.id NOT IN (SELECT new.id FROM ". THREAD_ENTRY_EMAIL_NEW_TABLE ." new)";
+
+         //XXX: Do a hard fail or error querying the database?
+         if(!($res=db_query($sql)))
+             return $this->error('Unable to query DB for Thread Entry Email migration!');
+
+         $count = db_result($res);
+
+         // Force the log message to the database
+         $ost->logDebug("Thread Entry Email Migration", 'Found '.$count
+             .' records to migrate', true);
+
+         if($count == 0)
+             return 0;  //Nothing else to do!!
+
+         // Get id of the next record to be inserted into the new table
+         $start = db_result(db_query("SELECT id
+         FROM ". THREAD_ENTRY_EMAIL_TABLE ."
+         WHERE id > (SELECT MAX(id) FROM ". THREAD_ENTRY_EMAIL_NEW_TABLE .")
+         LIMIT 1"));
+         $start = intval($start);
+
+         $this->queue = array();
+         $info=array(
+             'count'        => $count,
+             'start'        => $start,
+             'end'          => $start + $limit
+         );
+         $this->enqueue($info);
+
+         return $this->getQueueLength();
+     }
+
+     function skip($id, $error) {
+         $this->skipList[] = $id;
+
+         return $this->error($error." (ID #$id)");
+     }
+
+     function error($what) {
+         global $ost;
+
+         $this->errors++;
+         $this->errorList[] = $what;
+         // Log the error but don't send the alert email
+         $ost->logError('Upgrader: Thread Entry Email Migrater', $what, false);
+         # Assist in returning FALSE for inline returns with this method
+         return false;
+     }
+
+     function getErrors() {
+         return $this->errorList;
+     }
+
+     function getSkipList() {
+         return $this->skipList;
+     }
+
+     function enqueue($info) {
+         $this->queue[] = $info;
+     }
+
+     function getQueueLength() {
+         return $this->queue[0]['count'];
+     }
+
+     function next() {
+         # Fetch next item -- use the last item so the array indices don't
+         # need to be recalculated for every shift() operation.
+         $info = array_pop($this->queue);
+
+         // Insert rows into the new table starting at the start and stopping at the end id
+         $sql = "INSERT INTO ". THREAD_ENTRY_EMAIL_NEW_TABLE ."
+             SELECT B.id, B.thread_entry_id, NULL, B.mid, B.headers
+             FROM ". THREAD_ENTRY_EMAIL_TABLE . " B
+             WHERE B.id >= ".$info['start']." AND B.id < ". $info['end'];
+
+         db_query($sql);
+
+         return true;
+     }
+ }
+ return 'ThreadEntryEmailMigration';
+
+?>

--- a/setup/inc/streams/core/install-mysql.sql
+++ b/setup/inc/streams/core/install-mysql.sql
@@ -695,11 +695,13 @@ DROP TABLE IF EXISTS `%TABLE_PREFIX%thread_entry_email`;
 CREATE TABLE `%TABLE_PREFIX%thread_entry_email` (
   `id` int(11) unsigned NOT NULL auto_increment,
   `thread_entry_id` int(11) unsigned NOT NULL,
+  `email_id` int(11) unsigned DEFAULT NULL,
   `mid` varchar(255) NOT NULL,
   `headers` text,
   PRIMARY KEY (`id`),
   KEY `thread_entry_id` (`thread_entry_id`),
-  KEY `mid` (`mid`)
+  KEY `mid` (`mid`),
+  KEY `email_id` (`email_id`)
 ) DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `%TABLE_PREFIX%thread_entry_merge`;
@@ -750,7 +752,8 @@ CREATE TABLE `%TABLE_PREFIX%ticket` (
   KEY `closed` (`closed`),
   KEY `duedate` (`duedate`),
   KEY `topic_id` (`topic_id`),
-  KEY `sla_id` (`sla_id`)
+  KEY `sla_id` (`sla_id`),
+  KEY `ticket_pid` (`ticket_pid`)
 ) DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `%TABLE_PREFIX%lock`;


### PR DESCRIPTION
This commit fixes an issue we had with Auto Referrals. If a Ticket had been transfered/responded to by 3 or more departments and a user sent in an email response to one of the transferred departments (not including the original or current department), we created an auto referral for that department which could potentially give agents to access they should not have access to.

A new column, email_id, has been added to the thread_entry_email table so that we can see which system email each thread entry has been fetched from.

This commit also adds the event (EVENT_TABLE) relationship to the ThreadEvents (THREAD_EVENT_TABLE) class.