### PR TITLE
Issue: Blank Date Time

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4424,6 +4424,9 @@ class DatetimePickerWidget extends Widget {
         if (!isset($this->value) && ($default=$this->field->get('default')))
             $this->value = $default;
 
+        if ($this->value == 0)
+            $this->value = '';
+
         if ($this->value) {
 
             if (is_int($this->value))


### PR DESCRIPTION
This commit fixes an issue where an unset Date Time field would display as 0. As a result, if you were on the all edit page and edited some other field, it would appear as though you edited the date time field as well because it had a value in it. Instead, we need to make sure that the field renders as truly being blank if it isn't set yet to ensure nothing is being saved to it.