### PR TITLE
1.14 Misc. Fixes

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2538,10 +2538,13 @@ implements RestrictedAccess, Threadable, Searchable {
             $errors = array();
             foreach ($children as $child) {
                 if ($options['participants'] == 'all' && $collabs = $child->getCollaborators()) {
-                    foreach ($collabs as $collab)
-                        $parent->addCollaborator($collab->getUser(), array(), $errors);
+                    foreach ($collabs as $collab) {
+                        if ($collab->getId() != $parent->getOwnerId())
+                            $parent->addCollaborator($collab->getUser(), array(), $errors);
+                    }
                 }
-                $parent->addCollaborator($child->getUser(), array(), $errors);
+                if ($child->getId() != $parent->getOwnerId())
+                    $parent->addCollaborator($child->getUser(), array(), $errors);
                 $parentThread = $parent->getThread();
 
                 $deletedChild = Thread::objects()


### PR DESCRIPTION
- addCollaborator return null:
	- if the TicketOwner is being added as a Collaborator, we should just return null rather than throwing a specific errror message. The result would be the following message: 'Unable to add collaborator. Internal error occurred'. This ensures that children Tickets will be successfully closed upon merging without throwing a hidden error message as a result of attempting to move children participants over to the parent ticket.