### PR TITLE
issue: Filter Action Add Button

### DIFF
--- a/include/staff/filter.inc.php
+++ b/include/staff/filter.inc.php
@@ -307,6 +307,8 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
                 <button id="new-action-btn" type="button" class="inline green button" onclick="javascript:
                     var dropdown = $('#new-action-select'), selected = dropdown.find(':selected');
                     dropdown.val('');
+                    if (selected.val() === '')
+                        return;
                     $('#dynamic-actions')
                       .append($('<tr></tr>')
                         .append($('<td></td>')


### PR DESCRIPTION
This addresses issue #5513 where clicking the Add button on the Filter Actions tab without selecting an option will insert an `undefined` Action. This is due to the placeholder option having an empty `value` attribute. This updates the JS to check the selected option's `value` attribute and if empty we will return without appending. This will ensure the placeholder option does not append an `undefined` Action.