### PR TITLE
Oops: User Import Fix

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -525,7 +525,9 @@ implements TemplateVariable, Searchable {
     }
 
     function importFromPost($stream, $extra=array()) {
-        $stream = sprintf('name, email%s %s',PHP_EOL, $stream);
+        if (!is_array($stream))
+            $stream = sprintf('name, email%s %s',PHP_EOL, $stream);
+
         return User::importCsv($stream, $extra);
     }
 


### PR DESCRIPTION
This commit fixes an issue we had with a recent change to User Imports. We want to make sure the agent does not have to specify the 'name, email' headers if they are typing user imports, but if they are using a CSV for imports, we need to leave the headers as they are.