### PR TITLE
install: Add Mark As Answered To All Access

### DIFF
--- a/include/i18n/en_US/role.yaml
+++ b/include/i18n/en_US/role.yaml
@@ -21,6 +21,7 @@
     ticket.edit,
     ticket.merge,
     ticket.link,
+    ticket.markanswered,
     ticket.assign,
     ticket.release,
     ticket.transfer,


### PR DESCRIPTION
This adds the Mark As Answered permission to the All Access Role for new installs. This will ensure the "All Access" Role has all access for Tickets.