### PR TITLE
issue: DynamicForm i18n Instructions Decode

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -121,7 +121,7 @@ class DynamicForm extends VerySimpleModel {
         $fields = $this->getFields();
         $form = new SimpleForm($fields, $source, array(
             'title' => $this->getLocal('title'),
-            'instructions' => $this->getLocal('instructions'),
+            'instructions' => Format::htmldecode($this->getLocal('instructions')),
             'id' => $this->getId(),
         ));
         return $form;


### PR DESCRIPTION
This addresses an issue where saving translated Form Instructions with HTML formatting renders the Instructions as plaintext on the Client Portal showing all HTML, etc. This is due to saving the translated Instructions as encoded thanks to `Format::htmlchars()`. This uses `Format::htmldecode()` for `instructions` in `DynamicForm::getForm()` so that when the Form is rendered the Instructions are properly displayed.