### PR TITLE
Fixes broken popup problem related to edit-user-permission.

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -569,6 +569,7 @@ implements TemplateVariable, Searchable {
                     $name = $name->getClean();
                     if (is_array($name))
                         $name = implode(', ', $name);
+                    $name = str_replace('"', '', $name);
                     $this->name = $name;
                 }
 

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -88,6 +88,8 @@ if ($_POST)
                   <tr><td><?php echo __('User'); ?>:</td><td>
                     <div id="user-info">
                       <input type="hidden" name="uid" id="uid" value="<?php echo $user->getId(); ?>" />
+                      <?php if( $thisstaff->hasPerm(User::PERM_EDIT)) { ?>
+
                       <a href="#" onclick="javascript:
                       $.userLookup('ajax.php/users/<?php echo $user->getId(); ?>/edit',
                       function (user) {
@@ -95,7 +97,13 @@ if ($_POST)
                         $('#user-email').text(user.email);
                       });
                       return false;
-                      "><i class="icon-user"></i>
+                      ">
+                                                                                 ">
+                     <?php }else { ?>
+                        <a href="#">
+                     <?php } ?>
+
+                      <i class="icon-user"></i>
                       <span id="user-name"><?php echo Format::htmlchars($user->getName()); ?></span>
                       &lt;<span id="user-email"><?php echo $user->getEmail(); ?></span>&gt;
                     </a>


### PR DESCRIPTION
When creating a new ticket there is a link shown (in a popup) to edit-user. However if the current staff is not allowed to edit users, he/she will hit a broken popup  (blank +  malfunctioning). The proposed solution is to only show the edit-user-link if the current staff has the edit-user-permission.

Nb. I tested this only on v1.12.