### PR TITLE
redactor: Cancel Button

### DIFF
--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -124,7 +124,7 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
             $('.richtext').each(function() {
                 var redactor = $(this).data('redactor');
                 if (redactor && redactor.opts.draftDelete)
-                    redactor.draft.deleteDraft();
+                    redactor.plugin.draft.deleteDraft();
             });
             window.location.href='index.php';">
   </p>

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -474,7 +474,7 @@ print $response_form->getField('attachments')->render();
     <input type="reset"  name="reset"  value="<?php echo __('Reset');?>">
     <input type="button" name="cancel" value="<?php echo __('Cancel');?>" onclick="javascript:
         $(this.form).find('textarea.richtext')
-          .redactor('draft.deleteDraft');
+          .redactor('plugin.draft.deleteDraft');
         window.location.href='tickets.php'; " />
 </p>
 </form>


### PR DESCRIPTION
This addresses an issue reported on the Forum where the New Ticket Cancel buttons do not work in v1.14.1. This is due to the code using older methods utilized in v1.12. This updates the code to use the new method of accessing the plugin objects first before accessing the plugin itself.