### PR TITLE
Issue: Ticket Open URL

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -398,6 +398,7 @@ if($_POST && !$errors):
 
                     if(($ticket=Ticket::open($vars, $errors))) {
                         $msg=__('Ticket created successfully');
+                        $redirect = 'tickets.php?id='.$ticket->getId();
                         $_REQUEST['a']=null;
                         if (!$ticket->checkStaffPerm($thisstaff) || $ticket->isClosed())
                             $ticket=null;


### PR DESCRIPTION
This commit fixes an issue where when an Agent opens a Ticket, the URL still had a=open in it. This made it to where if you refreshed the page immediately after creating the ticket, a new identical ticket would be created. It also made it to where if you tried to open a task from within the ticket immediately after opening it, you would be navigated to the open ticket screen.

To fix this, we can just set the redirect to go to the ticket's id once the ticket has been created.