### PR TITLE
format: Strip PUA (Plane 16)

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -452,6 +452,7 @@ class Format {
                 '/[\x{23F0}-\x{23FF}]/u',   # Clock/Buttons
                 '/[\x{23E0}-\x{23EF}]/u',   # More Buttons
                 '/[\x{2310}-\x{231F}]/u',   # Hourglass/Watch
+                '/[\x{1000B6}]/u',          # Private Use Area (Plane 16)
                 '/[\x{2322}-\x{232F}]/u'    # Keyboard
             ), '', $text);
     }


### PR DESCRIPTION
This addresses an issue where if someone has the `U+1000B6` Unicode character somewhere inside the body of their email, the remainder of the email is cut off. The system doesn't know what to do with this character as [it's not considered a standardized character in Unicode itself](https://en.wikipedia.org/wiki/Private_Use_Areas) so parsing fails at the character truncating the rest of the content. This adds a new case to `strip_emoticons()` that strips this character if present so the rest of the content is safe. We do not need `U+1000B6` anyways as it's part of a PUA (Private Use Area), specifically in Plane 16, that's typically controlled by third parties.