### PR TITLE
issue: Mass Delete Help Topics Warning

### DIFF
--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -147,7 +147,7 @@ if($_POST){
                         foreach ($topics as $t)
                             $t->delete();
 
-                        if($topics && $topics==$count)
+                        if($topics && $topics->count()==$count)
                             $msg = sprintf(__('Successfully deleted %s.'),
                                 _N('selected help topic', 'selected help topics', $count));
                         elseif($topics>0)


### PR DESCRIPTION
This addresses an issue where deleting 2 or more Help Topics shows a warning of `X of X selected help topics deleted` even though all selected Help Topics were deleted. This is due to the check that ensures that the number of Help Topics deleted is the same as the how many Help Topics you selected. This updates the check to compare against the actual Topic count rather than the QuerySet itself.