### PR TITLE
Issue: Topic Fields on Ticket Edit

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -721,7 +721,10 @@ class TicketsAjaxAPI extends AjaxController {
             $info['error'] = $errors['err'] ?: __('Unable to update field');
         }
 
-        include STAFFINC_DIR . 'templates/field-edit.tmpl.php';
+        $template = $field instanceof TopicField ?
+            'templates/topic.tmpl.php' : 'templates/field-edit.tmpl.php';
+
+        include STAFFINC_DIR . $template;
     }
 
     function assign($tid, $target=null) {

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1064,6 +1064,7 @@ class DynamicFormEntry extends VerySimpleModel {
     function getSource() {
         return $this->_source ?: (isset($this->id) ? false : $_POST);
     }
+
     function setSource($source) {
         $this->_source = $source;
         // Ensure the field is connected to this data source
@@ -1158,13 +1159,32 @@ class DynamicFormEntry extends VerySimpleModel {
         if (!isset($entries[$ticket_id]) || $force) {
             $stuff = DynamicFormEntry::objects()
                 ->filter(array('object_id'=>$ticket_id, 'object_type'=>'T'));
+
+            //check to see if forms have been excluded by help topic
+            if (($ticket_topic = Ticket::objects()
+              ->filter(array('ticket_id'=>$ticket_id,
+                'flags__hasbit' => Ticket::FLAG_SHOW_FIELDS))
+              ->values_flat('topic_id')->first()) &&
+            $topic = Topic::lookup($ticket_topic[0])) {
+                $topicForms = array();
+                foreach($topic->getForms() as $form)
+                    $topicForms[] = $form->getId();
+
+                $stuff = $stuff->filter(
+                    Q::all(array('form_id__in'=>$topicForms)));
+            }
+
             // If forced, don't cache the result
             if ($force)
                 return $stuff;
-            $entries[$ticket_id] = &$stuff;
+
+            foreach($stuff as $entry)
+                $entries[$entry->getId()] = $entry;
         }
-        return $entries[$ticket_id];
+
+        return $entries;
     }
+
     function setTicketId($ticket_id) {
         $this->object_type = 'T';
         $this->object_id = $ticket_id;
@@ -1186,6 +1206,7 @@ class DynamicFormEntry extends VerySimpleModel {
 
     function render($options=array()) {
         $options += array('staff' => true);
+        $this->getForm()->options += $options;
         return $this->getForm()->render($options);
     }
 

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -225,17 +225,19 @@ class Form {
     function getMedia() {
         static $dedup = array();
 
-        foreach ($this->getFields() as $f) {
-            if (($M = $f->getMedia()) && is_array($M)) {
-                foreach ($M as $type=>$files) {
-                    foreach ($files as $url) {
-                        $key = strtolower($type.$url);
-                        if (isset($dedup[$key]))
-                            continue;
+        if ($this->getFields()) {
+            foreach ($this->getFields() as $f) {
+                if (($M = $f->getMedia()) && is_array($M)) {
+                    foreach ($M as $type=>$files) {
+                        foreach ($files as $url) {
+                            $key = strtolower($type.$url);
+                            if (isset($dedup[$key]))
+                                continue;
 
-                        self::emitMedia($url, $type);
+                            self::emitMedia($url, $type);
 
-                        $dedup[$key] = true;
+                            $dedup[$key] = true;
+                        }
                     }
                 }
             }
@@ -371,11 +373,30 @@ class CustomForm extends SimpleForm {
         $user = $options['user'] ?: $thisstaff ?: $thisclient;
         $isedit = ($options['mode'] == 'edit');
         $fields = array();
-        foreach (parent::getFields() as $field) {
-            if ($isedit && !$field->isEditable($user))
-                continue;
 
-            $fields[] = $field;
+        if ($options['entry'] && $answers = $options['entry']->getAnswers()->exclude(Q::any(array(
+            'field__flags__hasbit' => DynamicFormField::FLAG_EXT_STORED)))) {
+
+            if ($options['ticket'] && ($ticket = $options['ticket']) &&
+                $ticket->hasFlag(Ticket::FLAG_SHOW_FIELDS) &&
+                $disabledByTopic = Ticket::getMissingRequiredFields($ticket, true)) {
+                    $answers->exclude(Q::any(array('field__id__in' => $disabledByTopic)));
+            }
+
+            foreach($answers as $a) {
+                $field = $a->getField();
+                if ($isedit && !$field->isEditable($user))
+                    continue;
+
+                $fields[] = $field;
+            }
+        } else {
+            foreach (parent::getFields() as $field) {
+                if ($isedit && !$field->isEditable($user))
+                    continue;
+
+                $fields[] = $field;
+            }
         }
 
         return $fields;
@@ -2756,6 +2777,12 @@ class TopicField extends ChoiceField {
         if ($this->getTopics() &&
                 isset($this->topics[$id]))
             return Topic::lookup($id);
+    }
+
+    function getEditForm($source=null) {
+        $fields = array('field' => $this);
+
+        return new SimpleForm($fields, $source);
     }
 
     function getWidget($widgetClass=false) {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -121,6 +121,7 @@ implements RestrictedAccess, Threadable, Searchable {
     const FLAG_SEPARATE_THREADS    = 0x0002;
     const FLAG_LINKED              = 0x0008;
     const FLAG_PARENT              = 0x0010;
+    const FLAG_SHOW_FIELDS         = 0x0020;
 
     static protected $perms = array(
             self::PERM_CREATE => array(
@@ -228,6 +229,55 @@ implements RestrictedAccess, Threadable, Searchable {
             }
         }
         return $this->_answers;
+    }
+
+    function getDisabledFields($topicForm) {
+        $formId = $topicForm->getId();
+        $disabled = array();
+        $fieldIds = array();
+        foreach ($topicForm->getFields() as $field) {
+            if (!$field->isEnabled() && $field->hasFlag(DynamicFormField::FLAG_ENABLED))
+                $fieldIds[] = $field->get('id');
+        }
+        $disabled[$formId] = $fieldIds;
+
+        return $disabled;
+    }
+
+    function setDisabledFields($disabled, $form) {
+        $disabled = is_array($disabled[0]) ? $disabled[0] : $disabled;
+
+        foreach ($form->getFields() as $field) {
+            if (false !== array_search($field->get('id'), $disabled))
+                $field->disable();
+        }
+
+        // Track fields currently disabled
+        $form->extra = JsonDataEncoder::encode(array(
+            'disable' => $disabled
+        ));
+
+        return $form;
+    }
+
+    function updateFormEntries($topic) {
+        $forms = DynamicFormEntry::forTicket($this->getId());
+
+        $disabled = array();
+        foreach ($topic->getForms() as $topicForm)
+            $disabled += self::getDisabledFields($topicForm);
+
+        foreach ($forms as $form) {
+            //set extra for form entries
+            $fieldIds = array();
+            foreach($disabled as $d => $fieldId) {
+                if ($form->form_id == $d)
+                    $fieldIds[] = $fieldId;
+            }
+
+            self::setDisabledFields($fieldIds, $form);
+            $form->save();
+        }
     }
 
     function getAnswer($field, $form=null) {
@@ -3655,10 +3705,14 @@ implements RestrictedAccess, Threadable, Searchable {
 
         // Validate dynamic meta-data
         $forms = DynamicFormEntry::forTicket($this->getId());
+
+        self::updateFormEntries($topic);
+
         foreach ($forms as $form) {
             // Don't validate deleted forms
             if (!in_array($form->getId(), $vars['forms']))
                 continue;
+
             $form->filterFields(function($f) { return !$f->isStorable(); });
             $form->setSource($_POST);
             if (!$form->isValid(function($f) {
@@ -3802,6 +3856,17 @@ implements RestrictedAccess, Threadable, Searchable {
            }
        }
 
+       if (get_class($field) == 'TopicField') {
+           $topic = $field->getClean();
+
+           self::updateFormEntries($topic);
+
+           if ($_POST['show-fields'])
+               $this->setFlag(Ticket::FLAG_SHOW_FIELDS, true);
+           else
+              $this->setFlag(Ticket::FLAG_SHOW_FIELDS, false);
+       }
+
        if ($errors)
            return false;
 
@@ -3809,7 +3874,8 @@ implements RestrictedAccess, Threadable, Searchable {
        $this->logEvent('edited', $changes);
 
        // Log comments (if any)
-       if (($comments = $form->getField('comments')->getClean())) {
+       if (($form->getField('comments') && $comments = $form->getField('comments')->getClean()) ||
+       ($_POST['comments'] && $comments = $_POST['comments'])) {
            $title = sprintf(__('%s updated'), __($field->getLabel()));
            $_errors = array();
            $this->postNote(
@@ -4060,30 +4126,23 @@ implements RestrictedAccess, Threadable, Searchable {
             // entries, disable and track the requested disabled fields.
             if ($vars['topicId']) {
                 if ($__topic=Topic::lookup($vars['topicId'])) {
-                    foreach ($__topic->getForms() as $idx=>$__F) {
-                        $disabled = array();
-                        foreach ($__F->getFields() as $field) {
-                            if (!$field->isEnabled() && $field->hasFlag(DynamicFormField::FLAG_ENABLED))
-                                $disabled[] = $field->get('id');
-                        }
+                    foreach ($__topic->getForms() as $index=>$topicForm) {
+                        $disabled = self::getDisabledFields($topicForm);
                         // Special handling for the ticket form — disable fields
                         // requested to be disabled as per the help topic.
-                        if ($__F->get('type') == 'T') {
-                            foreach ($form->getFields() as $field) {
-                                if (false !== array_search($field->get('id'), $disabled))
-                                    $field->disable();
-                            }
-                            $form->sort = $idx;
-                            $__F = $form;
+                        if ($topicForm->get('type') == 'T') {
+                            $formId = $topicForm->getId();
+                            self::setDisabledFields($disabled[$formId], $form);
+                            $form->sort = $index;
                         }
                         else {
-                            $__F = $__F->instanciate($idx);
-                            $__F->setSource($vars);
-                            $topic_forms[] = $__F;
+                            $topicForm = $topicForm->instanciate($index);
+                            $topicForm->setSource($vars);
+                            $topic_forms[] = $topicForm;
                         }
                         // Track fields currently disabled
-                        $__F->extra = JsonDataEncoder::encode(array(
-                            'disable' => $disabled
+                        $topicForm->extra = JsonDataEncoder::encode(array(
+                            'disable' => call_user_func_array('array_merge', $disabled)
                         ));
                     }
                 }

--- a/include/staff/templates/dynamic-form.tmpl.php
+++ b/include/staff/templates/dynamic-form.tmpl.php
@@ -40,76 +40,79 @@ if (isset($options['entry']) && $options['mode'] == 'edit') { ?>
     </th></tr>
     <?php
     }
-    foreach ($form->getFields() as $field) {
-        try {
-            if (!$field->isEnabled())
-                continue;
-        }
-        catch (Exception $e) {
-            // Not connected to a DynamicFormField
-        }
-        ?>
-        <tr><?php if ($field->isBlockLevel()) { ?>
-                <td colspan="2">
-                <?php
+    if ($fields = $form->getFields()) {
+        foreach ($fields as $field) {
+            try {
+                if (!$field->isEnabled())
+                    continue;
             }
-            else { ?>
-                <td class="multi-line <?php if ($field->isRequiredForStaff() || $field->isRequiredForClose()) echo 'required';
-                ?>" style="min-width:120px;" <?php if ($options['width'])
-                    echo "width=\"{$options['width']}\""; ?>>
-                <?php echo Format::htmlchars($field->getLocal('label')); ?>:</td>
-                <td><div style="position:relative"><?php
+            catch (Exception $e) {
+                // Not connected to a DynamicFormField
             }
+            ?>
+            <tr><?php if ($field->isBlockLevel()) { ?>
+                    <td colspan="2">
+                    <?php
+                }
+                else { ?>
+                    <td class="multi-line <?php if ($field->isRequiredForStaff() || $field->isRequiredForClose()) echo 'required';
+                    ?>" style="min-width:120px;" <?php if ($options['width'])
+                        echo "width=\"{$options['width']}\""; ?>>
+                    <?php echo Format::htmlchars($field->getLocal('label')); ?>:</td>
+                    <td><div style="position:relative"><?php
+                }
 
-            if ($field->isEditableToStaff() || $isCreate) {
-                $field->render($options); ?>
-                <?php if (!$field->isBlockLevel() && $field->isRequiredForStaff()) { ?>
-                    <span class="error">*</span>
-                <?php
-                }
-                if ($field->isStorable() && ($a = $field->getAnswer()) && $a->isDeleted()) {
-                    ?><a class="action-button float-right danger overlay" title="Delete this data"
-                        href="#delete-answer"
-                        onclick="javascript:if (confirm('<?php echo __('You sure?'); ?>'))
-                            $.ajax({
-                                url: 'ajax.php/form/answer/'
-                                    +$(this).data('entryId') + '/' + $(this).data('fieldId'),
-                                type: 'delete',
-                                success: $.proxy(function() {
-                                    $(this).closest('tr').fadeOut();
-                                }, this)
-                            });
-                        return false;"
-                        data-field-id="<?php echo $field->getAnswer()->get('field_id');
-                    ?>" data-entry-id="<?php echo $field->getAnswer()->get('entry_id');
-                    ?>"> <i class="icon-trash"></i> </a></div><?php
-                }
-                if ($a && !$a->getValue() && $field->isRequiredForClose() && get_class($field) != 'BooleanField') {
-    ?><i class="icon-warning-sign help-tip warning"
-        data-title="<?php echo __('Required to close ticket'); ?>"
-        data-content="<?php echo __('Data is required in this field in order to close the related ticket'); ?>"
-    /></i><?php
-                }
-                if ($field->get('hint') && !$field->isBlockLevel()) { ?>
-                    <br /><em style="color:gray;display:inline-block"><?php
-                        echo Format::viewableImages($field->getLocal('hint')); ?></em>
-                <?php
-                }
-                foreach ($field->errors() as $e) { ?>
-                    <div class="error"><?php echo Format::htmlchars($e); ?></div>
-                <?php }
-            } else {
-                $val = '';
-                if ($field->value)
-                    $val = $field->display($field->value);
-                elseif (($a= $field->getAnswer()))
-                    $val = $a->display();
+                if ($field->isEditableToStaff() || $isCreate) {
+                    $field->render($options); ?>
+                    <?php if (!$field->isBlockLevel() && $field->isRequiredForStaff()) { ?>
+                        <span class="error">*</span>
+                    <?php
+                    }
+                    if ($field->isStorable() && ($a = $field->getAnswer()) && $a->isDeleted()) {
+                        ?><a class="action-button float-right danger overlay" title="Delete this data"
+                            href="#delete-answer"
+                            onclick="javascript:if (confirm('<?php echo __('You sure?'); ?>'))
+                                $.ajax({
+                                    url: 'ajax.php/form/answer/'
+                                        +$(this).data('entryId') + '/' + $(this).data('fieldId'),
+                                    type: 'delete',
+                                    success: $.proxy(function() {
+                                        $(this).closest('tr').fadeOut();
+                                    }, this)
+                                });
+                            return false;"
+                            data-field-id="<?php echo $field->getAnswer()->get('field_id');
+                        ?>" data-entry-id="<?php echo $field->getAnswer()->get('entry_id');
+                        ?>"> <i class="icon-trash"></i> </a></div><?php
+                    }
+                    if ($a && !$a->getValue() && $field->isRequiredForClose() && get_class($field) != 'BooleanField') {
+        ?><i class="icon-warning-sign help-tip warning"
+            data-title="<?php echo __('Required to close ticket'); ?>"
+            data-content="<?php echo __('Data is required in this field in order to close the related ticket'); ?>"
+        /></i><?php
+                    }
+                    if ($field->get('hint') && !$field->isBlockLevel()) { ?>
+                        <br /><em style="color:gray;display:inline-block"><?php
+                            echo Format::viewableImages($field->getLocal('hint')); ?></em>
+                    <?php
+                    }
+                    foreach ($field->errors() as $e) { ?>
+                        <div class="error"><?php echo Format::htmlchars($e); ?></div>
+                    <?php }
+                } else {
+                    $val = '';
+                    if ($field->value)
+                        $val = $field->display($field->value);
+                    elseif (($a= $field->getAnswer()))
+                        $val = $a->display();
 
-                echo $val;
-            }?>
-            </div></td>
-        </tr>
-    <?php }
+                    echo $val;
+                }?>
+                </div></td>
+            </tr>
+        <?php }
+    }
+
 if (isset($options['entry']) && $options['mode'] == 'edit') { ?>
 </tbody>
 <?php } ?>

--- a/include/staff/templates/topic.tmpl.php
+++ b/include/staff/templates/topic.tmpl.php
@@ -1,0 +1,86 @@
+<?php
+global $cfg;
+
+$options = array('template' => 'simple', 'form_id' => $form->getId());
+
+if (!$info[':title'])
+    $info[':title'] = __('Update Help Topic');
+?>
+<h3 class="drag-handle"><?php echo $info[':title']; ?></h3>
+<b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
+<div class="clear"></div>
+<hr/>
+<?php
+if ($info['error']) {
+    echo sprintf('<p id="msg_error">%s</p>', $info['error']);
+} elseif ($info['warn']) {
+    echo sprintf('<p id="msg_warning">%s</p>', $info['warn']);
+} elseif ($info['msg']) {
+    echo sprintf('<p id="msg_notice">%s</p>', $info['msg']);
+} elseif ($info['notice']) {
+   echo sprintf('<p id="msg_info"><i class="icon-info-sign"></i> %s</p>',
+           $info['notice']);
+}
+
+$action = $info[':action'] ?: ('#');
+?>
+<div style="display:block; margin:5px;">
+<form class="mass-action" method="post"
+    name="topic"
+    id="<?php echo $form->getFormId(); ?>"
+    action="<?php echo $action; ?>">
+    <table width="100%">
+        <?php
+        if ($info[':extra']) {
+            ?>
+        <tbody>
+            <tr><td colspan="2"><strong><?php echo $info[':extra'];
+            ?></strong></td> </tr>
+        </tbody>
+        <?php
+        }
+       ?>
+        <tbody>
+            <tr><td colspan=2>
+             <?php
+             include 'dynamic-form-simple.tmpl.php';
+             ?>
+            </td> </tr>
+            <tr>
+                <td colspan=2>
+                    <input type="checkbox" name="show-fields" value="1" <?php
+                        echo $ticket->hasFlag(Ticket::FLAG_SHOW_FIELDS)
+                            ?  'checked="checked"' : ''; ?>>
+                        <?php echo __('Show fields based on Help Topic'); ?>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <?php
+                    $placeholder = $info[':placeholder'] ?: __('Optional reason for the update.');
+                    ?>
+                    <textarea name="comments" id="comments"
+                        cols="50" rows="3" wrap="soft" style="width:100%"
+                        class="<?php if ($cfg->isRichTextEnabled()) echo 'richtext';
+                        ?> no-bar"
+                        placeholder="<?php echo $placeholder; ?>"><?php
+                        echo $info['comments']; ?></textarea>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <hr>
+    <p class="full-width">
+        <span class="buttons pull-left">
+            <input type="reset" value="<?php echo __('Reset'); ?>">
+            <input type="button" name="cancel" class="close"
+            value="<?php echo __('Cancel'); ?>">
+        </span>
+        <span class="buttons pull-right">
+            <input type="submit" value="<?php
+            echo $verb ?: __('Update'); ?>">
+        </span>
+     </p>
+</form>
+</div>
+<div class="clear"></div>

--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -154,7 +154,7 @@ if ($_POST)
 <table class="form_table dynamic-forms" width="940" border="0" cellspacing="0" cellpadding="2">
         <?php if ($forms)
             foreach ($forms as $form) {
-                $form->render(array('staff'=>true,'mode'=>'edit','width'=>160,'entry'=>$form));
+                $form->render(array('staff'=>true,'mode'=>'edit','width'=>160,'entry'=>$form, 'ticket'=>$ticket));
         } ?>
 </table>
 <table class="form_table" width="940" border="0" cellspacing="0" cellpadding="2">


### PR DESCRIPTION
This commit fixes an issue where we did not check the Help Topic to see which fields should be shown for Ticket Edits.
Now, a checkbox has been added to the inline edit for Help Topics that gives an option to show fields based on the Help Topic.

If this box remains unchecked, all visible/editable fields on a Ticket's forms will show up when the edit all button is clicked.
	- This is useful in the event that fields were populated before a Topic was changed to a Topic that does not necessarily include those populated fields.

If the box is checked, fields and forms will be shown/hidden based on the fields and forms for the Help Topic selected.
	- This is useful in the event that a Help Topic is chosen by default for incoming Tickets that may include fields that are not needed for the Help Topic that a Ticket is switched to.

One thing to note is that on Ticket creation, if a Help Topic was chosen that didn't include custom forms and the Topic is changed to one that should have custom forms, those forms will not be added automatically with the Help Topic being changed. The Agent would have to go to Manage Forms to add the other form to the Ticket.