### PR TITLE
Issue: Counts in Searches

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2067,6 +2067,28 @@ class NumericField extends FormField {
             )),
         );
     }
+
+    function getSearchQ($method, $value, $name=false) {
+        global $cfg;
+
+        switch ($method) {
+        case 'equal':
+            return new Q(array(
+                "{$name}__exact" => intval($value)
+            ));
+        break;
+        case 'greater':
+            return Q::any(array(
+                "{$name}__gt" => intval($value)
+            ));
+        break;
+        case 'less':
+            return Q::any(array(
+                "{$name}__lt" => intval($value)
+            ));
+        break;
+        }
+    }
 }
 
 class DatetimeField extends FormField {

--- a/include/staff/templates/queue-tickets.tmpl.php
+++ b/include/staff/templates/queue-tickets.tmpl.php
@@ -12,7 +12,29 @@ if (!$ignoreVisibility || //limited visibility
    ($ignoreVisibility && ($queue->isAQueue() || $queue->isASubQueue())) //unlimited visibility + not a search
 )
     $tickets->filter($thisstaff->getTicketsVisibility());
-
+    $optionName = array();
+    foreach ($tickets->constraints as $key => $value) {
+        switch ($constraint = key($value->constraints)) {
+            case (strpos($constraint, 'collaborator_count') !== false):
+                $optionName[] = 'collaborator_count';
+                ThreadCollaboratorCount::annotate($tickets, 'collaborator_count');
+                break;
+            case (strpos($constraint, 'attachment_count') !== false):
+                $optionName[] = 'attachment_count';
+                ThreadAttachmentCount::annotate($tickets, 'attachment_count');
+                break;
+            case (strpos($constraint, 'thread_count') !== false):
+                $optionName[] = 'thread_count';
+                TicketThreadCount::annotate($tickets, 'thread_count');
+                break;
+            case (strpos($constraint, 'reopen_count') !== false):
+                $optionName[] = 'reopen_count';
+                TicketReopenCount::annotate($tickets, 'reopen_count');
+                break;
+        }
+        if ($optionName)
+            $tickets->options(array('type' => CompiledExpression::TYPE_HAVING, 'fields' => $optionName));
+    }
 // Make sure the cdata materialized view is available
 TicketForm::ensureDynamicDataView();
 


### PR DESCRIPTION
This commit fixes an issue where you could not use a field that included a counter in Advanced Searches. This fixes the following fields:
- Attachment Count
- Collaborator Count
- Reopen Count
- Thread Count

This fixes Issue #5435