### PR TITLE
Issue: Overwriting thisstaff on Assign

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2749,7 +2749,6 @@ implements RestrictedAccess, Threadable, Searchable {
 
         $this->logEvent('assigned', $data, $user);
 
-        $thisstaff = $staff;
         $key = $data['claim'] ? 'claim' : 'auto';
         $type = array('type' => 'assigned', $key => true);
         Signal::send('object.edited', $this, $type);


### PR DESCRIPTION
This commit fixes an issue where we were overwriting the thisstaff variable as a result of trying to log audits for the audit log plugin.