### PR TITLE
issue: AuditEntry Not Found

### DIFF
--- a/scp/categories.php
+++ b/scp/categories.php
@@ -124,7 +124,8 @@ if($_POST){
                         if (count($categories)==$count || $categories>0) {
                             $data = array();
                             foreach ($_POST['ids'] as $id) {
-                                if ($data = AuditEntry::getDataById($id, 'C'))
+                                if (class_exists('AuditEntry')
+                                        && $data = AuditEntry::getDataById($id, 'C'))
                                     $name = json_decode($data[2], true);
                                 else {
                                     $name = __('NA');

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -171,7 +171,8 @@ if($_POST){
                         if ($topics==$count || $topics>0) {
                             $data = array();
                             foreach ($_POST['ids'] as $id) {
-                                if ($data = AuditEntry::getDataById($id, 'H'))
+                                if (class_exists('AuditEntry')
+                                        && $data = AuditEntry::getDataById($id, 'H'))
                                     $name = json_decode($data[2], true);
                                 else {
                                     $name = __('NA');

--- a/scp/pages.php
+++ b/scp/pages.php
@@ -110,7 +110,8 @@ if($_POST) {
                         if ($i==$count || $i>0) {
                             $data = array();
                             foreach ($_POST['ids'] as $id) {
-                                if ($data = AuditEntry::getDataById($id, 'G'))
+                                if (class_exists('AuditEntry')
+                                    && $data = AuditEntry::getDataById($id, 'G'))
                                         $name = json_decode($data[2], true);
                                 else {
                                     $name = __('NA');


### PR DESCRIPTION
This addresses an issue where not having the Audit Log plugin installed and attempting to delete a Help Topic, Knowledgebase Category, or Page the system fails with the error `Class 'AuditEntry' not found`. This adds a check for the `AuditEntry` class before calling it (for Help Topics, Knowledgebase Categories, and Pages) to avoid the `Class not found` error.