### PR TITLE
Issue: DB Error #1064 Queue Counts

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -904,10 +904,22 @@ class SavedQueue extends CustomQueue {
         // Aggregate constraints
         foreach ($queues as $queue) {
             $Q = $queue->getBasicQuery();
-            $expr = SqlCase::N()->when(new SqlExpr(new Q($Q->constraints)), new SqlField('ticket_id'));
-            $query->aggregate(array(
-                "q{$queue->id}" => SqlAggregate::COUNT($expr, true)
-            ));
+            if ($Q->constraints) {
+                $empty = false;
+                if (count($Q->constraints) > 1) {
+                    foreach ($Q->constraints as $key => $value) {
+                        if (!$value->constraints)
+                            $empty = true;
+                    }
+                }
+
+                if (!$empty) {
+                    $expr = SqlCase::N()->when(new SqlExpr(new Q($Q->constraints)), new SqlField('ticket_id'));
+                    $query->aggregate(array(
+                        "q{$queue->id}" => SqlAggregate::COUNT($expr, true)
+                    ));
+                }
+            }
 
             // Add extra tables joins  (if any)
             if ($Q->extra && isset($Q->extra['tables'])) {


### PR DESCRIPTION
This commit fixes an error where queue counts cannot be returned if the config saved for a queue is invalid. We try to build a query that does a count based on the criteria saved in the config, so when we try to build the query for an incorrectly saved config, the query we try to write looks something like this:

COUNT(DISTINCT CASE WHEN  THEN A1.`ticket_id` END) AS `q15`

Rather than trying to do a count for these, we should just skip over them so that no error is thrown since there is no way we would be able to count it anyway.

It is also possible for there to be more than 1 criteria defined, and if one of them is wrong, the same error will be thrown. We can check to see if there are multiple criteria, and if one is empty, we can skip that count as well.