### PR TITLE
Issue: Ticket Search Typeahead

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -41,6 +41,7 @@ class TicketsAjaxAPI extends AjaxController {
                 'tickets' => SqlAggregate::COUNT('ticket_id', true),
             ))
             ->order_by(SqlAggregate::SUM(new SqlCode('Z1.relevance')), QuerySet::DESC)
+            ->distinct('user__default_email__address')
             ->limit($limit);
 
         $q = $_REQUEST['q'];


### PR DESCRIPTION
When an agent uses the search bar located in the ticket queue, we include a dropdown that shows if the search has found any tickets based on what the agent has typed so far. We also include the number of tickets found in parentheses.

This commit fixes an issue where the number in parentheses for the tickets found always showed as (1). To fix this, we needed to group tickets found based on the ticket user's email address.