### PR TITLE
Issue: New Agent Extended Access and Teams

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -446,6 +446,8 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         ) {
             $this->dept_access->remove($da);
         }
+
+        $this->save();
     }
 
     function usePrimaryRoleOnAssignment() {
@@ -1115,30 +1117,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             }
         }
 
-        // Update some things for ::updateAccess to inspect
-        $this->setDepartmentId($vars['dept_id']);
-
-        // Format access update as [array(dept_id, role_id, alerts?)]
-        $access = array();
-        if (isset($vars['dept_access'])) {
-            foreach (@$vars['dept_access'] as $dept_id) {
-                $access[] = array($dept_id, $vars['dept_access_role'][$dept_id],
-                    @$vars['dept_access_alerts'][$dept_id]);
-            }
-        }
-        $this->updateAccess($access, $errors);
-        $this->setExtraAttr('def_assn_role',
-            isset($vars['assign_use_pri_role']), false);
-
-        // Format team membership as [array(team_id, alerts?)]
-        $teams = array();
-        if (isset($vars['teams'])) {
-            foreach (@$vars['teams'] as $team_id) {
-                $teams[] = array($team_id, @$vars['team_alerts'][$team_id]);
-            }
-        }
-        $this->updateTeams($teams, $errors);
-
         // Update the local permissions
         $this->updatePerms($vars['perms'], $errors);
 
@@ -1168,6 +1146,30 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             return false;
 
         if ($this->save()) {
+            // Update some things for ::updateAccess to inspect
+            $this->setDepartmentId($vars['dept_id']);
+
+            // Format access update as [array(dept_id, role_id, alerts?)]
+            $access = array();
+            if (isset($vars['dept_access'])) {
+                foreach (@$vars['dept_access'] as $dept_id) {
+                    $access[] = array($dept_id, $vars['dept_access_role'][$dept_id],
+                        @$vars['dept_access_alerts'][$dept_id]);
+                }
+            }
+            $this->updateAccess($access, $errors);
+            $this->setExtraAttr('def_assn_role',
+                isset($vars['assign_use_pri_role']), false);
+
+            // Format team membership as [array(team_id, alerts?)]
+            $teams = array();
+            if (isset($vars['teams'])) {
+                foreach (@$vars['teams'] as $team_id) {
+                    $teams[] = array($team_id, @$vars['team_alerts'][$team_id]);
+                }
+            }
+            $this->updateTeams($teams, $errors);
+
             if ($vars['welcome_email'])
                 $this->sendResetEmail('registration-staff', false);
             return true;


### PR DESCRIPTION
This commit fixes an issue we had with trying to create new Agents with Extended Department Access or a Team. We were trying to add them before there was a staff_id which resulted in a DB error as well as the actions not being performed. To fix this, we just need to add the Agent's Department access and Team membership after we save the Agent so that they have an id. We also need to save the Staff object in the setDepartmentId function.