### PR TITLE
issue: BooleanField Cannot Be Unchecked

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -641,6 +641,9 @@ class TicketsAjaxAPI extends AjaxController {
                         if (strlen($clean) > 200)
                              $clean = Format::truncate($clean, 200);
                         break;
+                    case $field instanceof BooleanField:
+                        $clean = $field->toString($field->getClean());
+                        break;
                     default:
                         $clean =  $field->getClean();
                         $clean = is_array($clean) ? implode($clean, ',') :

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4623,7 +4623,7 @@ class CheckboxWidget extends Widget {
                 return $data[$this->field->get('id')];
         }
 
-        if (isset($this->value))
+        if (!$data && isset($this->value))
             return $this->value;
 
 


### PR DESCRIPTION
This addresses an issue where checkboxes cannot be unchecked once saved as checked. This was introduced with a fix for another issue where it's necessary to return the default value for VisibilityConstraints. This is fine for Holiday Schedule checkboxes but for custom fields this breaks basic functionality. This updates `getValue()` for CheckboxWidget to only return the default value if `$data` (source) is not set.

This also addresses an issue where after setting a checkbox value via Inline Edit it shows the value as `0` or `1` instead of `Yes` or `No`. You have to refresh the page in order for the value to appear correctly. This is due to the raw value being returned instead of it's string equivalent. This adds a case in `TicketsAjaxAPI::editField()` for `BooleanField` that converts the raw value to the string value with `toString()`.