### PR TITLE
oops: is_numeric Soft Fail

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1457,7 +1457,8 @@ class TextboxField extends FormField {
                 __('Enter a valid phone number')),
             'ip' =>     array(array('Validator', 'is_ip'),
                 __('Enter a valid IP address')),
-            'number' => array('is_numeric', __('Enter a number')),
+            'number' => array(array('Validator', 'is_numeric'),
+                __('Enter a number')),
             'password' => array(array('Validator', 'check_passwd'),
                 __('Invalid Password')),
             'regex' => array(

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -182,13 +182,19 @@ class Validator {
         return true;
     }
 
-    static function is_valid_email($email) {
+    static function is_numeric($number, &$error='') {
+        if (!is_numeric($number))
+            $error = __('Enter a Number');
+        return $error == '';
+    }
+
+    static function is_valid_email($email, &$error='') {
         global $cfg;
         // Default to FALSE for installation
         return self::is_email($email, false, $cfg && $cfg->verifyEmailAddrs());
     }
 
-    static function is_phone($phone) {
+    static function is_phone($phone, &$error='') {
         /* We're not really validating the phone number but just making sure it doesn't contain illegal chars and of acceptable len */
         $stripped=preg_replace("(\(|\)|\-|\.|\+|[  ]+)","",$phone);
         return (!is_numeric($stripped) || ((strlen($stripped)<7) || (strlen($stripped)>16)))?false:true;
@@ -199,7 +205,7 @@ class Validator {
         return ($url && ($info=parse_url($url)) && $info['host']);
     }
 
-    static function is_ip($ip) {
+    static function is_ip($ip, &$error='') {
         return filter_var(trim($ip), FILTER_VALIDATE_IP) !== false;
     }
 


### PR DESCRIPTION
This addresses an issue introduced with commit 9e21dfd9 where `is_numeric()` validation fails even when inserting a legitimate number. In the aforementioned commit, we added the ability to return error messages from the source validator method. In doing so, we changed `call_user_func()` to `call_user_func_array()` which now passes two arguments to the validation method. This broke `is_numeric()` validation as this method does not accept more than one argument. This adds a new method to class Validator called `is_numeric()` that accepts two arguments so it does not fail. In addition, this updates the remaining validators that do not currently accept two arguments.