### PR TITLE
[Feature] Canned responses search - Matcher for non-adjacent keywords

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -214,14 +214,31 @@ var scp_prep = function() {
                 return data;
             }
 
-            keywords = (params.term).split(" ");
+            var original = data.text.toUpperCase();
+            var term = params.term.toUpperCase();
+            var keywords = term.split(" ");
 
             for (var i = 0; i < keywords.length; i++) {
-                if (((data.text).toUpperCase()).indexOf((keywords[i]).toUpperCase()) == -1)
+                if (original.indexOf(keywords[i]) == -1)
                     return null;
             }
 
-            return data;
+            var termIndex = original.indexOf(term);
+            if (termIndex > -1)
+                return $.extend({'matchType': 'term', 'index': termIndex}, data);
+             
+            return $.extend({'matchType': 'keyword', 'index': original.indexOf(keywords[0])}, data);
+        },
+        sorter: function (data) {
+            if (!data[0].hasOwnProperty('matchType'))
+                return data;
+
+            return data.sort(function(a, b) {
+                if (a.matchType == b.matchType)
+                    return a.index - b.index;
+                
+                return ((a.matchType == 'term') ? -1 : 1);
+            });
         }
     });
     $('form select#cannedResp').on('select2:opening', function (e) {

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -205,7 +205,25 @@ var scp_prep = function() {
         }
      });
 
-    $('form select#cannedResp').select2({width: '350px'});
+    // Custom matcher for non-adjacent keywords
+    // Thanks, https://stackoverflow.com/a/31626588/10706339
+    $('form select#cannedResp').select2({
+        width: '350px',
+        matcher: function (params, data) {
+            if ($.trim(params.term) === '') {
+                return data;
+            }
+
+            keywords = (params.term).split(" ");
+
+            for (var i = 0; i < keywords.length; i++) {
+                if (((data.text).toUpperCase()).indexOf((keywords[i]).toUpperCase()) == -1)
+                    return null;
+            }
+
+            return data;
+        }
+    });
     $('form select#cannedResp').on('select2:opening', function (e) {
         var redactor = $('.richtext', $(this).closest('form')).data('redactor');
         if (redactor)


### PR DESCRIPTION
Resolves #5367 

This custom matcher will return results for non-adjacent keywords in the canned responses search field (ticket view). Makes searching for canned responses easier when you don't know the exact order of the words, and when you have a large list of canned responses.
