### PR TITLE
feature: Force HTTPS

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -228,6 +228,7 @@ class OsticketConfig extends Config {
         'ticket_lock' => 2, // Lock on activity
         'max_open_tickets' => 0,
         'files_req_auth' => 1,
+        'force_https' => '',
     );
 
     function __construct($section=null) {
@@ -653,6 +654,10 @@ class OsticketConfig extends Config {
 
     function getTopicSortMode() {
         return $this->get('help_topic_sort_mode');
+    }
+
+    function forceHttps() {
+        return $this->get('force_https') == 'on';
     }
 
     function setTopicSortMode($mode) {
@@ -1258,6 +1263,7 @@ class OsticketConfig extends Config {
             'helpdesk_title'=>$vars['helpdesk_title'],
             'helpdesk_url'=>$vars['helpdesk_url'],
             'default_dept_id'=>$vars['default_dept_id'],
+            'force_https'=>$vars['force_https'] ? 'on' : '',
             'max_page_size'=>$vars['max_page_size'],
             'log_level'=>$vars['log_level'],
             'log_graceperiod'=>$vars['log_graceperiod'],

--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -50,6 +50,18 @@ default_schedule:
       - title: Manage Schedules
         href: /scp/schedules.php
 
+force_https:
+    title: Force HTTPS
+    content: >
+        This setting allows Admins to configure wether or not they want to Force
+        HTTPS system-wide. If enabled, any request that is using the HTTP protocol
+        will be redirected to the HTTPS protocol. Note, this will only work if you
+        have an SSL certificate installed and have HTTPS configured on the server.
+        <br/><br/>
+        <b>Note:</b><rb/>
+        This might affect remote piping scripts. Reference new scripts included in
+        <code>setup/scripts/</code> for updates.
+
 default_page_size:
     title: Default Page Size
     content: >

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -62,6 +62,16 @@ $gmtime = Misc::gmtime();
             </td>
         </tr>
         <tr>
+            <td><?php echo __('Force HTTPS'); ?>:</td>
+            <td>
+                <input type="checkbox" name="force_https" <?php
+                echo $config['force_https'] ? 'checked="checked"' : ''; ?>>
+                <?php echo __('Force all requests through HTTPS.'); ?>
+                <font class="error"><?php echo $errors['force_https']; ?></font>
+                <i class="help-tip icon-question-sign" href="#force_https"></i>
+            </td>
+        </tr>
+        <tr>
             <td><?php echo __('Collision Avoidance Duration'); ?>:</td>
             <td>
                 <input type="text" name="autolock_minutes" size=4 value="<?php echo $config['autolock_minutes']; ?>">

--- a/main.inc.php
+++ b/main.inc.php
@@ -33,6 +33,15 @@ $_SERVER['REMOTE_ADDR'] = osTicket::get_client_ip();
 if(!($ost=osTicket::start()) || !($cfg = $ost->getConfig()))
 Bootstrap::croak(__('Unable to load config info from DB.').' '.__('Get technical help!'));
 
+if ($cfg && $cfg->forceHttps()
+        && !osTicket::is_cli()
+        && !osTicket::is_https()) {
+    if ($_SERVER['REQUEST_METHOD'] !== 'GET')
+        Http::response(400, 'HTTPS Protocol Required');
+
+    Http::redirect('https://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']);
+}
+
 //Init
 $session = $ost->getSession();
 

--- a/setup/scripts/automail.php
+++ b/setup/scripts/automail.php
@@ -6,7 +6,7 @@
     PHP script used for remote email piping...same as as the perl version.
 
     Peter Rotich <peter@osticket.com>
-    Copyright (c)  2006-2013 osTicket
+    Copyright (c)  2006-2020 osTicket
     http://www.osticket.com
 
     Released under the GNU General Public License WITHOUT ANY WARRANTY.
@@ -16,12 +16,12 @@
 **********************************************************************/
 
 # Configuration: Enter the url and key. That is it.
-#  url => URL to api/tickets.email e.g http://yourdomain.com/support/api/tickets.email
+#  url => URL to api/tickets.email e.g http://yourdomain.com/api/tickets.email
 #  key => API's Key (see admin panel on how to generate a key)
-#   
+#
 
 $config = array(
-        'url'=>'http://yourdomain.com/support/api/tickets.email',
+        'url'=>'http://yourdomain.com/api/tickets.email',
         'key'=>'API KEY HERE'
         );
 
@@ -35,16 +35,16 @@ $data=file_get_contents('php://stdin') or die('Error reading stdin. No message')
 set_time_limit(10);
 
 #curl post
-$ch = curl_init();        
-curl_setopt($ch, CURLOPT_URL, $config['url']);        
-curl_setopt($ch, CURLOPT_POST, 1);        
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $config['url']);
+curl_setopt($ch, CURLOPT_POST, 1);
 curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
-curl_setopt($ch, CURLOPT_USERAGENT, 'osTicket API Client v1.7');
+curl_setopt($ch, CURLOPT_USERAGENT, 'osTicket API Client v1.14');
 curl_setopt($ch, CURLOPT_HEADER, TRUE);
 curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'Expect:', 'X-API-Key: '.$config['key']));
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, FALSE);
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE); 
-$result=curl_exec($ch);        
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+$result=curl_exec($ch);
 curl_close($ch);
 
 //Use postfix exit codes...expected by MTA.
