### PR TITLE
[Feature] Unread ticket message (column annotation)

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -704,7 +704,7 @@ class CustomQueue extends VerySimpleModel {
                 "width" => 250,
                 "bits" => QueueColumn::FLAG_SORTABLE,
                 "filter" => "link:ticket",
-                "annotations" => '[{"c":"TicketThreadCount","p":">"},{"c":"ThreadAttachmentCount","p":"a"},{"c":"OverdueFlagDecoration","p":"<"}]',
+                "annotations" => '[{"c":"TicketThreadCount","p":">"},{"c":"ThreadAttachmentCount","p":"a"},{"c":"OverdueFlagDecoration","p":"<"},{"c":"TicketUnreadDecoration","p":"<"}]',
                 "conditions" => '[{"crit":["isanswered","nset",null],"prop":{"font-weight":"bold"}}]',
                 "truncate" => 'ellipsis',
             )),
@@ -1742,6 +1742,31 @@ extends QueueColumnAnnotation {
 
     function isVisible($row) {
         return $row['isoverdue'];
+    }
+}
+
+class TicketUnreadDecoration
+extends QueueColumnAnnotation {
+    static $icon = 'plus-sign';
+    static $desc = 'Unread message icon';
+
+    function annotate($query, $name=false) {
+        global $thisstaff;
+
+        $query->values('updated');
+        return $query
+            ->annotate(array(
+                '_lastVisit' => TicketStaffLastVisit::objects()
+                    ->filter(array(
+                        'ticket_id' => new SqlField('ticket_id', 1),
+                        'staff_id' => $thisstaff->getId())) 
+                    ->values('lastvisit_date')        
+                    ));
+    }
+
+    function getDecoration($row, $text) {
+        if(strtotime($row['_lastVisit']) < strtotime($row['updated']))
+            return sprintf('<span class="Icon unreadTicket"></span>');
     }
 }
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1313,6 +1313,23 @@ implements RestrictedAccess, Threadable, Searchable {
         return $this->save();
     }
 
+    //mark as read for given staff
+    function setStaffLastVisitNow($staff) {
+        $stafflastvisit = TicketStaffLastVisit::lookup(array(
+            'ticket_id'=>$this->ticket_id,
+            'staff_id'=>$staff->getId()
+        ));        
+        if(!isset($stafflastvisit)) {
+            $stafflastvisit = new TicketStaffLastVisit(array(
+                'ticket_id' => $this->ticket_id,
+                'staff_id' => $staff->getId(),
+                'lastvisit_date' => SqlFunction::NOW()
+            ));
+        }
+        $stafflastvisit->lastvisit_date = SqlFunction::NOW();
+        $stafflastvisit->save();        
+    }
+
     // Ticket Status helper.
     function setStatus($status, $comments='', &$errors=array(), $set_closing_agent=true) {
         global $thisstaff;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4343,3 +4343,19 @@ class TicketCData extends VerySimpleModel {
     );
 }
 TicketCData::$meta['table'] = TABLE_PREFIX . 'ticket__cdata';
+
+class TicketStaffLastVisit extends VerySimpleModel {
+    static $meta = array(
+        'pk' => array('ticket_id', 'staff_id'),
+        'select_related' => array('staff'),
+        'joins' => array(
+            'ticket' => array(
+                'constraint' => array('ticket_id' => 'Ticket.ticket_id'),
+            ),
+            'staff' => array(
+                'constraint' => array('staff_id' => 'Staff.staff_id')
+            ),
+        ),
+    );
+}
+TicketStaffLastVisit::$meta['table'] = TABLE_PREFIX . 'ticket_stafflastvisit';

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -23,6 +23,7 @@ $id    = $ticket->getId();    //Ticket ID.
 $isManager = $dept->isManager($thisstaff); //Check if Agent is Manager
 $canRelease = ($isManager || $role->hasPerm(Ticket::PERM_RELEASE)); //Check if Agent can release tickets
 $canMarkAnswered = ($isManager || $role->hasPerm(Ticket::PERM_MARKANSWERED)); //Check if Agent can mark as answered/unanswered
+$ticket->setStaffLastVisitNow($thisstaff); //reset last visit time for read/unread mod
 
 //Useful warnings and errors the user might want to know!
 if ($ticket->isClosed() && !$ticket->isReopenable())

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -1042,6 +1042,7 @@ a.Icon:hover {
 .Icon.assignedTicket { background:url(../images/icons/assigned_ticket.gif) 0 0 no-repeat; }
 .Icon.lockedTicket { background:url(../images/icons/locked_ticket.gif) 0 0 no-repeat; }
 .Icon.editTicket { background-image: url(../images/icons/edit_ticket.png); }
+.Icon.unreadTicket { background:url(../images/icons/add.png) 0 0 no-repeat; }
 
 .Icon.staffAssigned { background-image: url(../images/icons/user.gif); }
 .Icon.teamAssigned { background-image: url(../images/icons/teams.png); }


### PR DESCRIPTION
**FEATURE DESCRIPTION**
Staff members needs to be notified about new messages in ticket thread. One already existing way is email notification. Other very simple solution could be column annotation in tickets overview table.
![image](https://user-images.githubusercontent.com/13980038/77224540-18cb4680-6b67-11ea-9326-8b7dde7a9c49.png)
This green plus sign indicates, that there is new message in ticket thread, that I have not read yet. If I open this ticket in browser, this annotation disappears.

This became must have feature for staff in my companies. Our team works with quite a lot of tickets daily. They get lost in email notifications. Staff members rely on this simple and effective feature.

![image](https://user-images.githubusercontent.com/13980038/77224726-c559f800-6b68-11ea-993f-7ee677254362.png)

Feature can be turn off/on in queue column settings (Admin panel - Settings - Tickets - Queues - Columns - Config). Yes, I see, that the icon is the same as near "Add a annotation". I leave icon selection up to maintainers (see TODO), because I did not want to include additional icons into project.

**TODO**
- Choose correct icon for annotation ticket table (I used scp - icons - add.png)
- Choose coorect icon in column settings (I used plus-sign)
- Maybe add "Mark as unread" possibility on ticket page. Ideal place would be under settings icon dropdown menu. I can implement this, if anybody is interested.

**DATABASE CHANGES**
```
CREATE TABLE `ost_ticket_stafflastvisit` (
  `ticket_id` int(11) unsigned NOT NULL,
  `staff_id` int(11) unsigned NOT NULL,
  `lastvisit_date` datetime NOT NULL DEFAULT '2015-01-01 12:00:00',
  PRIMARY KEY (`ticket_id`,`staff_id`),
  KEY `FK_staff_id` (`staff_id`)
);
```