### PR TITLE
i18n: TextareaField Placeholder

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4023,7 +4023,7 @@ class TextareaWidget extends Widget {
         <span style="display:inline-block;width:100%">
         <textarea <?php echo $rows." ".$cols." ".$maxlength." ".$class
                 .' '.Format::array_implode('=', ' ', $attrs)
-                .' placeholder="'.$config['placeholder'].'"'; ?>
+                .' placeholder="'.$this->field->getLocal('placeholder', $config['placeholder']).'"'; ?>
             id="<?php echo $this->id; ?>"
             name="<?php echo $this->name; ?>"><?php
                 echo Format::htmlchars($this->value);


### PR DESCRIPTION
This addresses an issue where TextareaFields do not show translated placeholders. This is due to using the placeholder from the default configuration instead of using the local placeholder. This updates the `TextareaWidget::render()` method to get the local placeholder instead of using the default from config. This also passes `$config['placeholder']` as a default in case there is no translation available.