### PR TITLE
mail: Mail_Parse::getAttachments ()

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -423,12 +423,23 @@ class Mail_Parse {
             // random filename for the image
             elseif (isset($part->headers['content-id'])
                     && $part->headers['content-id']
-                    && 0 === strcasecmp($part->ctype_primary, 'image'))
+                    && 0 === strcasecmp($part->ctype_primary, 'image')) {
                 $filename = 'image-'.Misc::randCode(4).'.'
                     .strtolower($part->ctype_secondary);
-            else
+            // Attachment of type message/rfc822 without name!!!
+            } elseif (strcasecmp($part->ctype_primary, 'message') === 0) {
+                $struct = $part->parts[0];
+                if ($struct && isset($struct->headers['subject']))
+                    $filename = Format::mimedecode($struct->headers['subject'],
+                                $this->charset);
+                else
+                    $filename = 'email-message-'.Misc::randCode(4);
+
+                $filename .='.eml';
+            } else {
                 // Not an attachment?
                 return false;
+            }
 
             $file=array(
                     'name'  => $filename,

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -436,6 +436,10 @@ class Mail_Parse {
                     $filename = 'email-message-'.Misc::randCode(4);
 
                 $filename .='.eml';
+            } elseif (isset($part->headers['content-disposition'])
+                    && $part->headers['content-disposition']
+                    && preg_match('/filename="([^"]+)"/', $part->headers['content-disposition'], $matches)) {
+                $filename = Format::mimedecode($matches[1], $this->charset);
             } else {
                 // Not an attachment?
                 return false;

--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -329,6 +329,7 @@ class Mail_mimeDecode extends PEAR
 
                 case 'message/rfc822':
                     $obj = new Mail_mimeDecode($body);
+                    $return->body = $body;
                     $return->parts[] = $obj->decode(array('include_bodies' => $this->_include_bodies,
 					                                      'decode_bodies'  => $this->_decode_bodies,
 														  'decode_headers' => $this->_decode_headers));


### PR DESCRIPTION
This addresses an issue where some email attachments are not being added to the thread. This is due to Pear's `Mail_mimeDecode::_parseHeaderValue` function not parsing the headers correctly. This updates `Mail_Parse::getAttachments` to check the `content-disposition` for a filename if all else fails. This will ensure a filename is returned if the headers are not parsed correctly.