### PR TITLE
issue: Show Custom Validation Message

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1480,8 +1480,7 @@ class TextboxField extends FormField {
         if (!$valid && !($this->getForm() instanceof AdvancedSearchForm))
             $valid = 'formula';
         $func = $validators[$valid];
-        $error = $func[1];
-        $err = null;
+        $error = $err = null;
         // If validator is number and the value is &#48 set to 0 (int) for is_numeric
         if ($valid == 'number' && $value == '&#48')
             $value = 0;
@@ -1489,7 +1488,7 @@ class TextboxField extends FormField {
             $error = $this->getLocal('validator-error', $config['validator-error']);
         if (is_array($func) && is_callable($func[0]))
             if (!call_user_func_array($func[0], array($value, &$err)))
-                $this->_errors[] = $err ?: $error;
+                $this->_errors[] =  $error ?: $err ?: $func[1];
     }
 
     function parse($value) {


### PR DESCRIPTION
This addresses an issue where custom validation messages are not appearing, instead the system shows the default validation messages. This is due to 9e21dfd where we failed to consider custom validation messages. Basically, the referenced commit made it to where we could use validation messages from the source validation method which is great but it overwrites the custom validation message. The end goal is to have Custom Messages displayed first, if no custom messages then we display the Source Messages, and if no source messages we display the Default Messages. This removes the line that sets the Default Validation Message to the variable of `$error` and updates the ternary check to first check `$error` (Custom Message) then check `$err` (Source Message) then lastly `$func[1]` (Default Message).