### PR TITLE
issue: Mass Process Add Users To Organization

### DIFF
--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -288,8 +288,9 @@ $(function() {
             $.dialog('ajax.php/orgs/lookup/form', 201, function(xhr, json) {
               var $form = $('form#users-list');
               try {
-                  var json = $.parseJSON(json),
-                      org_id = $form.find('#org_id');
+                  if ($.type(json) == 'string')
+                    var json = $.parseJSON(json);
+                  var org_id = $form.find('#org_id');
                   if (json.id) {
                       org_id.val(json.id);
                       goBaby('setorg', true);


### PR DESCRIPTION
This addresses an issue where checking the box next to a few Users' names then selecting the Action to Add To Organization does nothing. This is due to a pesky jQuery issue where `parseJSON()` will crap out if you pass in JSON (go figure). You MUST provide a string otherwise it will silently fail. So, this adds an if statement that checks if the content is a string and if so we will use `$.parseJSON()` otherwise we will not parse it.