@@ -71,10 +71,13 @@ if(preg_match('/HTTP\/.* ([0-9]+) .*/', $result, $status)) {
             $code = 69;
             break;
         case 500: //Server error.
-        default: //Temp (unknown) failure - retry 
+        default: //Temp (unknown) failure - retry
             $code = 75;
     }
 }
 
+if ($code == 66) {
+    echo "HTTPS protocol required. Please update the URL in automail.php to include 'https'.\r\n";
+}
 exit($code);
 ?>

--- a/setup/scripts/automail.pl
+++ b/setup/scripts/automail.pl
@@ -5,7 +5,7 @@
 #    Perl script used for remote email piping...same as as the PHP version.
 #
 #    Peter Rotich <peter@osticket.com>
-#    Copyright (c) 2006-2013 osTicket
+#    Copyright (c) 2006-2020 osTicket
 #    http://www.osticket.com
 #
 #    Released under the GNU General Public License WITHOUT ANY WARRANTY.
@@ -14,11 +14,16 @@
 #    vim: expandtab sw=4 ts=4 sts=4:
 #######################################################################
 
+#Requirements: The following libraries/modules are required.
+#  LWP    => LWP (World-Wide Web Library required for UserAgent)
+#  Switch => Switch (Module required for switch statements)
+#  HTTPS  => LWP::Protocol::https (Module required if using HTTPS)
+
 #Configuration: Enter the url and key. That is it.
-#  url=> URL to pipe.php e.g http://yourdomain.com/support/api/tickets.email
+#  url=> URL to pipe.php e.g http://yourdomain.com/api/tickets.email
 #  key=> API Key (see admin panel on how to generate a key)
 
-%config = (url => 'http://yourdomain.com/support/api/tickets.email',
+%config = (url => 'http://yourdomain.com/api/tickets.email',
            key => 'API KEY HERE');
 
 #Get piped message from stdin
@@ -29,7 +34,7 @@ while (<STDIN>) {
 use LWP::UserAgent;
 $ua = LWP::UserAgent->new;
 
-$ua->agent('osTicket API Client v1.7');
+$ua->agent('osTicket API Client v1.14');
 $ua->default_header('X-API-Key' => $config{'key'});
 $ua->timeout(10);
 
@@ -44,10 +49,10 @@ $response = $ua->request($req);
 # Add exit codes - depending on what your  MTA expects.
 # By default postfix exit codes are used - which are standard for MTAs.
 #
-    
+
 use Switch;
 
-$code = 75;    
+$code = 75;
 switch($response->code) {
     case 201 { $code = 0; }
     case 400 { $code = 66; }
@@ -57,4 +62,7 @@ switch($response->code) {
     case 500 { $code = 75 }
 }
 #print "RESPONSE: ". $response->code. ">>>".$code;
+if ($code == 66) {
+    print "HTTPS protocol required. Please update the URL in automail.pl to include 'https' and ensure the 'LWP::Protocol::https' Perl module is installed.\r\n"
+}
 exit $code;


### PR DESCRIPTION
This feature introduces a checkbox in the System Settings to force HTTPS. This is for people who either can't or don't know how to configure redirect rules via the webserver. If the setting is enabled, the system will redirect all osTicket web traffic to the HTTPS protocol automatically. In addition this adds an `HTTP_OK` option that disables the HTTPS redirect for local calls such as cron, pipe, and cli. This also updates the remote piping scripts (`automail.pl` and `automail.php`) to include support for HTTPS.