### PR TITLE
issue: Activity Notice getLastRespondent()

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -361,7 +361,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                     ))
                     ->values_flat('thread__entries__staff_id')
                     ->order_by('-thread__entries__id')
-                    ->limit(1)
+                    ->limit('1,1')
                 ))
                 ->first()
                 ?: false;
@@ -1039,9 +1039,6 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         }
         */
 
-        $this->lastrespondent = $response->staff;
-        $this->save();
-
         // Send activity alert to agents
         $activity = $vars['activity'] ?: $response->getActivity();
         $this->onActivity( array(
@@ -1049,6 +1046,10 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                     'threadentry' => $response,
                     'assignee' => $assignee,
                     ));
+
+        $this->lastrespondent = $response->staff;
+        $this->save();
+
         // Send alert to collaborators
         if ($alert && $vars['emailcollab']) {
             $signature = '';

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -814,7 +814,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     ))
                     ->values_flat('staff_id')
                     ->order_by('-id')
-                    ->limit(1)
+                    ->limit('1,1')
                 ))
                 ->first()
                 ?: false;
@@ -3329,9 +3329,9 @@ implements RestrictedAccess, Threadable, Searchable {
             $this->setStaffId($thisstaff->getId()); //direct assignment;
         }
 
-        $this->lastrespondent = $response->staff;
-
         $this->onResponse($response, array('assignee' => $assignee)); //do house cleaning..
+
+        $this->lastrespondent = $response->staff;
 
         $type = array('type' => 'message');
         Signal::send('object.created', $this, $type);


### PR DESCRIPTION
This addresses issue #3647 where Internal Activity Alerts are never sent out for both Tasks and Tickets. Upon initial investigation it appeared that we set the `lastrespondent` property before we call `onResponse()`/`onActivity()` so when we checked the Last Respondent it was the same Agent posting the Reply so an email was never sent out. Upon moving the `lastrespondent` property below the `onResponse()`/`onActivity()` calls, it still grabbed the current Responding Agent. Looking deeper into `getLastRespondent()` (for both Ticket and Task classes) I found that the query we use to get the Last Response from an Agent on the Thread, grabs the newly added Response. This is because the Thread Entry is added before we call `getLastRespondent()` so we really need to grab the second record, not the first. This updates the `limit()` clause from `1` to `1,1` to utilize MySQL/MariaDB "LIMIT offest" so that we grab the second entry which is the true Last Response. This also moves the `lastrespondent` property below the `onResponse()`/`onActivity()` calls to ensure we don't return the current Responding Agent.