### PR TITLE
issue: User Manage Org Name

### DIFF
--- a/include/staff/templates/user-account.tmpl.php
+++ b/include/staff/templates/user-account.tmpl.php
@@ -1,6 +1,7 @@
 <?php
 $account = $user->getAccount();
 $access = (isset($info['_target']) && $info['_target'] == 'access');
+$org = $user->getOrganization();
 
 if (!$info['title'])
     $info['title'] = Format::htmlchars($user->getName());
@@ -52,10 +53,7 @@ if ($info['error']) {
                 <td width="180">
                     <?php echo __('Organization'); ?>:
                 </td>
-                <td>
-                    <input type="text" size="35" name="org" value="<?php echo $info['org']; ?>">
-                    &nbsp;<span class="error">&nbsp;<?php echo $errors['org']; ?></span>
-                </td>
+                <td><?php echo $org ? Format::htmlchars($org->getName()) : ''; ?></td>
             </tr>
         </tbody>
         <tbody>


### PR DESCRIPTION
This addresses an issue reported on the Forum where clicking Manage Account for a User the Organization field is blank even though the User has an Organization. This is due to the system only using `$info` which is set by `$_POST`. Since we are not posting anything, just loading the popup template, there is no `$_POST` so `$info` will not be set. In addition, you cannot update the Organization using the Manage Account modal so there is no reason to use `$info` nor is there a reason to have the Organization field as an Input field. This updates the modal template to make the Organization field simple table data and to use `$user->getOrganization()->getName()` for the Organization Name.