### PR TITLE
Issue: Template Variables in Ticket Filter

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -331,8 +331,14 @@ extends VerySimpleModel {
      * If the matches() method returns TRUE, send the initial ticket to this
      * method to apply the filter actions defined
      */
-    function apply(&$ticket, $vars) {
+    function apply(&$ticket, $vars, $postCreate=false) {
         foreach ($this->getActions() as $a) {
+            //control when certain actions should be applied
+            //if action is send email and postCreate == false, skip
+            //if action is not send email and postCreate == true, skip
+            if ((($a->type == 'email') ? !$postCreate : $postCreate))
+                continue;
+
             $a->setFilter($this);
             $a->apply($ticket, $vars);
         }
@@ -848,9 +854,9 @@ class TicketFilter {
      * should be rejected, the first filter that matches and has reject
      * ticket set is returned.
      */
-    function apply(&$ticket) {
+    function apply(&$ticket, $postCreate=false) {
         foreach ($this->getMatchingFilterList() as $filter) {
-            $filter->apply($ticket, $this->vars);
+            $filter->apply($ticket, $this->vars, $postCreate);
             if ($filter->stopOnMatch()) break;
         }
     }

--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -525,12 +525,18 @@ class FA_SendEmail extends TriggerAction {
     function apply(&$ticket, array $info) {
         global $ost;
 
+        if (!$ticket['ticket'])
+            return false;
+
         $config = $this->getConfiguration();
-        $info = array('subject' => $config['subject'],
-            'message' => $config['message']);
-        $info = $ost->replaceTemplateVariables(
-            $info, array('ticket' => $ticket)
+        $vars = array(
+            'url' => $ost->getConfig()->getBaseUrl(),
+            'ticket' => $ticket['ticket'],
         );
+        $info = $ost->replaceTemplateVariables(array(
+            'subject' => $config['subject'],
+            'message' => $config['message'],
+        ), $vars);
 
         // Honor FROM address settings
         if (!$config['from'] || !($mailer = Email::lookup($config['from'])))
@@ -558,7 +564,6 @@ class FA_SendEmail extends TriggerAction {
             $I = $replacer->replaceVars($info);
             $mailer->send($recipient, $I['subject'], $I['message']);
         }
-
     }
 
     static function getVarScope() {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4299,6 +4299,9 @@ implements RestrictedAccess, Threadable, Searchable {
             return null;
 
         /* -------------------- POST CREATE ------------------------ */
+        $vars['ticket'] = $ticket;
+        self::filterTicketData($origin, $vars,
+            array_merge(array($form), $topic_forms), $user);
 
         // Save the (common) dynamic form
         // Ensure we have a subject

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3902,7 +3902,7 @@ implements RestrictedAccess, Threadable, Searchable {
         return db_fetch_array(db_query($sql));
     }
 
-    protected function filterTicketData($origin, $vars, $forms, $user=false) {
+    protected function filterTicketData($origin, $vars, $forms, $user=false, $postCreate=false) {
         global $cfg;
 
         // Unset all the filter data field data in case things change
@@ -3960,7 +3960,7 @@ implements RestrictedAccess, Threadable, Searchable {
 
             // Init ticket filters...
             $ticket_filter = new TicketFilter($origin, $vars);
-            $ticket_filter->apply($vars);
+            $ticket_filter->apply($vars, $postCreate);
         }
         catch (FilterDataChanged $ex) {
             // Don't pass user recursively, assume the user has changed
@@ -4098,7 +4098,7 @@ implements RestrictedAccess, Threadable, Searchable {
 
             try {
                 $vars = self::filterTicketData($origin, $vars,
-                    array_merge(array($form), $topic_forms), $user);
+                    array_merge(array($form), $topic_forms), $user, false);
             }
             catch (RejectedException $ex) {
                 return $reject_ticket(
@@ -4301,7 +4301,7 @@ implements RestrictedAccess, Threadable, Searchable {
         /* -------------------- POST CREATE ------------------------ */
         $vars['ticket'] = $ticket;
         self::filterTicketData($origin, $vars,
-            array_merge(array($form), $topic_forms), $user);
+            array_merge(array($form), $topic_forms), $user, true);
 
         // Save the (common) dynamic form
         // Ensure we have a subject


### PR DESCRIPTION
This commit fixes an issue where you could not use template variables when using the 'Send an Email' filter action. All variables would just display as 'Array'.

We needed to pass the Ticket object to FA_SendEmail::apply, however, we were running the filters before the Ticket object was created. To fix this, we can add the Ticket object to vars and run the filterTicketData function again after the Ticket is created and only apply the send email filter action if the Ticket object is found.