### PR TITLE
Issue: Class AuditEntry Not Found

### DIFF
--- a/include/class.category.php
+++ b/include/class.category.php
@@ -215,6 +215,9 @@ class Category extends VerySimpleModel {
         catch (OrmException $e) {
             return false;
         }
+        $type = array('type' => 'deleted');
+        Signal::send('object.deleted', $this, $type);
+
         return true;
     }
 

--- a/include/class.page.php
+++ b/include/class.page.php
@@ -154,9 +154,9 @@ class Page extends VerySimpleModel {
         if (!parent::delete())
             return false;
 
-        return Topic::objects()
-            ->filter(array('page_id'=>$this->getId()))
-            ->update(array('page_id'=>0));
+        $type = array('type' => 'deleted');
+        Signal::send('object.deleted', $this, $type);
+        return true;
     }
 
     function save($refetch=false) {

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -276,6 +276,9 @@ implements TemplateVariable, Searchable {
                 'topic_id' => $this->getId()
             ))->delete();
             db_query('UPDATE '.TICKET_TABLE.' SET topic_id=0 WHERE topic_id='.db_input($this->getId()));
+
+            $type = array('type' => 'deleted');
+            Signal::send('object.deleted', $this, $type);
         }
 
         return true;

--- a/scp/categories.php
+++ b/scp/categories.php
@@ -109,7 +109,7 @@ if($_POST){
                                       foreach ($faqs as $key => $faq)
                                           $faq->delete();
                                   }
-                             $c->delete();
+                              $c->delete();
                         }
 
                         if (count($categories)==$count)
@@ -121,20 +121,6 @@ if($_POST){
                         elseif (!$errors['err'])
                             $errors['err'] = sprintf(__('Unable to delete %s.'),
                                 _N('selected category', 'selected categories', $count));
-                        if (count($categories)==$count || $categories>0) {
-                            $data = array();
-                            foreach ($_POST['ids'] as $id) {
-                                if (class_exists('AuditEntry')
-                                        && $data = AuditEntry::getDataById($id, 'C'))
-                                    $name = json_decode($data[2], true);
-                                else {
-                                    $name = __('NA');
-                                    $data = array('C', $id);
-                                }
-                                $type = array('type' => 'deleted');
-                                Signal::send('object.deleted', $data, $type);
-                            }
-                        }
                         break;
                     default:
                         $errors['err']=sprintf('%s - %s', __('Unknown action'), __('Get technical help!'));

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -168,20 +168,6 @@ if($_POST){
                         elseif(!$errors['err'])
                             $errors['err']  = sprintf(__('Unable to delete %s.'),
                                 _N('selected help topic', 'selected help topics', $count));
-                        if ($topics==$count || $topics>0) {
-                            $data = array();
-                            foreach ($_POST['ids'] as $id) {
-                                if (class_exists('AuditEntry')
-                                        && $data = AuditEntry::getDataById($id, 'H'))
-                                    $name = json_decode($data[2], true);
-                                else {
-                                    $name = __('NA');
-                                    $data = array('H', $id);
-                                }
-                                $type = array('type' => 'deleted');
-                                Signal::send('object.deleted', $data, $type);
-                            }
-                        }
                         break;
                     case 'sort':
                         try {

--- a/scp/pages.php
+++ b/scp/pages.php
@@ -94,9 +94,11 @@ if($_POST) {
                                 _N('selected site page', 'selected site pages', $count));
                         break;
                     case 'delete':
-                        $i = Page::objects()
-                            ->filter(array('id__in'=>$_POST['ids']))
-                            ->delete();
+                        $i = 0;
+                        foreach (Page::objects()->filter(array('id__in'=>$_POST['ids'])) as $p) {
+                            if ($p->delete())
+                                $i++;
+                        }
 
                         if($i && $i==$count)
                             $msg = sprintf(__('Successfully deleted %s.'),
@@ -107,20 +109,6 @@ if($_POST) {
                         elseif(!$errors['err'])
                             $errors['err'] = sprintf(__('Unable to delete %s.'),
                                 _N('selected site page', 'selected site pages', $count));
-                        if ($i==$count || $i>0) {
-                            $data = array();
-                            foreach ($_POST['ids'] as $id) {
-                                if (class_exists('AuditEntry')
-                                    && $data = AuditEntry::getDataById($id, 'G'))
-                                        $name = json_decode($data[2], true);
-                                else {
-                                    $name = __('NA');
-                                    $data = array('G', $id);
-                                }
-                                $type = array('type' => 'deleted');
-                                Signal::send('object.deleted', $data, $type);
-                            }
-                        }
                         break;
                     default:
                         $errors['err']=sprintf('%s - %s', __('Unknown action'), __('Get technical help!'));


### PR DESCRIPTION
This commit fixes an issue where we were trying to use a Plugin function that some helpdesks may not include. Rather than calling the class from the Plugin, the Plugin needed to have a new Signal to handle auditing certain deletions.