### PR TITLE
issue: Confirm Popup Promise

### DIFF
--- a/include/staff/orgs.inc.php
+++ b/include/staff/orgs.inc.php
@@ -219,7 +219,11 @@ $(function() {
             $form.find('#selected-count').val(ids.length);
             $form.submit();
           };
-          $.confirm(__('You sure?')).then(submit);
+          $.confirm(__('You sure?')).then(function(promise) {
+            if (promise === false)
+              return false;
+            submit();
+          });
         }
         else if (!ids.length) {
             $.sysAlert(__('Oops'),

--- a/include/staff/queues-ticket.inc.php
+++ b/include/staff/queues-ticket.inc.php
@@ -89,7 +89,9 @@ $(function() {
       ids.push($(this).val());
     });
     if (ids.length) {
-      $.confirm(__('You sure?')).then(function() {
+      $.confirm(__('You sure?')).then(function(promise) {
+        if (promise === false)
+          return false;
         $.each(ids, function() { $form.append($('<input type="hidden" name="ids[]">').val(this)); });
         $form.append($('<input type="hidden" name="a" />')
           .val($(that).data('action')));

--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -300,7 +300,11 @@ $(function() {
             return;
           }
           if (!confirmed)
-              $.confirm(__('You sure?'), undefined, options).then(submit);
+              $.confirm(__('You sure?'), undefined, options).then(function(promise) {
+                if (promise === false)
+                  return false;
+                submit();
+              });
           else
               submit();
         }


### PR DESCRIPTION
This addresses an issue where clicking Cancel on some popups (eg. Organization Deletion popup, User Deletion popup, etc.) will perform the action instead of cancelling. This is because the `then()` and `done()` callbacks used on the custom `$.confirm()` method do not respect the returned promise. This adds a check to each `$.confirm()` usage to see if the promise is equal to `FALSE`, if so we return false. If the promise is not equal to `FALSE` then we continue with the callback.