### PR TITLE
i18n: Help Text Translate Button

### DIFF
--- a/include/staff/templates/dynamic-field-config.tmpl.php
+++ b/include/staff/templates/dynamic-field-config.tmpl.php
@@ -161,7 +161,7 @@
         </div>
         <div style="width:100%">
         <textarea style="width:90%; width:calc(100% - 20px)" name="hint" rows="2" cols="40"
-            class="richtext small no-bar"
+            class="richtext small"
             data-translate-tag="<?php echo $field->getTranslateTag('hint'); ?>"><?php
             echo Format::htmlchars($field->get('hint')); ?></textarea>
         </div>


### PR DESCRIPTION
This addresses an issue where you cannot translate Help Text for TextareaFields. This is due to no translate button to switch between languages. This removes the `no-bar` option from the Help Text textarea which shows Redactor's toolbar including the Translate button.