### PR TITLE
sanitize input: remove double-quote from username.

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -569,6 +569,7 @@ implements TemplateVariable, Searchable {
                     $name = $name->getClean();
                     if (is_array($name))
                         $name = implode(', ', $name);
+                    $name = str_replace('"', '', $name);
                     $this->name = $name;
                 }
 


### PR DESCRIPTION
This patch prevents the ability for an agent to save a user's  name with double-quotes. Nb. when a user has double-quotes around their name (e.g. "John Doe") we run into some unexpected behavior; the email-address is hidden in that case.
