### PR TITLE
feature: Configurable Agents As Collaborators

### DIFF
--- a/include/ajax.thread.php
+++ b/include/ajax.thread.php
@@ -102,16 +102,18 @@ class ThreadAjaxAPI extends AjaxController {
 
         $errors = $info = array();
         if ($user) {
-            // FIXME: Refuse to add ticket owner??
-            $vars = array();
-            if (($c=$thread->addCollaborator($user,
-                            $vars, $errors))) {
-                $info = array('msg' => sprintf(__('%s added as a collaborator'),
-                            Format::htmlchars($c->getName())));
-                $c->setCc($vars['active']);
-                $c->save();
-                return self::_collaborators($thread, $info);
-            }
+            if ($object->getOwnerId() !== $user->getId()) {
+                $vars = array();
+                if (($c=$thread->addCollaborator($user,
+                                $vars, $errors))) {
+                    $info = array('msg' => sprintf(__('%s added as a collaborator'),
+                                Format::htmlchars($c->getName())));
+                    $c->setCc($vars['active']);
+                    $c->save();
+                    return self::_collaborators($thread, $info);
+                }
+            } else
+                $errors['err'] = __('Ticket Owner cannot be a Collaborator');
         }
 
         if($errors && $errors['err']) {

--- a/include/ajax.thread.php
+++ b/include/ajax.thread.php
@@ -103,11 +103,12 @@ class ThreadAjaxAPI extends AjaxController {
         $errors = $info = array();
         if ($user) {
             // FIXME: Refuse to add ticket owner??
+            $vars = array();
             if (($c=$thread->addCollaborator($user,
-                            array(), $errors))) {
+                            $vars, $errors))) {
                 $info = array('msg' => sprintf(__('%s added as a collaborator'),
                             Format::htmlchars($c->getName())));
-                $c->setCc();
+                $c->setCc($vars['active']);
                 $c->save();
                 return self::_collaborators($thread, $info);
             }

--- a/include/class.collaborator.php
+++ b/include/class.collaborator.php
@@ -144,8 +144,8 @@ implements EmailContact, ITicketUser {
             $this->flags &= ~$flag;
     }
 
-    public function setCc() {
-      $this->setFlag(Collaborator::FLAG_ACTIVE, true);
+    public function setCc($active=true) {
+      $this->setFlag(Collaborator::FLAG_ACTIVE, $active);
       $this->setFlag(Collaborator::FLAG_CC, true);
       $this->save();
     }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -210,6 +210,7 @@ class OsticketConfig extends Config {
         'auto_claim_tickets'=>  true,
         'auto_refer_closed' => true,
         'collaborator_ticket_visibility' =>  true,
+        'disable_agent_collabs' => false,
         'require_topic_to_close' =>  false,
         'system_language' =>    'en_US',
         'default_storage_bk' => 'D',
@@ -1026,6 +1027,10 @@ class OsticketConfig extends Config {
         return $this->get('collaborator_ticket_visibility');
     }
 
+    function disableAgentCollaborators() {
+        return $this->get('disable_agent_collabs');
+    }
+
     function requireTopicToClose() {
         return $this->get('require_topic_to_close');
     }
@@ -1321,6 +1326,7 @@ class OsticketConfig extends Config {
             'agent_name_format'=>$vars['agent_name_format'],
             'hide_staff_name'=>isset($vars['hide_staff_name']) ? 1 : 0,
             'agent_avatar'=>$vars['agent_avatar'],
+            'disable_agent_collabs'=>isset($vars['disable_agent_collabs'])?1:0,
         ));
     }
 

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -167,7 +167,9 @@ implements Searchable {
                     'thread_id'   => $this->getId()));
     }
 
