### PR TITLE
lint: Uninitialized Matches

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -386,7 +386,7 @@ class Mail_Parse {
     }
 
     function getAttachments($part=null){
-        $files=array();
+        $files = $matches = array();
 
         /* Consider this part as an attachment if
          *   * It has a Content-Disposition header


### PR DESCRIPTION
This resolves lint test complaints of an uninitialized variable `$matches` in `include/class.mailparse.php`.