### PR TITLE
issue: PasswordField Validation

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1446,6 +1446,9 @@ class TextboxField extends FormField {
         $config = $this->getConfiguration();
         $validators = array(
             '' => '',
+            'noop' => array(
+                function($a, &$b) { return true; }
+            ),
             'formula' => array(array('Validator', 'is_formula'),
                 __('Content cannot start with the following characters: = - + @')),
             'email' =>  array(array('Validator', 'is_valid_email'),
@@ -1455,6 +1458,8 @@ class TextboxField extends FormField {
             'ip' =>     array(array('Validator', 'is_ip'),
                 __('Enter a valid IP address')),
             'number' => array('is_numeric', __('Enter a number')),
+            'password' => array(array('Validator', 'check_passwd'),
+                __('Invalid Password')),
             'regex' => array(
                 function($v) use ($config) {
                     $regex = $config['regex'];
@@ -1496,6 +1501,11 @@ class TextboxField extends FormField {
 
 class PasswordField extends TextboxField {
     static $widget = 'PasswordWidget';
+
+    function __construct($options=array()) {
+        parent::__construct($options);
+        $this->set('validator', 'password');
+    }
 
     function parse($value) {
         // Don't trim the value

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1480,14 +1480,15 @@ class TextboxField extends FormField {
             $valid = 'formula';
         $func = $validators[$valid];
         $error = $func[1];
+        $err = null;
         // If validator is number and the value is &#48 set to 0 (int) for is_numeric
         if ($valid == 'number' && $value == '&#48')
             $value = 0;
         if ($config['validator-error'])
             $error = $this->getLocal('validator-error', $config['validator-error']);
         if (is_array($func) && is_callable($func[0]))
-            if (!call_user_func($func[0], $value))
-                $this->_errors[] = $error;
+            if (!call_user_func_array($func[0], array($value, &$err)))
+                $this->_errors[] = $err ?: $error;
     }
 
     function parse($value) {

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -217,6 +217,15 @@ class Validator {
         return $error == '';
     }
 
+    static function check_passwd($passwd, &$error='') {
+        try {
+            PasswordPolicy::checkPassword($passwd, null);
+        } catch (BadPassword $ex) {
+            $error = $ex->getMessage();
+        }
+        return $error == '';
+    }
+
     /*
      * check_ip
      * Checks if an IP (IPv4 or IPv6) address is contained in the list of given IPs or subnets.


### PR DESCRIPTION
This addresses an issue reported in the Plugins repo where attempting to use a password that starts with any of these characters (`= - + @`) fails with `Content cannot start with the following characters: = - + @` validation error. This is due to Formula Injection prevention for any field that has potential to be exported. I did not take PasswordFields into account as these are not exportable fields. This adds a new validator to TextboxField called `password` that calls `Validation::check_passwd` which uses `PasswordPolicy::checkPassword()` to check the password against all active policies. This also adds a constructor to class `PasswordField` so we can add the `password` validator for all password fields. In addition this adds another validator to TextboxField called `noop` that returns true to skip validation (useful for LDAP password, etc.).

This adds the ability to use error messages returned by the source validation method for more detailed errors via TextboxFields (and it's children classes). If no error is returned by the source validation method we will use the default error message set by `validateEntry()`.