### PR TITLE
oops: Update Schedule No Description

### DIFF
--- a/include/class.schedule.php
+++ b/include/class.schedule.php
@@ -314,7 +314,7 @@ class Schedule extends VerySimpleModel {
         if (count($this->dirty))
             $this->set('updated', new SqlFunction('NOW'));
         if (isset($this->dirty['description']))
-            $this->description = Format::sanitize($this->notes);
+            $this->description = Format::sanitize($this->description);
 
         return parent::save($refetch);
     }


### PR DESCRIPTION
This addresses issue #5468 where updating a Schedule clears out the Description. This is due to the wrong property name being used when updating the Description. This updates `$this->notes` to `$this->description` so that the Description is set properly.