### PR TITLE
Issue: DB Error #1054

### DIFF
--- a/include/class.pagenate.php
+++ b/include/class.pagenate.php
@@ -34,13 +34,14 @@ class PageNate {
     }
 
     function setTotal($total, $approx=false) {
-        $this->total = intval($total);
-        $this->pages = ceil( $this->total / $this->limit );
+        $this->total = is_string($total) ? '-' : intval($total);
+        $total = is_string($total) ? 500 : $total;
+        $this->pages = ceil( $total / $this->limit );
 
-        if (($this->limit > $this->total) || ($this->page>ceil($this->total/$this->limit))) {
+        if (($this->limit > $total) || ($this->page>ceil($total/$this->limit))) {
             $this->start = 0;
         }
-        if (($this->limit-1)*$this->start > $this->total) {
+        if (($this->limit-1)*$this->start > $total) {
             $this->start -= $this->start % $this->limit;
         }
         $this->approx = $approx;
@@ -91,14 +92,18 @@ class PageNate {
     function showing() {
         $html = '';
         $start = $this->getStart() + 1;
-        $end = min($start + $this->limit + $this->slack - 1, $this->total);
+        $end = min($start + $this->limit + $this->slack - 1,
+            is_string($this->total) ? 500 : $this->total);
         if ($end < $this->total) {
             $to= $end;
         } else {
             $to= $this->total;
         }
         $html=__('Showing')."&nbsp;";
-        if ($this->total > 0) {
+        if (is_string($this->total))
+            $html .= sprintf(__('%1$d - %2$d' /* Used in pagination output */),
+               $start, $end);
+        elseif ($this->total > 0) {
             if ($this->approx)
                 $html .= sprintf(__('%1$d - %2$d of about %3$d' /* Used in pagination output */),
                    $start, $end, $this->total);
@@ -112,6 +117,7 @@ class PageNate {
     }
 
     function getPageLinks($hash=false, $pjax=false) {
+        $this->total = is_string($this->total) ? 500 : $this->total; //placeholder if no total
         $html                 = '';
         $file                =$this->url;
         $displayed_span     = 5;

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -912,25 +912,27 @@ class SavedQueue extends CustomQueue {
                             $empty = true;
                     }
                 }
-
-                if (!$empty) {
-                    $expr = SqlCase::N()->when(new SqlExpr(new Q($Q->constraints)), new SqlField('ticket_id'));
-                    $query->aggregate(array(
-                        "q{$queue->id}" => SqlAggregate::COUNT($expr, true)
-                    ));
-                }
             }
 
             // Add extra tables joins  (if any)
             if ($Q->extra && isset($Q->extra['tables'])) {
-               $counts['q'.$queue->getId()] = 500;
+               // skip counting keyword searches. Display them as '-'
+               $counts['q'.$queue->getId()] = '-';
                continue;
-                $contraints = array();
-                if ($Q->constraints)
-                     $constraints = new Q($Q->constraints);
-                foreach ($Q->extra['tables'] as $T)
-                    $query->addExtraJoin(array($T, $constraints, ''));
+               $contraints = array();
+               if ($Q->constraints)
+                    $constraints = new Q($Q->constraints);
+               foreach ($Q->extra['tables'] as $T)
+                   $query->addExtraJoin(array($T, $constraints, ''));
             }
+
+            if ($Q->constraints && !$empty) {
+                $expr = SqlCase::N()->when(new SqlExpr(new Q($Q->constraints)), new SqlField('ticket_id'));
+                $query->aggregate(array(
+                    "q{$queue->id}" => SqlAggregate::COUNT($expr, true)
+                ));
+            } else //display skipped counts as '-'
+                $counts['q'.$queue->getId()] = '-';
         }
 
         try {

--- a/include/staff/templates/queue-tickets.tmpl.php
+++ b/include/staff/templates/queue-tickets.tmpl.php
@@ -99,7 +99,23 @@ if (isset($tickets->extra['tables'])) {
 }
 
 $tickets->distinct('ticket_id');
-$count = $queue->getCount($thisstaff) ?: PAGE_LIMIT;
+$Q = $queue->getBasicQuery();
+
+if ($Q->constraints) {
+    if (count($Q->constraints) > 1) {
+        foreach ($Q->constraints as $value) {
+            if (!$value->constraints)
+                $empty = true;
+        }
+    }
+}
+
+if (($Q->extra && isset($Q->extra['tables'])) || !$Q->constraints || $empty) {
+    $skipCount = true;
+    $count = '-';
+}
+
+$count = $count ?: $queue->getCount($thisstaff);
 $pageNav->setTotal($count, true);
 $pageNav->setURL('tickets.php', $args);
 ?>
@@ -272,7 +288,7 @@ foreach ($tickets as $T) {
 </table>
 
 <?php
-    if ($count > 0) { //if we actually had any tickets returned.
+    if ($count > 0 || $skipCount) { //if we actually had any tickets returned.
 ?>  <div>
       <span class="faded pull-right"><?php echo $pageNav->showing(); ?></span>
 <?php


### PR DESCRIPTION
Error: Unknown column 'Z1.ticket_id' in 'field list'

This commit fixes an issue with how we approach skipping counts. If a search has a keyword or if a saved queue/search has an invalid criteria saved, we will completely ignore trying to do a count. In saved queue/searches, rather than showing a number or 500, we will display '-' in its place. For the count at the bottom (Showing # - # of about #), we will just display Showing # - #.