### PR TITLE
issue: New Task Alert

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1062,6 +1062,10 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
             break;
         case 'last_update':
             return new FormattedDate($this->last_update);
+        case 'description':
+            return Format::display($this->getThread()->getVar('original') ?: '');
+        case 'subject':
+            return Format::htmlchars($this->getTitle());
         default:
             if (isset($this->_answers[$tag]))
                 // The answer object is retrieved here which will
@@ -1084,6 +1088,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
             'dept' => array(
                 'class' => 'Dept', 'desc' => __('Department'),
             ),
+            'description' => __('Description'),
             'due_date' => array(
                 'class' => 'FormattedDate', 'desc' => __('Due Date'),
             ),
@@ -1344,7 +1349,12 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
 
         // Create a thread + message.
         $thread = TaskThread::create($task);
-        $thread->addDescription($vars);
+        $desc = $thread->addDescription($vars);
+        // Set the ORIGINAL_MESSAGE Flag if Description is added
+        if ($desc) {
+            $desc->setFlag(ThreadEntry::FLAG_ORIGINAL_MESSAGE);
+            $desc->save();
+        }
 
 
         $task->logEvent('created', null, $thisstaff);


### PR DESCRIPTION
This addresses an issue where the New Task Alert was not functioning as it should. This adds a new method called `onNewTask()` that runs after a Task is created and sends out the New Task Alert (if enabled). This will take into account the Global settings as well as the Department settings for Alerts and Notices.


This addresses an issue where the `subject` and `description` vars are missing from `Task::getVar()` so these variables are never replaced in the Task templates. This adds two cases for `Task::getVar()`; case `description` that retrieves the Task Description (if any) and case `subject` that retrieves the Task Subject. This also addresses an issue where the `description` var is missing from `Task::getVarScope()` so when an Agent uses the Variable Typeahead the `%{task.description}` option does not show.