### PR TITLE
Issue: Create Team With Members

### DIFF
--- a/include/class.team.php
+++ b/include/class.team.php
@@ -201,13 +201,14 @@ implements TemplateVariable {
                 $access[] = array($staff_id, @$vars['member_alerts'][$staff_id]);
             }
         }
-        $this->updateMembers($access, $errors);
 
         if ($errors)
             return false;
 
-        if ($this->save())
-            return $this->members->saveAll();
+        if ($this->save()) {
+            $this->updateMembers($access, $errors);
+            return true;
+        }
 
         if (isset($this->team_id)) {
             $errors['err']=sprintf(__('Unable to update %s.'), __('this team'))
@@ -354,7 +355,6 @@ implements TemplateVariable {
     static function __create($vars, &$errors) {
         return self::create($vars)->save();
     }
-
 }
 
 class TeamMember extends VerySimpleModel {


### PR DESCRIPTION
This commit fixes an issue we had with creating Teams with members at the same time.

Errors:

1064:
[UPDATE `ost_team_member` SET  WHERE (`ost_team_member`.`team_id` = 4 AND `ost_team_member`.`staff_id` = '2') LIMIT 1]

You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'WHERE (`ost_team_member`.`team_id` = 4 AND `ost_team_member`.`staff_id` = '2') L' at line 1

1062:
[INSERT INTO `ost_team` SET `created` = NOW(), `flags` = 1, `name` = 'Team1', `updated` = NOW()]

Duplicate entry 'Team1' for key 'name'