### PR TITLE
validate: Number Field Edit Zero

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1475,6 +1475,9 @@ class TextboxField extends FormField {
             $valid = 'formula';
         $func = $validators[$valid];
         $error = $func[1];
+        // If validator is number and the value is &#48 set to 0 (int) for is_numeric
+        if ($valid == 'number' && $value == '&#48')
+            $value = 0;
         if ($config['validator-error'])
             $error = $this->getLocal('validator-error', $config['validator-error']);
         if (is_array($func) && is_callable($func[0]))


### PR DESCRIPTION
This addresses an issue reported on the Forum where having a Short Answer field with it's Validator set to Number will throw validation error of `Enter a number` when updating the field with a value of `0`. This is due to the system converting `0` values to `&#48` in `TextboxField::validateEntry()` for methods ran before the default textbox field validation (which is `is_numeric`). This adds a check before the default textbox field validation to see if the validator is `number` and the value is `&#48`. If both are True we convert the value back to `0` (int) so the `is_numeric` validation passes.