### PR TITLE
Password Policy Revisited

### DIFF
--- a/account.php
+++ b/account.php
@@ -66,7 +66,16 @@ elseif ($_POST) {
         $errors['passwd1'] = __('New password is required');
     elseif (!$_POST['backend'] && $_POST['passwd2'] != $_POST['passwd1'])
         $errors['passwd1'] = __('Passwords do not match');
+    else {
+        try {
+            UserAccount::checkPassword($_POST['passwd1']);
+        } catch (BadPassword $ex) {
+             $errors['passwd1'] = $ex->getMessage();
+        }
+    }
 
+    if ($errors)
+        $errors['err'] = $errors['err'] ?: __('Unable to register account. See messages below');
     // XXX: The email will always be in use already if a guest is logged in
     // and is registering for an account. Instead,
     elseif (($addr = $user_form->getField('email')->getClean())

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -38,7 +38,7 @@ class StaffAjaxAPI extends AjaxController {
           try {
               // Validate password
               if (!$clean['welcome_email'])
-                  PasswordPolicy::checkPassword($clean['passwd1'], null);
+                  Staff::checkPassword($clean['passwd1'], null);
               if ($id == 0) {
                   // Stash in the session later when creating the user
                   $_SESSION['new-agent-passwd'] = $clean;

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -56,8 +56,8 @@ class StaffAjaxAPI extends AjaxController {
                   Http::response(201, 'Successfully updated');
           }
           catch (BadPassword $ex) {
-              $passwd1 = $form->getField('passwd1');
-              $passwd1->addError($ex->getMessage());
+              if ($passwd1 = $form->getField('passwd1'))
+                  $passwd1->addError($ex->getMessage());
           }
           catch (PasswordUpdateFailed $ex) {
               $errors['err'] = __('Password update failed:').' '.$ex->getMessage();
@@ -108,8 +108,8 @@ class StaffAjaxAPI extends AjaxController {
                     }
                 }
                 catch (BadPassword $ex) {
-                    $passwd1 = $form->getField('passwd1');
-                    $passwd1->addError($ex->getMessage());
+                    if ($passwd1 = $form->getField('passwd1'))
+                        $passwd1->addError($ex->getMessage());
                 }
                 catch (PasswordUpdateFailed $ex) {
                     $errors['err'] = __('Password update failed:').' '.$ex->getMessage();

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -450,8 +450,19 @@ class OsticketConfig extends Config {
         return $this->get('overdue_grace_period');
     }
 
+    // This is here for legacy reasons - default osTicket Password Policy
+    // uses it, if previously set.
     function getPasswdResetPeriod() {
         return $this->get('passwd_reset_period');
+    }
+
+
+    function getStaffPasswordPolicy() {
+        return $this->get('agent_passwd_policy');
+    }
+
+    function getClientPasswordPolicy() {
+        return $this->get('client_passwd_policy');
     }
 
     function isRichTextEnabled() {
@@ -1316,7 +1327,7 @@ class OsticketConfig extends Config {
             return false;
 
         return $this->updateAll(array(
-            'passwd_reset_period'=>$vars['passwd_reset_period'],
+            'agent_passwd_policy'=>$vars['agent_passwd_policy'],
             'staff_max_logins'=>$vars['staff_max_logins'],
             'staff_login_timeout'=>$vars['staff_login_timeout'],
             'staff_session_timeout'=>$vars['staff_session_timeout'],
@@ -1343,6 +1354,7 @@ class OsticketConfig extends Config {
             return false;
 
         return $this->updateAll(array(
+            'client_passwd_policy'=>$vars['client_passwd_policy'],
             'client_max_logins'=>$vars['client_max_logins'],
             'client_login_timeout'=>$vars['client_login_timeout'],
             'client_session_timeout'=>$vars['client_session_timeout'],

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1515,7 +1515,8 @@ class PasswordField extends TextboxField {
 
     function __construct($options=array()) {
         parent::__construct($options);
-        $this->set('validator', 'password');
+        if (!isset($options['validator']))
+            $this->set('validator', 'password');
     }
 
     function parse($value) {

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -55,16 +55,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
     var $_perm;
 
     function __onload() {
-
-        // WE have to patch info here to support upgrading from old versions.
-        $time = null;
-        if (isset($this->passwdreset) && $this->passwdreset)
-            $time=strtotime($this->passwdreset);
-        elseif (isset($this->added) && $this->added)
-            $time=strtotime($this->added);
-
-        if ($time)
-            $this->passwd_change = time()-$time; //XXX: check timezone issues.
     }
 
     function get($field, $default=false) {
@@ -228,11 +218,22 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         return $this->save();
     }
 
-    /* check if passwd reset is due. */
-    function isPasswdResetDue() {
-        global $cfg;
-        return ($cfg && $cfg->getPasswdResetPeriod()
-                    && $this->passwd_change>($cfg->getPasswdResetPeriod()*30*24*60*60));
+    function getPasswdResetTimestamp() {
+        if (!isset($this->passwd_change)) {
+            // WE have to patch info here to support upgrading from old versions.
+            if (isset($this->passwdreset) && $this->passwdreset)
+                $this->passwd_change = strtotime($this->passwdreset);
+            elseif (isset($this->added) && $this->added)
+                $this->passwd_change = strtotime($this->added);
+            elseif (isset($this->created) && $this->created)
+                $this->passwd_change = strtotime($this->created);
+        }
+
+        return $this->passwd_change;
+    }
+
+    static function checkPassword($new, $current=null) {
+        osTicketStaffAuthentication::checkPassword($new, $current);
     }
 
     function setPassword($new, $current=false) {
@@ -246,7 +247,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             || !$bk instanceof AuthBackend
         ) {
             // Fallback to osTicket authentication token udpates
-            $bk = new osTicketAuthentication();
+            $bk = new osTicketStaffAuthentication();
         }
 
         // And now for the magic
@@ -273,10 +274,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             return $something->checkStaffPerm($this);
 
         return true;
-    }
-
-    function isPasswdChangeDue() {
-        return $this->isPasswdResetDue();
     }
 
     function getRefreshRate() {

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1352,6 +1352,14 @@ extends AbstractForm {
                     new Q(array('welcome_email' => false)),
                     VisibilityConstraint::HIDDEN
                 ),
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
             'passwd2' => new PasswordField(array(
                 'placeholder' => __('Confirm Password'),
@@ -1363,6 +1371,14 @@ extends AbstractForm {
                     new Q(array('welcome_email' => false)),
                     VisibilityConstraint::HIDDEN
                 ),
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
             'change_passwd' => new BooleanField(array(
                 'default' => true,
@@ -1399,10 +1415,26 @@ extends AbstractForm {
                 'label' => __('Enter a new password'),
                 'placeholder' => __('New Password'),
                 'required' => true,
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
             'passwd2' => new PasswordField(array(
                 'placeholder' => __('Confirm Password'),
                 'required' => true,
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
         );
 
@@ -1589,6 +1621,14 @@ extends AbstractForm {
                 'configuration' => array(
                     'placeholder' => __("Temporary Password"),
                 ),
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
                 'visibility' => new VisibilityConstraint(
                     new Q(array('welcome_email' => false))
                 ),

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1273,10 +1273,13 @@ class UserAccount extends VerySimpleModel {
         if ($vars['passwd1'] || $vars['passwd2']) {
             if (!$vars['passwd1'])
                 $errors['passwd1'] = __('New password is required');
-            elseif ($vars['passwd1'] && strlen($vars['passwd1'])<6)
-                $errors['passwd1'] = __('Must be at least 6 characters');
-            elseif ($vars['passwd1'] && strcmp($vars['passwd1'], $vars['passwd2']))
-                $errors['passwd2'] = __('Passwords do not match');
+            else {
+                try {
+                    self::checkPassword($vars['passwd1']);
+                } catch (BadPassword $ex) {
+                    $errors['passwd1'] =  $ex->getMessage();
+                }
+            }
         }
 
         // Make sure the username is not an email.
@@ -1359,10 +1362,15 @@ class UserAccount extends VerySimpleModel {
                 && !isset($vars['sendemail'])) {
             if (!$vars['passwd1'])
                 $errors['passwd1'] = 'Temporary password required';
-            elseif ($vars['passwd1'] && strlen($vars['passwd1'])<6)
-                $errors['passwd1'] = 'Must be at least 6 characters';
             elseif ($vars['passwd1'] && strcmp($vars['passwd1'], $vars['passwd2']))
                 $errors['passwd2'] = 'Passwords do not match';
+            else {
+                try {
+                    self::checkPassword($vars['passwd1']);
+                } catch (BadPassword $ex) {
+                    $errors['passwd1'] =  $ex->getMessage();
+                }
+            }
         }
 
         if ($errors) return false;
@@ -1395,6 +1403,10 @@ class UserAccount extends VerySimpleModel {
             $account->sendConfirmEmail();
 
         return $account;
+    }
+
+    static function checkPassword($new, $current=null) {
+        osTicketClientAuthentication::checkPassword($new, $current);
     }
 
 }

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -39,19 +39,12 @@ disable_agent_collabs:
         This setting is global for all User created Tickets via API, Piping, and Fetching.
 
 # Authentication settings
-password_reset:
-    title: Password Expiration Policy
+agent_password_policy:
+    title: Password Management Policy
     content: >
-        Sets how often (in months) Agents will be required to change
-        their password. If disabled (set to "No expiration"), passwords will
-        not expire.
-
-password_expiration_policy:
-    title: Password Expiration Policy
-    content: >
-        Choose how often Agents will be required to change their password. If
-        disabled (i.e., <span class="doc-desc-opt">No Expiration</span>), passwords
-        will not expire.
+        Chose a <span class="doc-desc-title">Password Policy</span> for <span class="doc-desc-title">Agents</span>.
+        <br><br>
+        Additional policies can be added by installing <span class="doc-desc-title">Password Policy</span> plugins.
 
 allow_password_resets:
     title: Allow Password Resets

--- a/include/i18n/en_US/help/tips/settings.users.yaml
+++ b/include/i18n/en_US/help/tips/settings.users.yaml
@@ -21,6 +21,13 @@ client_name_format:
         will use it for names if no other format is specified.
 
 # Authentication settings
+client_password_policy:
+    title: Password Management Policy
+    content: >
+        Chose a <span class="doc-desc-title">Password Policy</span> for <span class="doc-desc-title">Users</span>.
+        <br><br>
+        Additional policies can be added by installing <span class="doc-desc-title">Password Policy</span> plugins.
+
 client_session_timeout:
     title: User Session Timeout
     content: >

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -83,20 +83,23 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                         </th>
                     </tr>
                     <tr>
-                        <td><?php echo __('Password Expiration Policy'); ?>:</td>
+                        <td><?php echo __('Password Policy'); ?>:</td>
                         <td>
-                            <select name="passwd_reset_period">
-                            <option value="0"> &mdash; <?php echo __('No expiration'); ?> &mdash;</option>
+                            <select name="agent_passwd_policy">
+                            <option value=" "> &mdash; <?php echo __('All Active Policies'); ?> &mdash;</option>
                             <?php
-                                for ($i = 1; $i <= 12; $i++) {
-                                echo sprintf('<option value="%d" %s>%s</option>',
-                                    $i,(($config['passwd_reset_period']==$i)?'selected="selected"':''),
-                                    sprintf(_N('Monthly', 'Every %d months', $i), $i));
+                                foreach (PasswordPolicy::allActivePolicies()
+                                        as $P) {
+                                echo sprintf('<option value="%s" %s>%s</option>',
+                                    $P::$id,
+                                    (($config['agent_passwd_policy'] == $P::$id) ? 'selected="selected"' : ''),
+                                    $P->getName());
                                 }
                             ?>
                             </select>
-                            <font class="error"><?php echo $errors['passwd_reset_period']; ?></font>
-                            <i class="help-tip icon-question-sign" href="#password_expiration_policy"></i>
+                            <font class="error"><?php echo
+                            $errors['agent_passwd_policy']; ?></font>
+                            <i class="help-tip icon-question-sign" href="#agent_password_policy"></i>
                         </td>
                     </tr>
                     <tr>

--- a/include/staff/settings-users.inc.php
+++ b/include/staff/settings-users.inc.php
@@ -89,6 +89,26 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config)
             <i class="help-tip icon-question-sign" href="#registration_method"></i>
             </td>
         </tr>
+		<tr>
+			<td><?php echo __('Password Policy'); ?>:</td>
+			<td>
+				<select name="client_passwd_policy">
+				<option value=" "> &mdash; <?php echo __('All Active Policies'); ?> &mdash;</option>
+				<?php
+					foreach (PasswordPolicy::allActivePolicies()
+							as $P) {
+					echo sprintf('<option value="%s" %s>%s</option>',
+						$P::$id,
+						(($config['client_passwd_policy'] == $P::$id) ? 'selected="selected"' : ''),
+						$P->getName());
+					}
+				?>
+				</select>
+				<font class="error"><?php echo
+				$errors['client_passwd_policy']; ?></font>
+				<i class="help-tip icon-question-sign" href="#client_password_policy"></i>
+			</td>
+		</tr>
         <tr><td><?php echo __('User Excessive Logins'); ?>:</td>
             <td>
                 <select name="client_max_logins">


### PR DESCRIPTION
This PR improves upon how osTicket enforces password policies systemwide for Agents and Users. Notable changes include;

* Ability to enforce policies on login
* Ability to specify applicable policy for Agents or Users alike
* Allow Password Policy plugins to expire passwords... etc