### PR TITLE
ui: improve action buttons

### DIFF
--- a/include/staff/templates/tickets-actions.tmpl.php
+++ b/include/staff/templates/tickets-actions.tmpl.php
@@ -35,42 +35,34 @@ if ($agent->hasPerm(Ticket::PERM_ASSIGN, false)) {?>
 
 //Mass Merge
 if ($agent->hasPerm(Ticket::PERM_MERGE, false)) {?>
-<span class="button action-button">
- <a class="tickets-action" id="tickets-merge" data-placement="bottom"
+ <a class="button action-button tickets-action" id="tickets-merge" data-placement="bottom"
     data-toggle="tooltip" title="<?php echo __('Merge'); ?>"
     href="#tickets/mass/merge"><i class="icon-code-fork"></i></a>
-</span>
 <?php
 }
 
 //Mass Link
 if ($agent->hasPerm(Ticket::PERM_LINK, false)) {?>
-<span class="button action-button">
- <a class="tickets-action" id="tickets-link" data-placement="bottom"
+ <a class="button action-button tickets-action" id="tickets-link" data-placement="bottom"
     data-toggle="tooltip" title="<?php echo __('Link'); ?>"
     href="#tickets/mass/link"><i class="icon-link"></i></a>
-</span>
 <?php
 }
 
 // Mass Transfer
 if ($agent->hasPerm(Ticket::PERM_TRANSFER, false)) {?>
-<span class="action-button">
- <a class="tickets-action" id="tickets-transfer" data-placement="bottom"
+ <a class="action-button tickets-action" id="tickets-transfer" data-placement="bottom"
     data-toggle="tooltip" title="<?php echo __('Transfer'); ?>"
     href="#tickets/mass/transfer"><i class="icon-share"></i></a>
-</span>
 <?php
 }
 
 
 // Mass Delete
 if ($agent->hasPerm(Ticket::PERM_DELETE, false)) {?>
-<span class="red button action-button">
- <a class="tickets-action" id="tickets-delete" data-placement="bottom"
+ <a class="red button action-button tickets-action" id="tickets-delete" data-placement="bottom"
     data-toggle="tooltip" title="<?php echo __('Delete'); ?>"
     href="#tickets/mass/delete"><i class="icon-trash"></i></a>
-</span>
 <?php
 }
 

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -81,7 +81,7 @@ if($ticket->isOverdue())
             }
 
             if ($role->hasPerm(Ticket::PERM_EDIT)) { ?>
-                <span class="action-button pull-right"><a data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Edit'); ?>" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=edit"><i class="icon-edit"></i></a></span>
+                <a class="action-button pull-right" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Edit'); ?>" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=edit"><i class="icon-edit"></i></a>
             <?php
             } ?>
             <span class="action-button pull-right" data-placement="bottom" data-dropdown="#action-dropdown-print" data-toggle="tooltip" title="<?php echo __('Print'); ?>">
@@ -107,11 +107,9 @@ if($ticket->isOverdue())
             <?php
             // Transfer
             if ($role->hasPerm(Ticket::PERM_TRANSFER)) {?>
-            <span class="action-button pull-right">
-            <a class="ticket-action" id="ticket-transfer" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Transfer'); ?>"
+            <a class="action-button pull-right ticket-action" id="ticket-transfer" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Transfer'); ?>"
                 data-redirect="tickets.php"
                 href="#tickets/<?php echo $ticket->getId(); ?>/transfer"><i class="icon-share"></i></a>
-            </span>
             <?php
             } ?>
 


### PR DESCRIPTION
If you press the button, but not the icon inside the button that's linked, nothing happens. Here is a list of action buttons this currently affects:
- Merge
- Link
- Transfer
- Delete
- Edit

This pull removes the `<span>` tag and moves the `<span>` class to the `<a>` tag to make the whole action button a link and complete the intended action. Fixes #3989