### PR TITLE
Redactor revert enter key behavior back to pre-v1.14 behavior.

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -377,6 +377,7 @@ $(function() {
                 'minHeight': selectedSize,
                 'maxWidth': el.hasClass('fullscreen') ? '950px' : false,
                 'focus': false,
+                'breakline': true,
                 'plugins': el.hasClass('no-bar')
                   ? ['imagemanager','definedlinks']
                   : ['imagemanager','table','video','definedlinks','autolock', 'fontcolor', 'fontfamily'],


### PR DESCRIPTION
osTicket v1.14 changed the behavior of the "enter" key so it adds a new paragraph in redactor rather than the more standard adding of a new line. This one-line change reverts this behavior back.

Brought up on the forums here too:
https://forum.osticket.com/d/96617-double-spacing-on-ticket-thread/2
