### PR TITLE
Issue: Ticket Number Search

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -109,7 +109,7 @@ class TicketsAjaxAPI extends AjaxController {
             $visibility = $thisstaff->getTicketsVisibility();
 
         $hits = Ticket::objects()
-            ->values('user__default_email__address', 'number', 'cdata__subject', 'user__name', 'ticket_id', 'thread__id', 'flags')
+            ->values('user__default_email__address', 'cdata__subject', 'user__name', 'ticket_id', 'thread__id', 'flags', 'number')
             ->annotate(array(
                 'tickets' => new SqlCode('1'),
                 'tasks' => SqlAggregate::COUNT('tasks__id', true),


### PR DESCRIPTION
This commit fixes an issue we had where we were doing a union on the adhoc search queries. One should return a lookup by number and the other should return tickets that belong to the user of the number searched.

When doing the union, we just needed to make sure the columns were in the same order for both queries.