### PR TITLE
PEAR: Turn off peer verification (SMTP)

### DIFF
--- a/include/pear/Net/SMTP.php
+++ b/include/pear/Net/SMTP.php
@@ -170,7 +170,7 @@ class Net_SMTP
         // Turn off peer name verification by default
         if (!$socket_options)
             $socket_options = array(
-                    'ssl' => array('verify_peer_name' => false)
+                    'ssl' => array('verify_peer_name' => false, 'verify_peer' => false)
                     );
 
         $this->socket_options = $socket_options;


### PR DESCRIPTION
As verify_peer_name is already disabled then it is logical to also disable verify_peer.

verify_peer_name disables check of certificate name (but does not disable check of a certificate itself, it should be trusted).
verify_peer also disables check of a certificate itself.

So if we already allow a certificate with ANY name then we also can just allow ANY certificate, it does not add security problems.

Also such certificates are widely used by self-hosted mail servers. And for example Plesk enables TLS by default but even does not provide a way to set another/correct certificate.