### PR TITLE
issue: Require Client Login

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -758,6 +758,13 @@ class OsticketConfig extends Config {
         return $this->get('client_registration');
     }
 
+    function isClientRegistrationMode($modes) {
+        if (!is_array($modes))
+            $modes = array($modes);
+
+        return in_array($this->getClientRegistrationMode(), $modes);
+    }
+
     function isClientEmailVerificationRequired() {
         return $this->get('client_verify_email');
     }
@@ -1593,11 +1600,6 @@ class OsticketConfig extends Config {
 
 
     function updateKBSettings($vars, &$errors) {
-
-        if ($vars['restrict_kb'] && !$this->isClientRegistrationEnabled())
-            $errors['restrict_kb'] =
-                __('The knowledge base cannot be restricted unless client registration is enabled');
-
         if ($errors) return false;
 
         return $this->updateAll(array(


### PR DESCRIPTION
This addresses an issue reported on the Forum where having your Client Registration set to Private and attempting to enable the setting Require Client Login for Knowledgebase results in an error saying `The knowledge base cannot be restricted unless client registration is enabled`. When saving the Knowledgebase Settings and we are updating the Restrict Knowledgebase setting we check if Client Registration is Enabled using the `isClientRegistrationEnabled()` method. This method only checks if the Registration method is `auto` or `open` (Public) and does not check if it is `closed` (Private). This is an issue in the aforementioned case as Users can still be registered by Agents so technically registration is not completely disabled. This adds a new function called `isClientRegistrationMode()` that can be used to compare the current Registration Mode to either a string or an array or modes. This updates the `updateKBSettings()` method to utilize the new method to see if the current registration mode is `auto`, `public` (Public), or `closed` (Private) and if so, we continue on without errors. This will allow Admins to make the Knowledgebase Private to only Users who are Registered by Agents and who are logged in.