### PR TITLE
i18n: Help Text Formatting

### DIFF
--- a/include/ajax.i18n.php
+++ b/include/ajax.i18n.php
@@ -73,7 +73,7 @@ class i18nAjaxAPI extends AjaxController {
                 }
                 else {
                     // Avoid XSS injection
-                    $p->text = trim(Format::striptags($phrase));
+                    $p->text = trim(Format::sanitize($phrase));
                     $p->agent_id = $thisstaff->getId();
                 }
             }

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2685,7 +2685,7 @@ class ThreadEntryField extends FormField {
 
     function getWidget($widgetClass=false) {
         if ($hint = $this->getLocal('hint'))
-            $this->set('placeholder', $hint);
+            $this->set('placeholder', Format::striptags($hint));
         $this->set('hint', null);
         $widget = parent::getWidget($widgetClass);
         return $widget;


### PR DESCRIPTION
This addresses an issue where Help Text for TextareaFields would not let you save text with formatting due to `Format::striptags()`. This changes `Format::striptags()` to `Format::sanitize()` to allow formatting whilst still preventing XSS Injections.

This also addresses an issue introduced with the previous commit where since we allow Formatting to be saved for Help Text now, the ThreadEntryFields do not render the Help Text correctly. Only ThreadEntryFields display the Help Text within the `placeholder` attribute. Since the content is placed in an attribute, it cannot be rendered as HTML. This adds `Format::striptags()` to `ThreadEntryField::getWidget()` so that tags are stripped from the Help Text before rendering.