### PR TITLE
template: Add Ticket ID To Var Scope

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2213,6 +2213,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 'class' => 'FormattedDate', 'desc' => __('Due Date'),
             ),
             'email' => __('Default email address of ticket owner'),
+            'id' => __('Ticket ID (internal ID)'),
             'name' => array(
                 'class' => 'PersonsName', 'desc' => __('Name of ticket owner'),
             ),


### PR DESCRIPTION
This addresses an issue where using the variable `%{ticket.id}` throws an Unsupported Variable Warning even though it's a valid variable. This adds `id` to the var scope for class Ticket so that the warning is not thrown.