### PR TITLE
session: Destroy Warning

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -228,7 +228,7 @@ extends SessionBackend {
     }
 
     function destroy($id){
-        return SessionData::objects()->filter(['session_id' => $id])->delete();
+        return (SessionData::objects()->filter(['session_id' => $id])->delete());
     }
 
     function cleanup() {


### PR DESCRIPTION
This addresses the `session_destroy()` warning many people are receiving with PHP 7+. The warning states `PHP Warning:  session_destroy(): Session callback expects true/false return value`. This is because our session destroy method does not always return true/false, sometimes it returns `int(1)`. This adds a check to see if the session was not deleted successfully, if not it returns false, otherwise it returns true. This will ensure `session_destroy()` always receives a true/false return value.