### PR TITLE
Issue add remote collaborator 400 error

### DIFF
--- a/include/ajax.thread.php
+++ b/include/ajax.thread.php
@@ -56,7 +56,7 @@ class ThreadAjaxAPI extends AjaxController {
     }
 
 
-    function addRemoteCollaborator($tid, $bk, $id) {
+    function addRemoteCollaborator($tid, $type=null, $bk, $id) {
         global $thisstaff;
 
         if (!($thread=Thread::lookup($tid))

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -216,7 +216,7 @@ $dispatcher = patterns('',
         url_get('^(?P<tid>\d+)/collaborators$', 'showCollaborators'),
         url_post('^(?P<tid>\d+)/collaborators$', 'updateCollaborators'),
         url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/(?P<uid>\d+)$', 'addCollaborator'),
-        url_get('^(?P<tid>\d+)/add-collaborator/auth:(?P<bk>\w+):(?P<id>.+)$', 'addRemoteCollaborator'),
+        url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/auth:(?P<bk>\w+):(?P<id>.+)$', 'addRemoteCollaborator'),
         url('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)$', 'addCollaborator'),
         url_get('^(?P<tid>\d+)/collaborators/(?P<cid>\d+)/view$', 'viewCollaborator'),
         url_post('^(?P<tid>\d+)/collaborators/(?P<cid>\d+)$', 'updateCollaborator')


### PR DESCRIPTION
When adding a remote user as a collaborator when viewing a ticket I was receiving a 400 error. This corrected the issue but not sure if it is right. Hope it helps. @JediKev found this to be helpful to fix the error 46afc966676fdd4ca60b01827473f8e23a8c661e