### PR TITLE
issue: Delete Users With Tickets

### DIFF
--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -301,10 +301,10 @@ $(function() {
             return;
           }
           if (!confirmed)
-              $.confirm(__('You sure?'), undefined, options).then(function(promise) {
-                if (promise === false)
+              $.confirm(__('You sure?'), undefined, options).then(function(data) {
+                if (data === false)
                   return false;
-                submit();
+                submit(data);
               });
           else
               submit();


### PR DESCRIPTION
This addresses an issue where deleting Users with Tickets and checking the box to delete all tickets throws a warning of `Unable to manage any of the selected end users`. This is due to commit b1f881b where we didn’t pass the data to the submit function. All data was present in the POST array except for the `deletetickets` option which we need to determine wether or not to delete all tickets. This changes `promise` to `data` and passes it to `submit()` (if exists).