### PR TITLE
revert: Agent Added Agent Collabs

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -168,7 +168,7 @@ implements Searchable {
     }
 
     function addCollaborator($user, $vars, &$errors, $event=true) {
-        global $cfg;
+        global $cfg, $thisstaff;
 
         if (!$user)
             return null;
@@ -183,8 +183,8 @@ implements Searchable {
             return null;
 
         $c->active = true;
-        // Disable Agent Collabs (if configured)
-        if ($this->object_type === 'T'
+        // Disable Agent Collabs (if configured) for User created tickets
+        if (!$thisstaff && $this->object_type === 'T'
                 && $cfg->disableAgentCollaborators()
                 && Staff::lookup($user->getDefaultEmailAddress()))
             $c->active = false;

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -30,13 +30,13 @@ staff_identity_masking:
 disable_agent_collabs:
     title: Disable Agent Collaborators
     content: >
-        If Enabled, Agents that are added as Collaborators will be automatically Disabled.
-        This is helpful when Users are blindly adding Agents to the CC field causing the
-        Agents to receive all of the Participant Alerts.
+        If Enabled, Agents that are added as Collaborators by Users will be automatically
+        Disabled. This is helpful when Users are blindly adding Agents to the CC field
+        causing the Agents to receive all of the Participant Alerts.
         <br><br>
         <strong>Note:</strong>
         <br>
-        This setting is global for all Tickets created via Web, API, Piping, and Fetching.
+        This setting is global for all User created Tickets via API, Piping, and Fetching.
 
 # Authentication settings
 password_reset:


### PR DESCRIPTION
This adds a check for `$thisstaff` in `Thread::addCollaborator()`. If we have a staff object we will enable Agent Collabs, if we do not have a staff object we will disable Agent Collabs. This will ensure all Agent added Agent Collabs are Enabled and any User added Agent Collabs are Disabled. This also updates the Help Tip for the setting to remove the `Web created tickets`part (as users cannot add collabs via web) and to clarify that this only affects User created tickets.