### PR TITLE
issue: Edit User Popup Perm

### DIFF
--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -88,6 +88,7 @@ if ($_POST)
                   <tr><td><?php echo __('User'); ?>:</td><td>
                     <div id="user-info">
                       <input type="hidden" name="uid" id="uid" value="<?php echo $user->getId(); ?>" />
+                      <?php if ($thisstaff->hasPerm(User::PERM_EDIT)) { ?>
                       <a href="#" onclick="javascript:
                       $.userLookup('ajax.php/users/<?php echo $user->getId(); ?>/edit',
                       function (user) {
@@ -95,7 +96,11 @@ if ($_POST)
                         $('#user-email').text(user.email);
                       });
                       return false;
-                      "><i class="icon-user"></i>
+                      ">
+                      <?php } else { ?>
+                      <a href="#">
+                      <?php } ?>
+                      <i class="icon-user"></i>
                       <span id="user-name"><?php echo Format::htmlchars($user->getName()); ?></span>
                       &lt;<span id="user-email"><?php echo $user->getEmail(); ?></span>&gt;
                     </a>


### PR DESCRIPTION
This is a rewrite of #5256 that addresses an issue where if an Agent does not have permission to Edit Users the Edit User link on Ticket Create will show a broken/blank popup. This adds a check for the Agent's User Edit Permission and if they do not have permission to Edit Users we will remove the `onclick` event so it does not trigger a popup.