### PR TITLE
Issue: User Imports Headers

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -525,6 +525,7 @@ implements TemplateVariable, Searchable {
     }
 
     function importFromPost($stream, $extra=array()) {
+        $stream = sprintf('name, email%s %s',PHP_EOL, $stream);
         return User::importCsv($stream, $extra);
     }
 

--- a/include/staff/templates/user-import.tmpl.php
+++ b/include/staff/templates/user-import.tmpl.php
@@ -34,7 +34,7 @@ if ($org_id) { ?>
 'To import more other fields, use the Upload tab.'); ?></em>
 </p>
 <textarea name="pasted" style="display:block;width:100%;height:8em"
-    placeholder="<?php echo sprintf('%s %s%s', __('Name, Email'), PHP_EOL, __('John Doe, john.doe@osticket.com')); ?>">
+    placeholder="<?php echo __('e.g. John Doe, john.doe@osticket.com'); ?>">
 <?php echo $info['pasted']; ?>
 </textarea>
 </div>


### PR DESCRIPTION
This commit makes it so that when importing users, the agent does not have to specify the 'name, email' headers. They can simply put the users' names and emails into the text area field.