### PR TITLE
issue: Move Owner Check to Ticket Collabs

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -178,7 +178,7 @@ implements Searchable {
 
         $vars = array_merge(array(
                 'threadId' => $this->getId(),
-                'userId' => $user->getId()), $vars);
+                'userId' => $user->getId()), $vars ?: array());
         if (!($c=Collaborator::add($vars, $errors)))
             return null;
 
@@ -3364,6 +3364,7 @@ interface Threadable {
     function getThreadId();
     function getThread();
     function postThreadEntry($type, $vars, $options=array());
+    function addCollaborator($user, $vars, &$errors, $event=true);
 }
 
 /**

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1211,17 +1211,19 @@ implements RestrictedAccess, Threadable, Searchable {
 
     function addCollaborator($user, $vars, &$errors, $event=true) {
 
-        if (!$user || $user->getId() == $this->getOwnerId())
-            return null;
+        if ($user && $user->getId() == $this->getOwnerId())
+            $errors['err'] = __('Ticket Owner cannot be a Collaborator');
 
-        if ($c = $this->getThread()->addCollaborator($user, $vars, $errors, $event)) {
+        if ($user && !$errors
+                && ($c = $this->getThread()->addCollaborator($user, $vars,
+                        $errors, $event))) {
             $c->setCc($c->active);
-            $c->save();
             $this->collaborators = null;
             $this->recipients = null;
+            return $c;
         }
 
-        return $c;
+        return null;
     }
 
     function addCollaborators($users, $vars, &$errors, $event=true) {


### PR DESCRIPTION
This addresses an issue where adding a Task Collab fails with error `Call to undefined method Task::getOwnerId()`. This updates `ThreadAjaxAPI::addCollaborator()` to call `$object->addCollaborator()` instead of `$thread->addCollaborator()`. This gives us the opportunity to perform separate actions/checks for Ticket and Task Collabs. This also updates `Ticket::addCollaborator()` to check if the current Collab is the Owner, if so we will refuse to add the Owner as a Collab.