### PR TITLE
queue: Inherit Columns Option

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1015,12 +1015,6 @@ class CustomQueue extends VerySimpleModel {
     }
 
     function inheritColumns() {
-        global $thisstaff;
-
-        if ($thisstaff && ($inherit = self::staffSettings('inherit-columns'))
-                && !is_null($inherit))
-            return $inherit == 'true';
-
         return $this->hasFlag(self::FLAG_INHERIT_COLUMNS);
     }
 
@@ -1040,22 +1034,6 @@ class CustomQueue extends VerySimpleModel {
 
     function isDefaultSortInherited() {
         return $this->hasFlag(self::FLAG_INHERIT_DEF_SORT);
-    }
-
-    function staffSettings($key=null) {
-        global $thisstaff;
-
-        if (!$config = QueueConfig::objects()->filter(array(
-                'staff_id' => $thisstaff->getId(),
-                'queue_id' => $this->getId()))->first())
-            return null;
-
-        $settings = JsonDataParser::decode($config->setting) ?: null;
-
-        if ($key && $settings)
-            return $settings[$key];
-
-        return $settings;
     }
 
     function buildPath() {

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -788,6 +788,13 @@ class SavedQueue extends CustomQueue {
         return parent::useStandardColumns();
     }
 
+    function inheritColumns() {
+        if ($this->getSettings() && isset($this->_settings['inherit-columns']))
+            return $this->_settings['inherit-columns'];
+
+        return parent::inheritColumns();
+    }
+
     function getStandardColumns() {
         return parent::getColumns(is_null($this->parent));
     }

--- a/include/staff/templates/queue-columns.tmpl.php
+++ b/include/staff/templates/queue-columns.tmpl.php
@@ -29,8 +29,7 @@ if ($queue->parent) { ?>
     </tr>
   </tbody>
 <?php }
-$hidden_cols = $queue->inheritColumns() || ($queue->useStandardColumns() &&
-        $queue->parent_id);
+$hidden_cols = $queue->inheritColumns() || $queue->useStandardColumns();
 ?>
   <tbody class="if-not-inherited <?php if ($hidden_cols) echo 'hidden'; ?>">
     <tr class="header">
@@ -108,8 +107,6 @@ $hidden_cols = $queue->inheritColumns() || ($queue->useStandardColumns() &&
 </div>
 <script>
 +function() {
-if ($('[name=inherit-columns]').attr('disabled'))
-    $('.if-not-inherited').hide();
 $('[name=inherit-columns]').on('click', function() {
     $('.standard-columns').toggle();
 });


### PR DESCRIPTION
This is a rewrite of a commit that was accidentally merged. This, in part, removes all unnecessary code from the accidental commit. This adds a new `inheritColumns()` method to SavedQueue to use with all queues. Lastly, this removes `$this->parent_id` from the `$hidden_cols` check so all queues behave correctly. Most queues will not have a `parent_id` and will fail this check.