### PR TITLE
tooltip: Email Username

### DIFF
--- a/include/i18n/en_US/help/tips/emails.email.yaml
+++ b/include/i18n/en_US/help/tips/emails.email.yaml
@@ -47,6 +47,16 @@ auto_response:
         You may disable the Auto-Response sent to the User when a new ticket
         is created via this Email Address.
 
+userid:
+    title: Username
+    content: >
+        The Username is utilized in the email authentication process. We accept
+        single address strings, shared mailbox strings, servername + username
+        strings, and a combination of all.
+    links:
+      - title: More Information
+        href: https://docs.osticket.com/en/latest/Admin/Emails/Emails.html
+
 username:
     title: Username
     content: >

--- a/include/staff/email.inc.php
+++ b/include/staff/email.inc.php
@@ -189,6 +189,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
                 <input type="text" size="35" name="userid" value="<?php echo $info['userid']; ?>"
                     autocomplete="off" autocorrect="off">
                 &nbsp;<span class="error">&nbsp;<?php echo $errors['userid']; ?>&nbsp;</span>
+                <i class="help-tip icon-question-sign" href="#userid"></i>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
This adds a tooltip for the Email Login Information Username. This explains the different formats we accept and includes a link to the documentation site for a deeper explanation.