### PR TITLE
templates: %{ticket.thread.complete} Not Respecting Identity Masking

### DIFF
--- a/include/client/templates/thread-export.tmpl.php
+++ b/include/client/templates/thread-export.tmpl.php
@@ -13,6 +13,8 @@ AttachmentFile::objects()->filter(array(
 
 $entries = $thread->getEntries();
 $entries->filter(array('type__in' => array_keys($entryTypes)))->order_by("{$order}id");
+// Respect the masking broh
+$agentmasking = $cfg->hideStaffName();
 ?>
 <style type="text/css">
     div {font-family: sans-serif;}
@@ -29,7 +31,11 @@ $entries->filter(array('type__in' => array_keys($entryTypes)))->order_by("{$orde
             <?php
             foreach ($entries as $entry) {
                 $user = $entry->getUser() ?: $entry->getStaff();
-                $name = $user ? $user->getName() : $entry->poster;
+                // Check if Identity Masking is enabled
+                if ($entry->staff_id && $agentmasking)
+                    $name = __('Staff');
+                else
+                    $name = $user ? $user->getName() : $entry->poster;
                 $color = $entryTypes[$entry->type]['color'];
                 ?>
                 <tr>


### PR DESCRIPTION
This addresses an issue where Karen is not respecting the drip…just kidding. This addresses an issue where `%{ticket.thread.complete}` does not respect Agent Identity Masking. This adds a check for `hideStaffName()` and if `TRUE` we will use `Staff` as the Agent's name in the thread export template for clients. If `hideStaffName()` returns `FALSE` then we will use the Agent's actual name. This only applies to the `thread-export.tmpl.php` for clients.