### PR TITLE
install: Task Title/Description Field Flags

### DIFF
--- a/include/i18n/en_US/form.yaml
+++ b/include/i18n/en_US/form.yaml
@@ -191,7 +191,7 @@
   fields:
     - type: text # notrans
       name: title # notrans
-      flags: 0x470B1
+      flags: 0x770B1
       sort: 1
       label: Title
       configuration:
@@ -199,7 +199,7 @@
         length: 50
     - type: thread # notrans
       name: description # notrans
-      flags: 0x450F3
+      flags: 0x650F3
       sort: 2
       label: Description
       hint: Details on the reason(s) for creating the task.


### PR DESCRIPTION
This addresses an issue where the Task Title field allows any Admin to remove the View and Required perms for Agents even though this field should be Viewable and Required. This adds the `FLAG_MASK_REQUIRE` and `FLAG_MASK_VIEW` flags to the form install file to ensure Admins cannot change this behavior for both perms. This also addresses an issue where the Task Description field allows any Admin to remove the View perms for Agents even though this field should always be Viewable. This adds the `FLAG_MASK_VIEW` flag to the form install file to ensure Admins cannot change this behavior.