### PR TITLE
Fix connection string used for non-SSL connections

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -86,7 +86,10 @@ class MailFetcher {
             if ($this->authuser)
                 $this->srvstr .= sprintf('/authuser=%s', $this->authuser);
 
-            $this->srvstr.='/novalidate-cert}';
+            if(!strcasecmp($this->getEncryption(), 'SSL'))
+				$this->srvstr.='/novalidate-cert}';
+			else
+				$this->srvstr.='/notls}';
 
         }
 


### PR DESCRIPTION
Fix I am using for https://github.com/osTicket/osTicket/issues/5020