### PR TITLE
oops: JS Method Typo

### DIFF
--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -156,7 +156,7 @@
     update: function(lock) {
       if (typeof lock != 'object' || lock.retry === true) {
         // Non-json response, or retry requested server-side
-        return this.retry(this.renew, this.activeAjax, false, lock);
+        return this.retry(this.renew, this.ajaxActive, false, lock);
       }
       if (!lock.id) {
         // Response did not include a lock id number


### PR DESCRIPTION
This addresses a small typo where `this.activeAjax` should actually be `this.ajaxActive`.