### PR TITLE
redactor: Double Spacing Optional

### DIFF
--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -50,6 +50,7 @@ class ConfigAjaxAPI extends AjaxController {
               'secondary_languages' => $cfg->getSecondaryLanguages(),
               'page_size'       => $thisstaff->getPageLimit() ?: PAGE_LIMIT,
               'path'            => ROOT_PATH,
+              'editor_spacing' => $thisstaff->editorSpacing(),
         );
         return $this->json_encode($config);
     }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -94,6 +94,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
                         'default_ticket_queue_id' => 0,
                         'reply_redirect' => 'Ticket',
                         'img_att_view' => 'download',
+                        'editor_spacing' => 'double',
                         ));
             $this->_config = $_config->getInfo();
         }
@@ -356,6 +357,10 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
 
     function getImageAttachmentView() {
         return $this->img_att_view;
+    }
+
+    function editorSpacing() {
+        return $this->editor_spacing;
     }
 
     function forcePasswdChange() {
@@ -776,6 +781,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
                     'default_ticket_queue_id' => $vars['default_ticket_queue_id'],
                     'reply_redirect' => ($vars['reply_redirect'] == 'Queue') ? 'Queue' : 'Ticket',
                     'img_att_view' => ($vars['img_att_view'] == 'inline') ? 'inline' : 'download',
+                    'editor_spacing' => ($vars['editor_spacing'] == 'double') ? 'double' : 'single'
                     )
                 );
         $this->_config = $_config->getInfo();

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -334,6 +334,24 @@ if ($avatar->isChangeable()) { ?>
                 <div class="error"><?php echo $errors['img_att_view']; ?></div>
             </td>
         </tr>
+        <tr>
+            <td><?php echo __('Editor Spacing'); ?>:
+                <div class="faded"><?php echo __('Set the editor spacing to Single or Double when pressing Enter.');?></div>
+            </td>
+            <td>
+                <select name="editor_spacing">
+                  <?php
+                  $options=array('double'=>__('Double'),'single'=>__('Single'));
+                  $spacing = $staff->editor_spacing;
+                  foreach($options as $key=>$opt) {
+                      echo sprintf('<option value="%s" %s>%s</option>',
+                                $key,($spacing==$key)?'selected="selected"':'',$opt);
+                  }
+                  ?>
+                </select>
+                <div class="error"><?php echo $errors['editor_spacing']; ?></div>
+            </td>
+        </tr>
       </tbody>
       <tbody>
         <tr class="header">

--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -457,6 +457,8 @@ $(function() {
                 options['plugins'].push('textdirection');
             if (el.find('rtl').length)
                 options['direction'] = 'rtl';
+            if (c.editor_spacing == 'single')
+                options.breakline = true;
             el.data('redactor', el.redactor(options));
         });
     },


### PR DESCRIPTION
This addresses an issue where upgraded redactor does double spacing by default (which matches most modern editors). A lot of people do not like this change however so the solution is to make double spacing optional via a setting. This adds a new Profile setting called Editor Spacing that allows you to configure Double or Single spacing for the editor. If set to Double, the text editor will double space when pressing Enter. If set to Single, the text editor will single space when pressing Enter like the old redactor version. If a staff does not have this setting configured, it defaults to Double Spacing.