### PR TITLE
Issue: Inline Edit Long Answer

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -635,12 +635,16 @@ class TicketsAjaxAPI extends AjaxController {
                     case $field instanceof DepartmentField:
                         $clean = (string) Dept::lookup($field->getClean());
                         break;
+                    case $field instanceof TextareaField:
+                        $clean =  (string) $field->getClean();
+                        $clean = Format::striptags($clean) ? $clean : '&mdash;' . __('Empty') .  '&mdash;';
+                        if (strlen($clean) > 200)
+                             $clean = Format::truncate($clean, 200);
+                        break;
                     default:
                         $clean =  $field->getClean();
                         $clean = is_array($clean) ? implode($clean, ',') :
                             (string) $clean;
-                        if (strlen($clean) > 200)
-                             $clean = Format::truncate($clean, 200);
                 }
 
                 // Set basic response data

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -674,9 +674,9 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
         $id =  $a->getLocal('id');
         $label = $a->getLocal('label');
         $v = $a->display();
-        $class = $v ? '' : 'class="faded"';
-        $clean = $v ?: '&mdash;' . __('Empty') .  '&mdash;';
         $field = $a->getField();
+        $class = (Format::striptags($v)) ? '' : 'class="faded"';
+        $clean = (Format::striptags($v)) ? $v : '&mdash;' . __('Empty') .  '&mdash;';
         $isFile = ($field instanceof FileUploadField);
 ?>
         <tr>
@@ -688,7 +688,7 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
                     if ($isFile && !$isEmpty) {
                         echo sprintf('<span id="field_%s" %s >%s</span><br>', $id,
                             $class,
-                            $v ?: '<span class="faded">&mdash;' . __('Empty') .  '&mdash; </span>');
+                            $clean);
                     }
                          ?>
                   <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
@@ -713,7 +713,7 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
               </a>
             <?php
             } else {
-                echo $v;
+                echo $clean;
             } ?>
             </td>
         </tr>


### PR DESCRIPTION
This commit fixes an issue we had with saving an empty long answer field using inline edit. Before, the field would save as an empty line break which would then technically be set and saved, displaying nothing in the field, which prevented agents from doing another inline edit on the long answer field. This is most likely do to the redactor update that makes all the lines double spaced now.