### PR TITLE
fix issue on MySQL 8 on user creation

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -1329,7 +1329,7 @@ abstract class PasswordPolicy {
                         Q::not(array('session_id' => $user->session->session_id)));
                 break;
             case ($model instanceof User):
-                $regexp = '_auth\|.*"user";[a-z]+:[0-9]+:{[a-z]+:[0-9]+:"id";[a-z]+:'.$model->getId();
+                $regexp = '_auth\|.*"user";[a-z]+:[0-9]+:\{[a-z]+:[0-9]+:"id";[a-z]+:'.$model->getId();
                 $criteria['user_id'] = 0;
                 $criteria['session_data__regex'] = $regexp;
 


### PR DESCRIPTION
error in apache log : Uncaught InconsistentModelException: Unable to prepare query
SQL error was Error Code: 3692. Incorrect description of a {min,max} interval.