### PR TITLE
lint: updateEstDueDate

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1525,7 +1525,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     $ecb = function ($t) {
                         $t->logEvent('reopened', false, null, 'closed');
                         // Set new sla duedate if any
-                        $t->updateEstDuedate();
+                        $t->updateEstDueDate();
                     };
                 }
 


### PR DESCRIPTION
This addresses an issue where lint tests complain about an undefined method `updateEstDuedate()`. This is correct as the method is actually called `updateEstDueDate()`. This updates the method name from `updateEstDuedate()` to `updateEstDueDate()`.