### PR TITLE
Allow external UserAuthenticationBackend to provide a way to set an error while running the triggerAuth.

### DIFF
--- a/login.php
+++ b/login.php
@@ -108,8 +108,12 @@ elseif (isset($_GET['do'])) {
     switch($_GET['do']) {
     case 'ext':
         // Lookup external backend
-        if ($bk = UserAuthenticationBackend::getBackend($_GET['bk']))
-            $bk->triggerAuth();
+        if ($bk = UserAuthenticationBackend::getBackend($_GET['bk'])) {
+            $result = $bk->triggerAuth();
+            if ($result instanceof AccessDenied) {
+                $errors['err'] = $result->getMessage();
+            }
+        }
     }
 }
 elseif ($user = UserAuthenticationBackend::processSignOn($errors, false)) {


### PR DESCRIPTION
Right now there is no way to notify the login page about an error that happened during the triggerAuth process.

This simple patch allows the UserAuthenticationBackend to return an AccessDenied exception that will be identified and its message added in the error var, that way, the error is prompted to the user.