### PR TITLE
plugins: Add Version Column

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -334,6 +334,8 @@ class PluginManager {
             .', install_path='.db_input($path)
             .', name='.db_input($info['name'])
             .', isphar='.db_input($is_phar);
+        if ($info['version'])
+            $sql.=', version='.db_input($info['version']);
         if (!db_query($sql) || !db_affected_rows())
             return false;
         static::clearCache();

--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -388,6 +388,7 @@ abstract class Plugin {
     function getName() { return $this->__($this->info['name']); }
     function isActive() { return $this->ht['isactive']; }
     function isPhar() { return $this->ht['isphar']; }
+    function getVersion() { return $this->ht['version'] ?: $this->info['version']; }
     function getInstallDate() { return $this->ht['installed']; }
     function getInstallPath() { return $this->ht['install_path']; }
 

--- a/include/staff/plugins.inc.php
+++ b/include/staff/plugins.inc.php
@@ -55,7 +55,8 @@ $showing=$pageNav->showing().' '._N('plugin', 'plugins', $count);
     <thead>
         <tr>
             <th width="4%">&nbsp;</th>
-            <th width="66%"><?php echo __('Plugin Name'); ?></th>
+            <th width="56%"><?php echo __('Plugin Name'); ?></th>
+            <th width="10%"><?php echo __('Version'); ?></th>
             <th width="10%"><?php echo __('Status'); ?></th>
             <th width="20%"><?php echo __('Date Installed'); ?></th>
         </tr>
@@ -67,8 +68,9 @@ foreach ($ost->plugins->allInstalled() as $p) {
     <tr>
         <td align="center"><input type="checkbox" class="ckb" name="ids[]" value="<?php echo $p->getId(); ?>"
                 <?php echo $sel?'checked="checked"':''; ?>></td>
-        <td><a href="plugins.php?id=<?php echo $p->getId(); ?>"
-            ><?php echo $p->getName(); ?></a></td>
+        <td><a href="plugins.php?id=<?php echo $p->getId(); ?>">
+        <?php echo $p->getName(); ?></a></td>
+        <td><?php echo $p->getVersion(); ?></a></td>
         <td><?php echo ($p->isActive())
             ? 'Enabled' : '<strong>Disabled</strong>'; ?></td>
         <td><?php echo Format::datetime($p->getInstallDate()); ?></td>
@@ -78,7 +80,7 @@ foreach ($ost->plugins->allInstalled() as $p) {
     </tbody>
     <tfoot>
      <tr>
-        <td colspan="4">
+        <td colspan="5">
             <?php if($count){ ?>
             <?php echo __('Select'); ?>:&nbsp;
             <a id="selectAll" href="#ckb"><?php echo __('All'); ?></a>&nbsp;&nbsp;


### PR DESCRIPTION
This adds a new column to the Plugins template to show the Version Number for each plugin. This adds a new method called `getVersion()` that will return either the version number from the database or the version number from the `load()` method.

In addition this addresses an issue where upon installing a plugin, no version number is added in the database. This is due to not setting the version in the SQL query when inserting the plugin table record.