### PR TITLE
Oops: Set Child Ticket Status

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2553,7 +2553,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     $child->getThread()->setExtra($parentThread);
 
                 $child->setMergeType($options['combine']);
-                $child->setStatus(intval($options['statusId']), false, $errors, true, true); //force close status for children
+                $child->setStatus(intval($options['childStatusId']), false, $errors, true, true); //force close status for children
 
                 if ($options['parentStatusId'])
                     $parent->setStatus(intval($options['parentStatusId']));


### PR DESCRIPTION
This commit fixes an issue where the child status name was changed from statusId to childStatusId in the template but not in the ticket class.