### PR TITLE
issue: Add Remote Collaborator

### DIFF
--- a/include/ajax.thread.php
+++ b/include/ajax.thread.php
@@ -56,7 +56,7 @@ class ThreadAjaxAPI extends AjaxController {
     }
 
 
-    function addRemoteCollaborator($tid, $bk, $id) {
+    function addRemoteCollaborator($tid, $type, $bk, $id) {
         global $thisstaff;
 
         if (!($thread=Thread::lookup($tid))
@@ -74,7 +74,7 @@ class ThreadAjaxAPI extends AjaxController {
         if (!$user_info)
             $info['error'] = __('Unable to find user in directory');
 
-        return self::_addcollaborator($thread, null, $form, 'addcc', $info);
+        return self::_addcollaborator($thread, null, $form, $type, $info);
     }
 
     //Collaborators utils

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -216,7 +216,7 @@ $dispatcher = patterns('',
         url_get('^(?P<tid>\d+)/collaborators$', 'showCollaborators'),
         url_post('^(?P<tid>\d+)/collaborators$', 'updateCollaborators'),
         url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/(?P<uid>\d+)$', 'addCollaborator'),
-        url_get('^(?P<tid>\d+)/add-collaborator/auth:(?P<bk>\w+):(?P<id>.+)$', 'addRemoteCollaborator'),
+        url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/auth:(?P<bk>\w+):(?P<id>.+)$', 'addRemoteCollaborator'),
         url('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)$', 'addCollaborator'),
         url_get('^(?P<tid>\d+)/collaborators/(?P<cid>\d+)/view$', 'viewCollaborator'),
         url_post('^(?P<tid>\d+)/collaborators/(?P<cid>\d+)$', 'updateCollaborator')


### PR DESCRIPTION
This addresses an issue where adding a Collaborator that is from a remote backend such as LDAP fails. This is due to the AJAX URL not being recognized. The regex is expecting `^(?P<tid>\d+)/add-collaborator/auth:(?P<bk>\w+):(?P<id>.+)$` but the URL being called is `XXX/add-collabborator/addcc/auth:XXX` (with the added `/addcc` part). This updates the regex to account for the `/addcc` part, and adds `$type` as an argument for `addRemoteCollaborator()`.

Rewrite of [this pull](https://github.com/osTicket/osTicket/pull/5383) by @jdelhome3578.