### PR TITLE
session: Destroy Warning PHP 7.3

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -228,7 +228,7 @@ extends SessionBackend {
     }
 
     function destroy($id){
-        return (SessionData::objects()->filter(['session_id' => $id])->delete());
+        return SessionData::objects()->filter(['session_id' => $id])->delete() ? true : false;
     }
 
     function cleanup() {


### PR DESCRIPTION
This addresses an issue where logging out of the system using PHP 7.3 throws the infamous `session_destroy(): Session callback expects true/false return value` warning. This was addressed in previous updates with `(SessionData::objects()->filter(['session_id' => $id])->delete())` but apparently PHP 7.3 does not like that anymore so this updates it to a ternary operator to ensure True/False return values.