### PR TITLE
issue: MySQL 8.0 {min,max} Value Error

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -1365,7 +1365,7 @@ abstract class PasswordPolicy {
                         Q::not(array('session_id' => $user->session->session_id)));
                 break;
             case ($model instanceof User):
-                $regexp = '_auth\|.*"user";[a-z]+:[0-9]+:{[a-z]+:[0-9]+:"id";[a-z]+:'.$model->getId();
+                $regexp = '_auth\|.*"user";[a-z]+:[0-9]+:\{[a-z]+:[0-9]+:"id";[a-z]+:'.$model->getId();
                 $criteria['user_id'] = 0;
                 $criteria['session_data__regex'] = $regexp;
 


### PR DESCRIPTION
This addresses an issue reported on the Forum where registering as a User with MySQL 8.0 throws an error of `Incorrect description of a {min,max} interval.`. This is due to MySQL seeing `{` in the regex `_auth\|.*"user";[a-z]+:[0-9]+:{[a-z]+:[0-9]+:"id";[a-z]+:` as the start of repetition notation. In order to avoid this, we can simply escape the `{` so it’s seen as a literal squiggly bracket and not the start of repetition notation.

Reference:
- https://dev.mysql.com/doc/refman/8.0/en/regexp.html#regexp-syntax