### PR TITLE
Issue: Organization Field Change Name Type

### DIFF
--- a/include/staff/dynamic-form.inc.php
+++ b/include/staff/dynamic-form.inc.php
@@ -191,7 +191,9 @@ if ($form && count($langs) > 1) { ?>
                 </font>
             </td>
             <td nowrap><select style="max-width:150px" name="type-<?php echo $id; ?>" <?php
-                if (!$fi->isChangeable()) echo 'disabled="disabled"'; ?>>
+                if (!$fi->isChangeable() ||
+                   ($form->get('type') == 'O' && $force_name))
+                   echo 'disabled="disabled"'; ?>>
                 <?php foreach (FormField::allTypes() as $group=>$types) {
                         ?><optgroup label="<?php echo Format::htmlchars(__($group)); ?>"><?php
                         foreach ($types as $type=>$nfo) {


### PR DESCRIPTION
This commit prevents Agents from being able to change the field type of the name field on the Organization form. We should be forcing it to be a Short Answer field.