### PR TITLE
Accessible Labels on Installation Pages

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -41,6 +41,7 @@ class TicketsAjaxAPI extends AjaxController {
                 'tickets' => SqlAggregate::COUNT('ticket_id', true),
             ))
             ->order_by(SqlAggregate::SUM(new SqlCode('Z1.relevance')), QuerySet::DESC)
+            ->distinct('user__default_email__address')
             ->limit($limit);
 
         $q = $_REQUEST['q'];

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -595,6 +595,7 @@ if($ticket->isOverdue())
 <br>
 <?php
 foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
+    $form->addMissingFields();
     //Find fields to exclude if disabled by help topic
     $disabled = Ticket::getMissingRequiredFields($ticket, true);
 

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1191,6 +1191,8 @@ $(document).on('click.note', '.quicknote .action.save-note', function() {
     return false;
 });
 $(document).on('click.note', '.quicknote .delete', function() {
+  if (!window.confirm(__('Confirm Deletion')))
+    return;
   var that = $(this),
       id = $(this).closest('.quicknote').data('id');
   $.ajax('ajax.php/note/' + id, {

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -398,6 +398,7 @@ if($_POST && !$errors):
 
                     if(($ticket=Ticket::open($vars, $errors))) {
                         $msg=__('Ticket created successfully');
+                        $redirect = 'tickets.php?id='.$ticket->getId();
                         $_REQUEST['a']=null;
                         if (!$ticket->checkStaffPerm($thisstaff) || $ticket->isClosed())
                             $ticket=null;

--- a/setup/inc/install.inc.php
+++ b/setup/inc/install.inc.php
@@ -15,105 +15,105 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):array('prefix'=>'ost_','dbho
                     <span class="ltr"><strong><?php echo URL; ?></strong></span>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Helpdesk Name');?>:</label>
-                    <input type="text" name="name" size="45" tabindex="1" value="<?php echo $info['name']; ?>">
-                    <a class="tip" href="#helpdesk_name"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="name"><?php echo __('Helpdesk Name');?>:</label>
+                    <input type="text" id="name" name="name" size="45" value="<?php echo $info['name']; ?>">
+                    <a class="tip" href="#helpdesk_name" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['name']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Default Email');?>:</label>
-                    <input type="text" name="email" size="45" tabindex="2" value="<?php echo $info['email']; ?>">
-                    <a class="tip" href="#system_email"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="email"><?php echo __('Default Email');?>:</label>
+                    <input type="text" id="email" name="email" size="45" value="<?php echo $info['email']; ?>">
+                    <a class="tip" href="#system_email" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['email']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Primary Language');?>:</label>
+                    <label for="lang_id"><?php echo __('Primary Language');?>:</label>
 <?php $langs = Internationalization::availableLanguages(); ?>
-                <select name="lang_id">
+                <select id="lang_id" name="lang_id">
 <?php foreach($langs as $l) {
     $selected = ($info['lang_id'] == $l['code']) ? 'selected="selected"' : ''; ?>
                     <option value="<?php echo $l['code']; ?>" <?php echo $selected;
                         ?>><?php echo Internationalization::getLanguageDescription($l['code']); ?></option>
 <?php } ?>
                 </select>
-                <a class="tip" href="#default_lang"><i class="icon-question-sign help-tip"></i></a>
+                <a class="tip" href="#default_lang" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                 <font class="error">&nbsp;<?php echo $errors['lang_id']; ?></font>
                 </div>
 
                 <h4 class="head admin"><?php echo __('Admin User');?></h4>
                 <span class="subhead"><?php echo __('Your primary administrator account - you can add more users later.');?></span>
                 <div class="row">
-                    <label><?php echo __('First Name');?>:</label>
-                    <input type="text" name="fname" size="45" tabindex="3" value="<?php echo $info['fname']; ?>">
-                    <a class="tip" href="#first_name"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="fname"><?php echo __('First Name');?>:</label>
+                    <input type="text" id="fname" name="fname" size="45" value="<?php echo $info['fname']; ?>">
+                    <a class="tip" href="#first_name" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['fname']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Last Name');?>:</label>
-                    <input type="text" name="lname" size="45" tabindex="4" value="<?php echo $info['lname']; ?>">
-                    <a class="tip" href="#last_name"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="lname"><?php echo __('Last Name');?>:</label>
+                    <input type="text" id="lname" name="lname" size="45" value="<?php echo $info['lname']; ?>">
+                    <a class="tip" href="#last_name" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['lname']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Email Address');?>:</label>
-                    <input type="text" name="admin_email" size="45" tabindex="5" value="<?php echo $info['admin_email']; ?>">
-                    <a class="tip" href="#email"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="admin_email"><?php echo __('Email Address');?>:</label>
+                    <input type="text" id="admin_email" name="admin_email" size="45" value="<?php echo $info['admin_email']; ?>">
+                    <a class="tip" href="#email" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['admin_email']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Username');?>:</label>
-                    <input type="text" name="username" size="45" tabindex="6" value="<?php echo $info['username']; ?>" autocomplete="off">
-                    <a class="tip" href="#username"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="username"><?php echo __('Username');?>:</label>
+                    <input type="text" id="username" name="username" size="45" value="<?php echo $info['username']; ?>" autocomplete="off">
+                    <a class="tip" href="#username" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['username']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Password');?>:</label>
-                    <input type="password" name="passwd" size="45" tabindex="7" value="<?php echo $info['passwd']; ?>" autocomplete="off">
-                    <a class="tip" href="#password"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="passwd"><?php echo __('Password');?>:</label>
+                    <input type="password" id="passwd" name="passwd" size="45" value="<?php echo $info['passwd']; ?>" autocomplete="off">
+                    <a class="tip" href="#password" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['passwd']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Retype Password');?>:</label>
-                    <input type="password" name="passwd2" size="45" tabindex="8" value="<?php echo $info['passwd2']; ?>">
-                    <a class="tip" href="#password2"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="passwd2"><?php echo __('Retype Password');?>:</label>
+                    <input type="password" id="passwd2" name="passwd2" size="45" value="<?php echo $info['passwd2']; ?>">
+                    <a class="tip" href="#password2" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['passwd2']; ?></font>
                 </div>
 
                 <h4 class="head database"><?php echo __('Database Settings');?></h4>
                 <span class="subhead"><?php echo __('Database connection information');?> <font class="error"><?php echo $errors['db']; ?></font></span>
                 <div class="row">
-                    <label><?php echo __('MySQL Table Prefix');?>:</label>
-                    <input type="text" name="prefix" size="45" tabindex="9" value="<?php echo $info['prefix']; ?>">
-                    <a class="tip" href="#db_prefix"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="prefix"><?php echo __('MySQL Table Prefix');?>:</label>
+                    <input type="text" id="prefix" name="prefix" size="45" value="<?php echo $info['prefix']; ?>">
+                    <a class="tip" href="#db_prefix" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['prefix']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('MySQL Hostname');?>:</label>
-                    <input type="text" name="dbhost" size="45" tabindex="10" value="<?php echo $info['dbhost']; ?>">
-                    <a class="tip" href="#db_host"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="dbhost"><?php echo __('MySQL Hostname');?>:</label>
+                    <input type="text" id="dbhost" name="dbhost" size="45" value="<?php echo $info['dbhost']; ?>">
+                    <a class="tip" href="#db_host" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['dbhost']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('MySQL Database');?>:</label>
-                    <input type="text" name="dbname" size="45" tabindex="11" value="<?php echo $info['dbname']; ?>">
-                    <a class="tip" href="#db_schema"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="dbname"><?php echo __('MySQL Database');?>:</label>
+                    <input type="text" id="dbname" name="dbname" size="45" value="<?php echo $info['dbname']; ?>">
+                    <a class="tip" href="#db_schema" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['dbname']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('MySQL Username');?>:</label>
-                    <input type="text" name="dbuser" size="45" tabindex="12" value="<?php echo $info['dbuser']; ?>">
-                    <a class="tip" href="#db_user"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="dbuser"><?php echo __('MySQL Username');?>:</label>
+                    <input type="text" id="dbuser" name="dbuser" size="45" value="<?php echo $info['dbuser']; ?>">
+                    <a class="tip" href="#db_user"aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['dbuser']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('MySQL Password');?>:</label>
-                    <input type="password" name="dbpass" size="45" tabindex="13" value="<?php echo $info['dbpass']; ?>">
-                    <a class="tip" href="#db_password"><i class="icon-question-sign help-tip"></i></a>
+                    <label for="dbpass"><?php echo __('MySQL Password');?>:</label>
+                    <input type="password" id="dbpass" name="dbpass" size="45" value="<?php echo $info['dbpass']; ?>">
+                    <a class="tip" href="#db_password" aria-label="What's this?"><i class="icon-question-sign help-tip"></i></a>
                     <font class="error"><?php echo $errors['dbpass']; ?></font>
                 </div>
                 <br>
                 <div id="bar">
-                    <input class="btn" type="submit" value="<?php echo __('Install Now');?>" tabindex="14">
+                    <input class="btn" type="submit" value="<?php echo __('Install Now');?>">
                 </div>
 
                 <input type="hidden" name="timezone" id="timezone"/>

--- a/setup/inc/subscribe.inc.php
+++ b/setup/inc/subscribe.inc.php
@@ -10,24 +10,24 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):$_SESSION['info'];
         <form action="install.php" method="post">
             <input type="hidden" name="s" value="subscribe">
                 <div class="row">
-                    <label><?php echo __('Full Name');?>:</label>
-                    <input type="text" name="name" size="30" value="<?php echo $info['name']; ?>">
+                    <label for="name"><?php echo __('Full Name');?>:</label>
+                    <input id="name" type="text" name="name" size="30" value="<?php echo $info['name']; ?>">
                     <font color="red"><?php echo $errors['name']; ?></font>
                 </div>
                 <div class="row">
-                    <label><?php echo __('Email Address');?>:</label>
-                    <input type="text" name="email" size="30" value="<?php echo $info['email']; ?>">
+                    <label for="email"><?php echo __('Email Address');?>:</label>
+                    <input id="email" type="text" name="email" size="30" value="<?php echo $info['email']; ?>">
                     <font color="red"><?php echo $errors['email']; ?></font>
                 </div>
                 <br>
                 <div class="row">
                     <strong><?php echo __("I'd like to receive the following notifications");?>: <font color="red"><?php echo $errors['notify']; ?></font></strong>
-                    <label style="width:500px">
-                        <input style="position:relative; top:4px; margin-right:10px"
+                    <label for="news" style="width:500px">
+                        <input id="news" style="position:relative; top:4px; margin-right:10px"
                             type="checkbox" name="news" value="1" <?php echo (!isset($info['news']) || $info['news'])?'checked="checked"':''; ?> >
                             <?php echo __('News &amp; Announcements');?></label>
-                    <label style="width:500px">
-                        <input style="position:relative; top:4px; margin-right:10px"
+                    <label for="alerts" style="width:500px">
+                        <input id="alerts" style="position:relative; top:4px; margin-right:10px"
                             type="checkbox" name="alerts" value="1" <?php echo (!isset($info['alerts']) || $info['alerts'])?'checked="checked"':''; ?>>
                             <?php echo __('Security Alerts');?></label>
                 </div>


### PR DESCRIPTION
### Link to issue number: ###
This issue partially addresses #5359 at least on the installation pages.

### Description of this pull request ###
This pull requests adds labels to form fields to expand click target size as well as add an accessible label for screen readers. This addresses the installation pages only.

### How to test ###
Tab through and fill out the installation pages using the keyboard alone. Notice how each link, edit field, and button are receiving keyboard focus.
Also, click on an edit fields label. Notice how keyboard focus is placed inside the edit field.