### PR TITLE
issue: Multiple Choice Export

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1817,7 +1817,7 @@ class ChoiceField extends FormField {
         if (is_string($value) && strpos($value, ',')) {
             $values = array();
             $choices = $this->getChoices();
-            $vals = explode(',', $value);
+            $vals = array_map('trim', explode(',', $value));
             foreach ($vals as $V) {
                 if (isset($choices[$V]))
                     $values[$V] = $choices[$V];


### PR DESCRIPTION
This addresses an issue where saving multiple choices for a ChoiceField does not show all values in Queue Columns nor Ticket Exports. This is due to the `to_php()` method exploding on `,` while the keys are saved like `key1, key2` (with comma then space). This updates the `to_php()` method to explode on `, ` (comma and space) so we get the proper keys for the value lookups.
(Partially addresses #5376)