### PR TITLE
issue: Information Field Help Text Decode

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4827,7 +4827,7 @@ class FreeTextWidget extends Widget {
         }
         if ($hint = $this->field->getLocal('hint')) { ?>
         <em><?php
-            echo Format::htmlchars($hint);
+            echo Format::display($hint);
         ?></em><?php
         } ?>
         <div><?php


### PR DESCRIPTION
This addresses an issue where formatting Help Text for Information fields displays the content as plain-text instead of rendering the HTML. This is due to `htmlchars()` which uses `htmlspecialchars()` to encode the content. This updates `Format::htmlchars()` to `Format::display()` so we can render the content as HTML rather than plaintext.