### PR TITLE
Issue: Duplicate Thread Entry Merge Records

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1556,11 +1556,17 @@ implements TemplateVariable {
 
     function setExtra($entries, $info=NULL, $thread_id=NULL) {
         foreach ($entries as $entry) {
-            $mergeInfo = new ThreadEntryMergeInfo(array(
-                'thread_entry_id' => $entry->getId(),
-                'data' => json_encode($info),
-            ));
-            $mergeInfo->save();
+            $mergeInfo = ThreadEntryMergeInfo::objects()
+                ->filter(array('thread_entry_id'=>$entry->getId()))
+                ->values_flat('thread_entry_id')
+                ->first();
+            if (!$mergeInfo) {
+                $mergeInfo = new ThreadEntryMergeInfo(array(
+                    'thread_entry_id' => $entry->getId(),
+                    'data' => json_encode($info),
+                ));
+                $mergeInfo->save();
+            }
             $entry->saveExtra($info, $thread_id);
         }
 


### PR DESCRIPTION
This commit fixes an issue we had with creating duplicate records in the thread_entry_merge table. This would happen if you were to merge tickets, deleting the child tickets, and then try to merge that ticket into another ticket.

This fixes Issue #5379.