### PR TITLE
issue: Signature Box No Longer Expands

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -285,22 +285,21 @@
                 .on('change', this.updateSignature.bind(this));
             // Expand on hover
             var outer = this.$signatureBox,
-                inner = $('.inner', this.$signatureBox).get(0),
+                inner = $('.inner', this.$signatureBox.get(0)).get(0),
                 originalHeight = outer.height(),
                 hoverTimeout = undefined,
                 originalShadow = this.$signatureBox.css('box-shadow');
-            this.$signatureBox.on('hover', function() {
+            this.$signatureBox.on('mouseenter', function() {
                 hoverTimeout = setTimeout(function() {
-                    originalHeight = Math.max(originalHeight, outer.height());
                     $(this).animate({
-                        'height': inner.offsetHeight
+                        'height': inner.offsetHeight + 25
                     }, 'fast');
                     $(this).css('box-shadow', 'none', 'important');
                 }.bind(this), 250);
-            }, function() {
+            }).on('mouseleave', function() {
                 clearTimeout(hoverTimeout);
                 $(this).stop().animate({
-                    'height': Math.min(inner.offsetHeight, originalHeight)
+                    'height': Math.min(inner.offsetHeight, originalHeight - 10)
                 }, 'fast');
                 $(this).css('box-shadow', originalShadow);
             });


### PR DESCRIPTION
This addresses issue #5531 where the Signature Box no longer expands when hovering over it. This is due to some outdated jQuery that needs to be updated. This updates `.on('hover'` and breaks it into `.on('mouseenter'` and `.on('mouseleave'`. This also removes `originalHeight = Math.max` as it just kept adding more and more pixels causing the collapsed area to grow and grow (ew). In addition, this adds 25 pixels to the offsetHeight to expand the box past the content and subtracts 10 pixels from originalHeight so it collapses back to the same height.