### PR TITLE
Issue: Filter Actions for Deleted Objects

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -546,18 +546,6 @@ implements TemplateVariable, Searchable {
                 ->filter(array('dept_id' => $id))
                 ->delete();
 
-            foreach(FilterAction::objects()
-                ->filter(array('type' => FA_RouteDepartment::$type)) as $fa
-            ) {
-                $config = $fa->getConfiguration();
-                if ($config && $config['dept_id'] == $id) {
-                    $config['dept_id'] = 0;
-                    // FIXME: Move this code into FilterAction class
-                    $fa->set('configuration', JsonDataEncoder::encode($config));
-                    $fa->save();
-                }
-            }
-
             // Delete extended access entries
             StaffDeptAccess::objects()
                 ->filter(array('dept_id' => $id))
@@ -873,9 +861,9 @@ implements TemplateVariable, Searchable {
 
         $filter_actions = FilterAction::objects()->filter(array('type' => 'dept', 'configuration' => '{"dept_id":'. $this->getId().'}'));
         if ($filter_actions && $vars['status'] == 'active')
-          FilterAction::setFilterFlag($filter_actions, 'dept', false);
+          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', false);
         else
-          FilterAction::setFilterFlag($filter_actions, 'dept', true);
+          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', true);
 
         switch ($vars['status']) {
           case 'active':

--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -28,6 +28,11 @@ class FilterAction extends VerySimpleModel {
     function setFilter($filter) {
         $this->_filter = $filter;
     }
+
+    function getFilterId() {
+        return $this->filter_id;
+    }
+
     function getFilter() {
         return $this->_filter;
     }
@@ -84,14 +89,19 @@ class FilterAction extends VerySimpleModel {
         return $this->_impl;
     }
 
-    function setFilterFlag($actions, $flag, $bool) {
-        foreach ($actions as $action) {
-          $filter = Filter::lookup($action->filter_id);
-          if ($filter && ($flag == 'dept') && ($filter->hasFlag(Filter::FLAG_INACTIVE_DEPT) != $bool))
-            $filter->setFlag(Filter::FLAG_INACTIVE_DEPT, $bool);
-          if ($filter && ($flag == 'topic') && ($filter->hasFlag(Filter::FLAG_INACTIVE_HT) != $bool))
-            $filter->setFlag(Filter::FLAG_INACTIVE_HT, $bool);
-        }
+    function setFilterFlags($actions=false, $flag, $bool) {
+        $flag = constant($flag);
+        if ($actions) {
+            foreach ($actions as $action)
+                $action->setFilterFlag($flag, $bool);
+        } else
+            $this->setFilterFlag($flag, $bool);
+    }
+
+    function setFilterFlag($flag, $bool) {
+        $filter = Filter::lookup($this->filter_id);
+        if ($filter && ($filter->hasFlag($flag) != $bool))
+          $filter->setFlag($flag, $bool);
     }
 
     function apply(&$ticket, array $info) {

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -1455,10 +1455,12 @@ implements CustomListItem, TemplateVariable, Searchable {
     function delete() {
 
         // Statuses with tickets are not deletable
-        if (!$this->isDeletable())
+        if (!$this->isDeletable() || !parent::delete())
             return false;
 
-        return parent::delete();
+        Signal::send('object.deleted', $this);
+
+        return true;
     }
 
     function __toString() {

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -469,9 +469,9 @@ implements TemplateVariable, Searchable {
 
         $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $this->getId().'}'));
         if ($filter_actions && $vars['status'] == 'active')
-          FilterAction::setFilterFlag($filter_actions, 'topic', false);
+          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', false);
         else
-          FilterAction::setFilterFlag($filter_actions, 'topic', true);
+          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
 
         switch ($vars['status']) {
           case 'active':

--- a/include/staff/filters.inc.php
+++ b/include/staff/filters.inc.php
@@ -124,6 +124,10 @@ else
                     if ($row['flags'] & Filter::FLAG_INACTIVE_HT)
                       echo '<a data-placement="bottom" data-toggle="tooltip" title="Inactive Help Topic Selected"
                         <i class="pull-right icon-warning-sign"></a>';
+
+                    if ($row['flags'] & Filter::FLAG_DELETED_OBJECT)
+                      echo '<a data-placement="bottom" data-toggle="tooltip" title="Deleted Object Selected"
+                        <i class="pull-right icon-warning-sign"></a>';
                   ?>
                 </td>
                 <td><?php echo $row['isactive']?__('Active'):'<b>'.__('Disabled').'</b>'; ?></td>
@@ -190,4 +194,3 @@ endif;
      </p>
     <div class="clear"></div>
 </div>
-

--- a/scp/departments.php
+++ b/scp/departments.php
@@ -102,7 +102,7 @@ if($_REQUEST['id'] && !($dept=Dept::lookup($_REQUEST['id'])))
                               $d->setFlag(Dept::FLAG_ARCHIVED, false);
                               $d->setFlag(Dept::FLAG_ACTIVE, true);
                               $filter_actions = FilterAction::objects()->filter(array('type' => 'dept', 'configuration' => '{"dept_id":'. $d->getId().'}'));
-                              FilterAction::setFilterFlag($filter_actions, 'dept', false);
+                              FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', false);
                               if($d->save()) {
                                   $type = array('type' => 'edited', 'status' => 'Active');
                                   Signal::send('object.edited', $d, $type);
@@ -132,7 +132,7 @@ if($_REQUEST['id'] && !($dept=Dept::lookup($_REQUEST['id'])))
                               $d->setFlag(Dept::FLAG_ARCHIVED, false);
                               $d->setFlag(Dept::FLAG_ACTIVE, false);
                               $filter_actions = FilterAction::objects()->filter(array('type' => 'dept', 'configuration' => '{"dept_id":'. $d->getId().'}'));
-                              FilterAction::setFilterFlag($filter_actions, 'dept', true);
+                              FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', true);
                               if($d->save()) {
                                 $type = array('type' => 'edited', 'status' => 'Disabled');
                                 Signal::send('object.edited', $d, $type);
@@ -161,7 +161,7 @@ if($_REQUEST['id'] && !($dept=Dept::lookup($_REQUEST['id'])))
                               $d->setFlag(Dept::FLAG_ARCHIVED, true);
                               $d->setFlag(Dept::FLAG_ACTIVE, false);
                               $filter_actions = FilterAction::objects()->filter(array('type' => 'dept', 'configuration' => '{"dept_id":'. $d->getId().'}'));
-                              FilterAction::setFilterFlag($filter_actions, 'dept', true);
+                              FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', true);
                               if($d->save()) {
                                 $type = array('type' => 'edited', 'status' => 'Archived');
                                 Signal::send('object.edited', $d, $type);

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -72,7 +72,7 @@ if($_POST){
                           $t->setFlag(Topic::FLAG_ARCHIVED, false);
                           $t->setFlag(Topic::FLAG_ACTIVE, true);
                           $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
-                          FilterAction::setFilterFlag($filter_actions, 'topic', false);
+                          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', false);
                           if($t->save()) {
                               $type = array('type' => 'edited', 'status' => 'Active');
                               Signal::send('object.edited', $t, $type);
@@ -103,7 +103,7 @@ if($_POST){
                           $t->setFlag(Topic::FLAG_ARCHIVED, false);
                           $t->setFlag(Topic::FLAG_ACTIVE, false);
                           $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
-                          FilterAction::setFilterFlag($filter_actions, 'topic', true);
+                          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
                           if($t->save()) {
                               $type = array('type' => 'edited', 'status' => 'Disabled');
                               Signal::send('object.edited', $t, $type);
@@ -132,7 +132,7 @@ if($_POST){
                           $t->setFlag(Topic::FLAG_ARCHIVED, true);
                           $t->setFlag(Topic::FLAG_ACTIVE, false);
                           $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
-                          FilterAction::setFilterFlag($filter_actions, 'topic', true);
+                          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
                           if($t->save()) {
                             $type = array('type' => 'edited', 'status' => 'Archived');
                             Signal::send('object.edited', $t, $type);


### PR DESCRIPTION
This commit fixes an issue where an object could be deleted that was included in a filter action without properly accounting for the deletion. Now, if something is deleted and there is a Filter Action associated to that object, the Filter will be disabled and the Filter Action configuration will be updated to no longer include the invalid id. This has been done for the following objects:

- Help Topic
- Department
- Agent
- Team
- SLA
- Ticket Status
- Email
- Canned Response