### PR TITLE
export: User/Org Tickets

### DIFF
--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -645,9 +645,9 @@ implements TemplateVariable, Searchable {
                 'staff_id' => $thisstaff->getId(),
                 'title' => $name
             ));
-            $this->_queue->filter(array(
-                'user__org__name' => $name
-            ));
+            $this->_queue->config = [[
+                'user__org__name', 'equal', $name
+            ]];
         }
 
         return $this->_queue;

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -698,21 +698,21 @@ implements TemplateVariable, Searchable {
 
         if (!$this->_queue) {
             $email = $this->getDefaultEmailAddress();
-            $filter = new Q(array(
-                'user__id' => $this->getId()
-            ));
+            $filter = [
+                ['user__id', 'equal', $this->getId()],
+            ];
             if ($collabs)
-                $filter = Q::any(array(
-                    'user__emails__address' => $email,
-                    'thread__collaborators__user__emails__address' => $email,
-                ));
+                $filter = [
+                    ['user__emails__address', 'equal', $email],
+                    ['thread__collaborators__user__emails__address', 'equal',  $email],
+                ];
             $this->_queue = new AdhocSearch(array(
                 'id' => 'adhoc,uid'.$this->getId(),
                 'root' => 'T',
                 'staff_id' => $thisstaff->getId(),
                 'title' => $this->getName()
             ));
-            $this->_queue->filter($filter);
+            $this->_queue->config = $filter;
         }
 
         return $this->_queue;


### PR DESCRIPTION
This addresses an issue introduced with #5207 where reverting the changes of a commit left some old code behind. This causes the User Ticket exports and Org Ticket exports to crash when clicking Export. This changes both `filter()` methods to setting `$this->_queue->config` directly as `filter()` no longer exists for AdhocSearches.