### PR TITLE
issue: Update Staff checkPassword()

### DIFF
--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -37,7 +37,8 @@ class StaffAjaxAPI extends AjaxController {
           $clean = $form->getClean();
           try {
               // Validate password
-              PasswordPolicy::checkPassword($clean['passwd1'], null);
+              if (!$clean['welcome_email'])
+                  PasswordPolicy::checkPassword($clean['passwd1'], null);
               if ($id == 0) {
                   // Stash in the session later when creating the user
                   $_SESSION['new-agent-passwd'] = $clean;


### PR DESCRIPTION
This addresses an issue where clicking Update in the Set Password modal with the `Send the agent a password reset email` option checked either shows a forever spinning Loading screen or instantly kicks back to the modal having accomplished nothing. This is due to checking `$clean['passwd1']` even when `welcome_email` (password reset) is set. If `welcome_email` is set/enabled we should not check the variable as there is no new password being set as we are sending a Reset Email. This adds a check for `welcome_email` and if none, then we check the password.