### PR TITLE
issue: New Agent Welcome Email

### DIFF
--- a/scp/staff.php
+++ b/scp/staff.php
@@ -43,6 +43,10 @@ if($_POST){
                 foreach ($_SESSION['new-agent-passwd'] as $k=>$v)
                     if (!isset($_POST[$k]))
                         $_POST[$k] = $v;
+            } else { // If no password && no backend set or is local then send Welcome Email
+                $bk = array_key_exists('backend', $_POST) ? $_POST['backend'] : null;
+                if (!$bk || $bk == 'local')
+                    $_POST['welcome_email'] = 1;
             }
             if ($staff->update($_POST,$errors)) {
                 unset($_SESSION['new-agent-passwd']);


### PR DESCRIPTION
This addresses the underlying problem with issue #2870 where the Welcome Email checkbox is no longer present but even then no Welcome Email is ever sent to the Agent regardless of how they are created. This is due to an option called `welcome_email` that is not being passed to the `update()` method for Staff. When an Agent account is created with no Password set and the Authentication backend is not external we should send the Welcome Email so the Staff in question can create a Password and access the system. If no password is set and the authentication backend is external however then we should not send the email as the Staff will use their AD credentials to login. This adds an else statement to set `welcome_email = 1` if there is no password set and if there is no backend set or is Local.