### PR TITLE
Issue: Thread Events for File Field Changes

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3669,8 +3669,8 @@ class FileUploadField extends FormField {
         $A = (array) $after;
         $added = array_diff($A, $B);
         $deleted = array_diff($B, $A);
-        $added = Format::htmlchars(array_keys($added));
-        $deleted = Format::htmlchars(array_keys($deleted));
+        $added = Format::htmlchars(array_values($added));
+        $deleted = Format::htmlchars(array_values($deleted));
 
         if ($added && $deleted) {
             $desc = sprintf(


### PR DESCRIPTION
This commit fixes an issue where we were displaying array keys instead of array values for the thread events of edited file upload fields. Displaying the array values will show the file's name rather than the file's index in an array.