### PR TITLE
queue: Inherit Columns Option

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1025,7 +1025,8 @@ class CustomQueue extends VerySimpleModel {
     }
 
     function useStandardColumns() {
-        return !count($this->columns);
+        return ($this->hasFlag(self::FLAG_INHERIT_COLUMNS) ||
+                !count($this->columns));
     }
 
     function inheritExport() {
@@ -1264,6 +1265,9 @@ class CustomQueue extends VerySimpleModel {
         $this->setFlag(self::FLAG_INHERIT_SORTING,
             $this->parent_id > 0 && isset($vars['inherit-sorting']));
 
+        // Saved Search - Use standard columns
+        if ($this instanceof SavedSearch && isset($vars['inherit-columns']))
+            $this->setFlag(self::FLAG_INHERIT_COLUMNS);
         // Update queue columns (but without save)
         if (!isset($vars['columns']) && $this->parent) {
             // No columns -- imply column inheritance

--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1015,6 +1015,12 @@ class CustomQueue extends VerySimpleModel {
     }
 
     function inheritColumns() {
+        global $thisstaff;
+
+        if ($thisstaff && ($inherit = self::staffSettings('inherit-columns'))
+                && !is_null($inherit))
+            return $inherit == 'true';
+
         return $this->hasFlag(self::FLAG_INHERIT_COLUMNS);
     }
 
@@ -1033,6 +1039,22 @@ class CustomQueue extends VerySimpleModel {
 
     function isDefaultSortInherited() {
         return $this->hasFlag(self::FLAG_INHERIT_DEF_SORT);
+    }
+
+    function staffSettings($key=null) {
+        global $thisstaff;
+
+        if (!$config = QueueConfig::objects()->filter(array(
+                'staff_id' => $thisstaff->getId(),
+                'queue_id' => $this->getId()))->first())
+            return null;
+
+        $settings = JsonDataParser::decode($config->setting) ?: null;
+
+        if ($key && $settings)
+            return $settings[$key];
+
+        return $settings;
     }
 
     function buildPath() {

--- a/include/staff/templates/queue-columns.tmpl.php
+++ b/include/staff/templates/queue-columns.tmpl.php
@@ -108,6 +108,8 @@ $hidden_cols = $queue->inheritColumns() || ($queue->useStandardColumns() &&
 </div>
 <script>
 +function() {
+if ($('[name=inherit-columns]').attr('disabled'))
+    $('.if-not-inherited').hide();
 $('[name=inherit-columns]').on('click', function() {
     $('.standard-columns').toggle();
 });


### PR DESCRIPTION
This addresses part of issue #5259 where Advanced Searches are showing the Customizable Columns even though you cannot customize an Advanced Search's columns. This adds some JS to hide the `.if-not-inherited` div on initial load if `.inherit-columns` checkbox is Disabled.

This addresses an issue where saving a Parent Queue with "Use standard columns" Enabled will show the option Enabled but still show the customizable Columns instead of the Standard Columns. This addresses an issue where saving a Child Queue with "Inherit columns from the parent queue" Enabled shows the Standard Columns but does not show the option Enabled. This adds a check in `inheritColumns()` for Staff Configurations for the queue and if exists we use the Staff preferences, else we default to the Queue Flag check. This adds a new method called `staffSettings()` that returns staff settings for a queue. It takes an optional argument (a setting's name) that can return a specific setting's value.

This addresses an issue where saving a Saved Search with "Use standard columns" Enabled, shows the Customizable Columns instead of the Standard Columns and does not show the option Enabled as the INHERIT_COLUMNS flag is not set.  This adds a check when saving a SavedSearch for the `inherit-columns` setting and if set, we set the Queue's INHERIT_COLUMNS Flag.

### Parent Queues

#### Save With "Use standard columns" Checked
<img width="640" alt="O Criteria" src="https://user-images.githubusercontent.com/11823401/71588965-eae6e080-2ae8-11ea-9f59-5dfc88ae889b.png">

### Children Queues

#### Save With "Inherit columns from the parent queue" Checked
<img width="637" alt="I Columns" src="https://user-images.githubusercontent.com/11823401/71588993-ffc37400-2ae8-11ea-844c-0362104a9d6e.png">

### Advanced Search

#### Shows Columns
<img width="637" alt="Advanced Ticket Search" src="https://user-images.githubusercontent.com/11823401/71589014-0fdb5380-2ae9-11ea-8011-b3b25756ae5a.png">

### Saved Searches

#### Save With "Use standard columns" Checked
<img width="633" alt="Saved Search" src="https://user-images.githubusercontent.com/11823401/71589034-1b2e7f00-2ae9-11ea-94ea-90c4eb053af6.png">