### PR TITLE
lint: Minified JS Warnings

### DIFF
--- a/setup/test/tests/class.test.php
+++ b/setup/test/tests/class.test.php
@@ -15,6 +15,10 @@ class Test {
         '/include/plugins/',
         '/include/h2o/',
         '/include/mpdf/',
+        '/js/select2.min.js',
+        '/js/redactor.min.js',
+        '/js/jquery-ui-1.12.1.custom.min.js',
+        '/js/fabric.min.js',
 
         # Includes in the core-plugins project
         '/lib/',


### PR DESCRIPTION
This addresses an issue where when running lint tests it throws 150+ warnings about minified JS files. This adds the 3rd party minified files to `$third_party_paths` so that they are ignored (`js/select2.min.js`, `js/redactor.min.js`, `js/jquery-ui-1.12.1.custom.min.js`, `js/fabric.min.js`).