### PR TITLE
Oops: Variable Overwrite

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -907,7 +907,7 @@ class SavedQueue extends CustomQueue {
             if ($Q->constraints) {
                 $empty = false;
                 if (count($Q->constraints) > 1) {
-                    foreach ($Q->constraints as $key => $value) {
+                    foreach ($Q->constraints as $value) {
                         if (!$value->constraints)
                             $empty = true;
                     }


### PR DESCRIPTION
This commit fixes and issue where the $key variable was overwritten when creating a foreach loop. Since we didn't actually need the key, it can be removed from the loop.