### PR TITLE
install: Schedule, SLA, and Help Tip Updates

### DIFF
--- a/include/i18n/en_US/help/tips/manage.sla.yaml
+++ b/include/i18n/en_US/help/tips/manage.sla.yaml
@@ -25,7 +25,10 @@ grace_period:
         Determine the number of hours after a ticket is created that it will
         be automatically marked as overdue.
         <br><br>
-        <em>Hours are counted from ticket create time.</em>
+        Hours are counted during the specified Schedule. The hierarchy is Department
+        Schedule, SLA Schedule, then System Default Schedule. If no Schedule is
+        configured, the Hours are counted 24/7 (even after business hours) until the
+        Ticket is Overdue.
 
 transient:
     title: Transient

--- a/include/i18n/en_US/sla.yaml
+++ b/include/i18n/en_US/sla.yaml
@@ -18,6 +18,6 @@
 ---
 - id: 1
   flags: 3
-  grace_period: 48
+  grace_period: 18
   name: Default SLA
   notes: |

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -178,6 +178,7 @@ class Installer extends SetupWizard {
         list($sla_id) = Sla::objects()->order_by('id')->values_flat('id')->first();
         list($dept_id) = Dept::objects()->order_by('id')->values_flat('id')->first();
         list($role_id) = Role::objects()->order_by('id')->values_flat('id')->first();
+        list($schedule_id) = Schedule::objects()->order_by('id')->values_flat('id')->first();
 
         $sql='SELECT `tpl_id` FROM `'.TABLE_PREFIX.'email_template_group` ORDER BY `tpl_id` LIMIT 1';
         $template_id_1 = db_result(db_query($sql, false));
@@ -248,7 +249,9 @@ class Installer extends SetupWizard {
         $defaults = array(
             'default_email_id'=>$support_email_id,
             'alert_email_id'=>$alert_email_id,
-            'default_dept_id'=>$dept_id, 'default_sla_id'=>$sla_id,
+            'default_dept_id'=>$dept_id,
+            'default_sla_id'=>$sla_id,
+            'schedule_id'=>$schedule_id,
             'default_template_id'=>$template_id_1,
             'default_timezone' => $vars['timezone'] ?: date_default_timezone_get(),
             'admin_email'=>$vars['admin_email'],


### PR DESCRIPTION
This sets the System Default Schedule to the `Monday - Friday 8am - 5pm with U.S. Holidays` Schedule for new installs. This will ensure all SLAs are counted during normal US business hours (excluding US Holidays).

This also updates the System Default SLA's Grace Period from 48 Hours to 18 Hours. This ensures the Default SLA is in tandem with the new System Default Schedule. With this update, the two 9 Hour days (8am-5pm) will then allow tickets to become overdue in 2 business days.

Lastly, this updates the SLA Grace Period Help Tip to include more information about Schedules and how they affect the Grace Period.