### PR TITLE
Audit Plugin Modal Fix

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1110,8 +1110,6 @@ $(document).on('pjax:start', function() {
     // Cancel save-changes warning banner
     $(document).unbind('pjax:beforeSend.changed');
     $(window).unbind('beforeunload');
-    // Close popups
-    $('.dialog .body').empty().parent().hide();
     $.toggleOverlay(false);
     // Close tooltips
     $('.tip_box').remove();


### PR DESCRIPTION
This commit removes a line of code that caused the Ticket Audit modal to close any time you tried to go to the next page of audits or sort the audits by timestamp. The code was put in place 6 years ago for file upload fields, but they still work fine everywhere in the codebase without that line now.