### PR TITLE
Update class.filter.php

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -800,6 +800,7 @@ class TicketFilter {
             'Precedence'        => array('AUTO_REPLY', 'BULK', 'JUNK', 'LIST'),
             'X-Precedence'      => array('AUTO_REPLY', 'BULK', 'JUNK', 'LIST'),
             'X-Autoreply'       => 'YES',
+            'X-Auto-Response-Suppress' => array('AutoReply'),
             'X-Autoresponse'    => '*',
             'X-AutoReply-From'  => '*',
             'X-Autorespond'     => '*',

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -800,7 +800,6 @@ class TicketFilter {
             'Precedence'        => array('AUTO_REPLY', 'BULK', 'JUNK', 'LIST'),
             'X-Precedence'      => array('AUTO_REPLY', 'BULK', 'JUNK', 'LIST'),
             'X-Autoreply'       => 'YES',
-            'X-Auto-Response-Suppress' => array('ALL', 'DR', 'RN', 'NRN', 'OOF', 'AutoReply'),
             'X-Autoresponse'    => '*',
             'X-AutoReply-From'  => '*',
             'X-Autorespond'     => '*',


### PR DESCRIPTION
Remove X-Auto-Response-Suppress from $auto_headers
Fixes #726

Issue #726 was recently closed however the problem remains.  No further comments have been added since my last post in December 2016, I suggest the reviewing these comments and URLs linked describing a similar issue.

I have made this change on my production osTicket for several years now with no ill effects, including when out of office is enabled, there is no resulting email storm.

Credit to forum user lkrms who first posted this fix.  Thanks for your consideration.