### PR TITLE
issue: Flush Model Cache

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -298,7 +298,7 @@ class ModelMeta implements ArrayAccess {
 
     static function flushModelCache() {
         if (self::$model_cache)
-            @apcu_clear_cache('user');
+            @apcu_clear_cache();
     }
 }
 


### PR DESCRIPTION
This addresses an issue where `ModelMeta::flushModelCache()` doesn't work correctly. In theory, it's supposed to clear all APCu cache. This is especially helpful for Upgrades by preventing the selection of data/structures that don't exist anymore. This is due to the fact that when we updated `apc_clear_cache()` to `apcu_clear_cache()` we forgot to remove the argument. `apcu_clear_cache()` takes no arguments and you would think that PHP would be smart enough to void the argument but apparently it's not. This removes the argument so that it works properly and clears all APCu cache.