### PR TITLE
xss: FAQ Category On Errors

### DIFF
--- a/include/staff/category.inc.php
+++ b/include/staff/category.inc.php
@@ -150,7 +150,7 @@ if (count($langs) > 1) { ?>
     </div>
     <textarea class="richtext" name="<?php echo $dname; ?>" cols="21" rows="12"
         style="width:100%;"><?php
-        echo $desc; ?></textarea>
+        echo Format::sanitize($desc); ?></textarea>
     </div>
 <?php } ?>
 </div>
@@ -160,7 +160,7 @@ if (count($langs) > 1) { ?>
     <b><?php echo __('Internal Notes');?></b>:
     <span class="faded"><?php echo __("Be liberal, they're internal");?></span>
     <textarea class="richtext no-bar" name="notes" cols="21"
-        rows="8" style="width: 80%;"><?php echo $info['notes']; ?></textarea>
+        rows="8" style="width: 80%;"><?php echo Format::sanitize($info['notes']); ?></textarea>
 </div>
 
 


### PR DESCRIPTION
This addresses 1/2 of the vulnerability reported at #5514 where pasting an XSS Payload in the Category Description/Notes and saving changes without filling out required info executes the XSS Payload. This is due to the system not sanitizing the return values on errors. This adds `Format::sanitize()` to the Description and Notes fields so that any value displayed is properly sanitized. The Description/Notes are properly sanitized before saving to the database, the issue only lies when returning values on errors.