-    function addCollaborator($user, $vars, &$errors, $event=true) {
+    function addCollaborator($user, &$vars, &$errors, $event=true) {
+        global $cfg;
+
         if (!$user)
             return null;
 
@@ -179,6 +181,13 @@ implements Searchable {
                 'userId' => $user->getId()), $vars);
         if (!($c=Collaborator::add($vars, $errors)))
             return null;
+
+        $vars['active'] = true;
+        // Disable Agent Collabs (if configured)
+        if ($this->object_type === 'T'
+                && $cfg->disableAgentCollaborators()
+                && Staff::lookup($user->getDefaultEmailAddress()))
+            $vars['active'] = false;
 
         $this->_collaborators = null;
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1209,12 +1209,14 @@ implements RestrictedAccess, Threadable, Searchable {
         return $fields ? $fields[0] : null;
     }
 
-    function addCollaborator($user, $vars, &$errors, $event=true) {
+    function addCollaborator($user, &$vars, &$errors, $event=true) {
 
         if (!$user || $user->getId() == $this->getOwnerId())
             return null;
 
         if ($c = $this->getThread()->addCollaborator($user, $vars, $errors, $event)) {
+            $c->setCc($vars['active']);
+            $c->save();
             $this->collaborators = null;
             $this->recipients = null;
         }
@@ -3094,7 +3096,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 if (($cuser=User::fromVars($recipient))) {
                   if (!$existing = Collaborator::getIdByUserId($cuser->getId(), $ticket->getThreadId())) {
                     if ($c=$ticket->addCollaborator($cuser, $info, $errors, false)) {
-                      $c->setCc();
+                      $c->setCc($info['active']);
 
                       // FIXME: This feels very unwise — should be a
                       // string indexed array for future

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4318,6 +4318,11 @@ implements RestrictedAccess, Threadable, Searchable {
         // Start tracking ticket lifecycle events (created should come first!)
         $ticket->logEvent('created', null, $thisstaff ?: $user);
 
+        // Set default ticket status (if none) for Thread::getObject()
+        // in addCollaborators()
+        if ($ticket->getStatusId() <= 0)
+            $ticket->setStatusId($cfg->getDefaultTicketStatusId());
+
         // Add collaborators (if any)
         if (isset($vars['ccs']) && count($vars['ccs']))
           $ticket->addCollaborators($vars['ccs'], array(), $errors);

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -74,6 +74,7 @@ core:
     show_assigned_tickets: 1
     show_answered_tickets: 0
     hide_staff_name: 0
+    disable_agent_collabs: 0
     overlimit_notice_active: 0
     email_attachments: 1
     ticket_number_format: '######'

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -27,6 +27,17 @@ staff_identity_masking:
         If enabled, this will hide the Agent’s name from the Client during any
         communication.
 
+disable_agent_collabs:
+    title: Disable Agent Collaborators
+    content: >
+        If Enabled, Agents that are added as Collaborators will be automatically Disabled.
+        This is helpful when Users are blindly adding Agents to the CC field causing the
+        Agents to receive all of the Participant Alerts.
+        <br><br>
+        <strong>Note:</strong>
+        <br>
+        This setting is global for all Tickets created via Web, API, Piping, and Fetching.
+
 # Authentication settings
 password_reset:
     title: Password Expiration Policy

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -69,6 +69,15 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                         </td>
                     </tr>
                     <tr>
+                        <td><?php echo __('Disable Agent Collaborators'); ?>:</td>
+                        <td>
+                            <input type="checkbox" name="disable_agent_collabs"
+                                <?php echo $config['disable_agent_collabs']?'checked="checked"':''; ?>>
+                            <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign"
+                                href="#disable_agent_collabs"></i>
+                        </td>
+                    </tr>
+                    <tr>
                         <th colspan="2">
                             <em><b><?php echo __('Authentication Settings'); ?></b></em>
                         </th>


### PR DESCRIPTION
This adds a new setting called "Disable Agent Collaborators" that allows Admins to globally configure wether or not to allow Agents to be added as Collaborators via any communication on tickets. In some use cases Agents do not want to be added as Collaborators on tickets to avoid an overload of emails/alerts, etc. This adds a new checkbox labeled `Disable Agent Collaborators` to **Admin Panel > Settings > Agents** that if Enabled/Checked will automatically Disable Agents that are added as Collaborators. This disables the participant alerts for the Agents whilst giving other Agents/Admins the ability to enable them at a later date instead of having to manually add them back. If an Agent tries adding another Agent as a Collaborator via the Manage Collaborators modal it will also Disable the Agent Collaborator.