### PR TITLE
dept: Disable Auto Claim

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -845,6 +845,8 @@ implements TemplateVariable, Searchable {
                 }
             }
         }
+        if ($vars['disable_auto_claim'] !== 1)
+            unset($vars['disable_auto_claim']);
 
         $this->pid = $vars['pid'] ?: null;
         $this->ispublic = isset($vars['ispublic']) ? (int) $vars['ispublic'] : 0;


### PR DESCRIPTION
This addresses an issue where unchecking `Disable auto claim` and saving changes will show the option as Enabled still. This is due to some changes from Audit Log where we set `disable_auto_claim` to either `1` or `0` to interact with the Audit Log methods. The flag is typically set to `on` or `Null`. When we check the `disable_auto_claim` flag with `isset()`, and it is set to `0` it will return True when it is actually Disabled. This updates the code to unset the option after the Audit code if it does not equal `1` so the subsequent methods can remove the flag from the department.