### PR TITLE
install: Embedded Domain Whitelist

### DIFF
--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -86,3 +86,4 @@ core:
     log_graceperiod: 12
     client_registration: 'public'
     default_ticket_queue: 1
+    embedded_domain_whitelist: 'youtube.com, dailymotion.com, vimeo.com, player.vimeo.com, web.microsoftstream.com'


### PR DESCRIPTION
This adds `youtube.com, dailymotion.com, vimeo.com, player.vimeo.com, web.microsoftstream.com` as the default values for the Embedded Domain Whitelist feature for new installs.