### PR TITLE
sla: Force Intval For Scientific Floats

### DIFF
--- a/include/class.businesshours.php
+++ b/include/class.businesshours.php
@@ -166,7 +166,7 @@ class BusinessHours {
                 if ($_seconds > $seconds) {
                     // TODO: Guard aganist backtracking to non working
                     // hours.
-                    $time = round(($_seconds-$seconds));
+                    $time = intval(round(($_seconds-$seconds)));
                     $interval = new DateInterval('PT'.$time.'S');
                     $date->sub($interval);
                     $this->timeline(sprintf('%s -> Backtrack %f Hours  %s (%s)',


### PR DESCRIPTION
This addresses issue #5532 where some floats are being formatted in Scientific Format (ie. `2.777E+4`) which causes a fatal error for `DateInterval::__construct()`. This is most likely due to the `precision` INI setting in some instances. This adds `intval()` around `round()` to ensure an INT value is returned to avoid the fatal error on format issues.