### PR TITLE
issue: Quotes In User Name

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -288,7 +288,7 @@ implements TemplateVariable, Searchable {
 
         if (!isset($this->_email))
             $this->_email = new EmailAddress(sprintf('"%s" <%s>',
-                    $this->getName(),
+                    addcslashes($this->getName(), '"'),
                     $this->default_email->address));
 
         return $this->_email;


### PR DESCRIPTION
This addresses issue #5345 where double quotes in a User's Name will make their email address appear as empty (`@`). This is due to the `getEmail()` method where we combine the User's Name and Email Address into one string by putting the User's name inside double quotes and the email after in angular brackets (eg. `"First Last" <email@domain.tld>`). We do not escape double quotes within the User's name so when we insert the name between double quotes, the string is cut off at the first double quote (eg. `"First "Nickname" Last" <email@domain.tld>` -> `"First "`). Since the string is incomplete we are unable to find the email address so it appears as `@`. This adds `addcslashes()` to the `getEmail()` method so we can escape any double quotes within the User's name and the string does not get cut off.