### PR TITLE
i18n: Don't Store Files Under Branch Name

### DIFF
--- a/include/cli/modules/i18n.php
+++ b/include/cli/modules/i18n.php
@@ -197,7 +197,8 @@ class i18n_Compiler extends Module {
                 // Skip files in (other) branches
                 continue;
             }
-            $phar->addFromString($info['name'], $contents);
+            $lname = $branch ? explode('/', $info['name'], 2)[1] : $info['name'];
+            $phar->addFromString($lname, $contents);
         }
 
         // TODO: Add i18n extras (like fonts)


### PR DESCRIPTION
This addresses an issue where upon building the language packs we store the files for a particular branch in an identically named directory within the PHAR archive. (ie. if branch name is `1.14.x` then the directory name will be `1.14.x`). For instance, the Russian PHAR archive has the structure of:
```
ru.phar
|_ 1.14.x
  |_ help/
  |_ templates/
…
```

This is problematic as when we attempt to retrieve a template with `$i18n->getTemplate()` the system can’t find it. A good example is Help Tips, when we get a help tip like `$i18n->getTemplate("help/tips/settings.ticket.yaml")`, `help/tips/settings.ticket.yaml` cannot be found (because the actual path is `1.14.x/help/tips/settings.ticket.yaml`) so the default English version is returned. This adds a check for `$branch` and if exists we will remove the branch name from the name/path.