### PR TITLE
Display ticket owners telephone number and click2dial link.

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -513,7 +513,20 @@ if($ticket->isOverdue())
                 <tr>
                     <th><?php echo __('Phone'); ?>:</th>
                     <td>
-                        <span id="user-<?php echo $ticket->getOwnerId(); ?>-phone"><?php echo $ticket->getPhoneNumber(); ?></span>
+                        <a href="#tickets/<?php echo $ticket->getId(); ?>/user"
+                           onclick="javascript:
+                                   saveDraft();
+                                   $.userLookup('ajax.php/tickets/<?php echo $ticket->getId(); ?>/user',
+                                   function (user) {
+                                   $('#user-'+user.id+'-name').text(user.name);
+                                   $('#user-'+user.id+'-email').text(user.email);
+                                   $('#user-'+user.id+'-phone').text(user.phone);
+                                   $('#user-'+user.id+'-phone-url').attr('href', 'tel:'+user.phone.substr(0, ( ( user.phone.indexOf('x') == -1 ) ? user.phone.length : user.phone.indexOf('x') ) ).trim());
+                                   $('select#emailreply option[value=1]').text(user.name+' <'+user.email+'>');
+                                   });
+                                   return false;
+                                   "><span id="user-<?php echo $ticket->getOwnerId(); ?>-phone"><?php echo ( ( $ticket->getPhoneNumber() != '' ) ? $ticket->getPhoneNumber() : __('None') )?></span></a>
+                                    <a id="user-<?php echo $ticket->getOwnerId(); ?>-phone-url" href="tel:<?php echo trim( substr( $ticket->getPhoneNumber(), 0, ( ( strpos($ticket->getPhoneNumber(), 'x') === FALSE ) ? strlen( $ticket->getPhoneNumber() ) : strripos( $ticket->getPhoneNumber(), 'x' ) ) ) ); ?>"><i class="icon-phone"></i></a>
                     </td>
                 </tr>
             </table>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -510,6 +510,12 @@ if($ticket->isOverdue())
                     ?>
                  </td>
                 </tr>
+                <tr>
+                    <th><?php echo __('Phone'); ?>:</th>
+                    <td>
+                        <span id="user-<?php echo $ticket->getOwnerId(); ?>-phone"><?php echo $ticket->getPhoneNumber(); ?></span>
+                    </td>
+                </tr>
             </table>
         </td>
     </tr>


### PR DESCRIPTION
Often time our agents receive a ticket by email, but need to call the ticket owner to get more details before they can resolve the ticket. Therefore displaying the ticket owners telephone number and including a link that uses the standard "tel:" protocol to have the browser launch a telephone app to call them is extremely helpful. 

This small self-contained PR adds that functionality as well as a slightly faster way to inline edit the ticket owners telephone number if needed.

I tested scenarios of inline editing and adding/removing a telephone extension to make sure that is stripped from the "tel:" URL. 