### PR TITLE
issue: Collab Pass By Reference

### DIFF
--- a/include/ajax.thread.php
+++ b/include/ajax.thread.php
@@ -108,7 +108,7 @@ class ThreadAjaxAPI extends AjaxController {
                                 $vars, $errors))) {
                     $info = array('msg' => sprintf(__('%s added as a collaborator'),
                                 Format::htmlchars($c->getName())));
-                    $c->setCc($vars['active']);
+                    $c->setCc($c->active);
                     $c->save();
                     return self::_collaborators($thread, $info);
                 }

--- a/include/class.collaborator.php
+++ b/include/class.collaborator.php
@@ -37,6 +37,8 @@ implements EmailContact, ITicketUser {
     const FLAG_ACTIVE = 0x0001;
     const FLAG_CC = 0x0002;
 
+    var $active;
+
     function __toString() {
         return Format::htmlchars($this->toString());
     }

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -167,7 +167,7 @@ implements Searchable {
                     'thread_id'   => $this->getId()));
     }
 
-    function addCollaborator($user, &$vars, &$errors, $event=true) {
+    function addCollaborator($user, $vars, &$errors, $event=true) {
         global $cfg;
 
         if (!$user)
@@ -182,12 +182,12 @@ implements Searchable {
         if (!($c=Collaborator::add($vars, $errors)))
             return null;
 
-        $vars['active'] = true;
+        $c->active = true;
         // Disable Agent Collabs (if configured)
         if ($this->object_type === 'T'
                 && $cfg->disableAgentCollaborators()
                 && Staff::lookup($user->getDefaultEmailAddress()))
-            $vars['active'] = false;
+            $c->active = false;
 
         $this->_collaborators = null;
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1209,13 +1209,13 @@ implements RestrictedAccess, Threadable, Searchable {
         return $fields ? $fields[0] : null;
     }
 
-    function addCollaborator($user, &$vars, &$errors, $event=true) {
+    function addCollaborator($user, $vars, &$errors, $event=true) {
 
         if (!$user || $user->getId() == $this->getOwnerId())
             return null;
 
         if ($c = $this->getThread()->addCollaborator($user, $vars, $errors, $event)) {
-            $c->setCc($vars['active']);
+            $c->setCc($c->active);
             $c->save();
             $this->collaborators = null;
             $this->recipients = null;
@@ -3096,7 +3096,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 if (($cuser=User::fromVars($recipient))) {
                   if (!$existing = Collaborator::getIdByUserId($cuser->getId(), $ticket->getThreadId())) {
                     if ($c=$ticket->addCollaborator($cuser, $info, $errors, false)) {
-                      $c->setCc($info['active']);
+                      $c->setCc($c->active);
 
                       // FIXME: This feels very unwise — should be a
                       // string indexed array for future


### PR DESCRIPTION
This addresses an issue introduced with 5f5403d where passing `$vars` by reference to `Thread::addCollaborator()` broke a couple of things for Collaborators. This reverts the pass by reference and adds a new global variable to class Collaborator called `active`. This allows us to track the `active` variable whilst not messing with other collab functions.