### PR TITLE
issue: PDF Global $ost

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -83,7 +83,7 @@ class Ticket2PDF extends mPDFWithLocalImages
     }
 
     function _print() {
-        global $thisstaff, $thisclient, $cfg;
+        global $thisstaff, $thisclient, $cfg, $ost;
 
         if(!($ticket=$this->getTicket()))
             return;
@@ -119,7 +119,7 @@ class Task2PDF extends mPDFWithLocalImages {
     }
 
     function _print() {
-        global $thisstaff, $cfg;
+        global $thisstaff, $cfg, $ost;
 
         if (!($task=$this->task) || !$thisstaff)
             return;


### PR DESCRIPTION
This addresses an issue where `$ost` is not available for the ticket and task print templates which causes `(string) $ost->company;` to appear as an empty string. This adds `$ost` to the globals for printing tickets and tasks so that the company name is properly displayed.