### PR TITLE
2FA Backends

### DIFF
--- a/account.php
+++ b/account.php
@@ -66,7 +66,16 @@ elseif ($_POST) {
         $errors['passwd1'] = __('New password is required');
     elseif (!$_POST['backend'] && $_POST['passwd2'] != $_POST['passwd1'])
         $errors['passwd1'] = __('Passwords do not match');
+    else {
+        try {
+            UserAccount::checkPassword($_POST['passwd1']);
+        } catch (BadPassword $ex) {
+             $errors['passwd1'] = $ex->getMessage();
+        }
+    }
 
+    if ($errors)
+        $errors['err'] = $errors['err'] ?: __('Unable to register account. See messages below');
     // XXX: The email will always be in use already if a guest is logged in
     // and is registering for an account. Instead,
     elseif (($addr = $user_form->getField('email')->getClean())

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -38,7 +38,7 @@ class StaffAjaxAPI extends AjaxController {
           try {
               // Validate password
               if (!$clean['welcome_email'])
-                  PasswordPolicy::checkPassword($clean['passwd1'], null);
+                  Staff::checkPassword($clean['passwd1'], null);
               if ($id == 0) {
                   // Stash in the session later when creating the user
                   $_SESSION['new-agent-passwd'] = $clean;

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -56,8 +56,8 @@ class StaffAjaxAPI extends AjaxController {
                   Http::response(201, 'Successfully updated');
           }
           catch (BadPassword $ex) {
-              $passwd1 = $form->getField('passwd1');
-              $passwd1->addError($ex->getMessage());
+              if ($passwd1 = $form->getField('passwd1'))
+                  $passwd1->addError($ex->getMessage());
           }
           catch (PasswordUpdateFailed $ex) {
               $errors['err'] = __('Password update failed:').' '.$ex->getMessage();
@@ -108,8 +108,8 @@ class StaffAjaxAPI extends AjaxController {
                     }
                 }
                 catch (BadPassword $ex) {
-                    $passwd1 = $form->getField('passwd1');
-                    $passwd1->addError($ex->getMessage());
+                    if ($passwd1 = $form->getField('passwd1'))
+                        $passwd1->addError($ex->getMessage());
                 }
                 catch (PasswordUpdateFailed $ex) {
                     $errors['err'] = __('Password update failed:').' '.$ex->getMessage();

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -307,13 +307,16 @@ class StaffAjaxAPI extends AjaxController {
     }
 
     function reset2fA($staffId) {
+        global $thisstaff;
+
+        if (!$thisstaff)
+            Http::response(403, 'Agent login required');
+        if (!$thisstaff->isAdmin())
+            Http::response(403, 'Access denied');
+
         $default_2fa = ConfigItem::getConfigsByNamespace('staff.'.$staffId, 'default_2fa');
-        $config = ConfigItem::getConfigsByNamespace('staff.'.$staffId, $default_2fa->value);
 
         if ($default_2fa)
             $default_2fa->delete();
-
-        if ($config)
-            $config->delete();
     }
 }

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -305,4 +305,15 @@ class StaffAjaxAPI extends AjaxController {
 
         include STAFFINC_DIR . 'templates/2fas.tmpl.php';
     }
+
+    function reset2fA($staffId) {
+        $default_2fa = ConfigItem::getConfigsByNamespace('staff.'.$staffId, 'default_2fa');
+        $config = ConfigItem::getConfigsByNamespace('staff.'.$staffId, $default_2fa->value);
+
+        if ($default_2fa)
+            $default_2fa->delete();
+
+        if ($config)
+            $config->delete();
+    }
 }

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -278,11 +278,17 @@ class StaffAjaxAPI extends AjaxController {
                     $vars = $_POST ?: $config['config'] ?: array('email' => $staff->getEmail());
                     $form = $auth->getSetupForm($vars);
                     if ($_POST && $form && $form->isValid()) {
+                        if ($config['config'] && $config['config']['external2fa'])
+                            $external2fa = true;
+
                         // Save the setting based on setup form
                         $clean = $form->getClean();
-                        $config = ['config' => $clean, 'verified' => 0];
-                        $staff->updateConfig(array(
-                                    $auth->getId() => JsonDataEncoder::encode($config)));
+                        if (!$external2fa) {
+                            $config = ['config' => $clean, 'verified' => 0];
+                            $staff->updateConfig(array(
+                                        $auth->getId() => JsonDataEncoder::encode($config)));
+                        }
+
                         // Send verification token to the user
                         if ($token=$auth->send($staff)) {
                             // Transition to verify state
@@ -291,7 +297,7 @@ class StaffAjaxAPI extends AjaxController {
                             $info['notice'] = __('Token sent to you!');
                         } else {
                             // Generic error TODO: better wording
-                            $info['error'] = __('Error sending Token - doubdle check entry');
+                            $info['error'] = __('Error sending Token - double check entry');
                         }
                     }
             }

--- a/include/class.2fa.php
+++ b/include/class.2fa.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * TwoFactorAuthentication backend
+ *
+ * Provides the basis of abstracting 2fa backends 
+
+ * The authentication backend should define a validate() method which
+ * receives a user and OPT.
+ */
+abstract class TwoFactorAuthenticationBackend {
+    // Global registry
+    static protected $registry = array();
+    // Grace period in minutes before OTP is expired and user logged out
+    // It's hardcoded to 6 minutes here but downstream backends can make it
+    // configurable 
+    protected $timeout = 6;
+
+    // Maximum number of validation attempts before the user is logged out
+    // It's hardcoded to 3 attempts here but downstream backends can make it
+    // configurable
+    protected $maxstrikes = 3;
+
+    // Base properties
+    static $id;
+    static $name;
+    static $desc;
+
+    // Forms
+    private $_setupform;
+    private $_inputform;
+
+
+    // Send OTP to user specified and stash it
+    abstract function send($user);
+    // validate OTP provided by user
+    abstract function validate($form, $user);
+
+    function getId() {
+        return static::$id;
+    }
+
+    function getName() {
+        return __(static::$name);
+    }
+
+    function getDescription() {
+        return __(static::$desc);
+    }
+
+    function getTimeout() {
+        return $this->timeout;
+    }
+
+    function getMaxStrikes() {
+        return $this->maxstrikes;
+    }
+
+    protected function getSetupOptions() {
+        return array();
+    }
+
+    protected function getInputOptions() {
+        return array();
+    }
+
+    // stash OTP info in the session 
+    protected function store($otp) {
+       $store =  &$_SESSION['_2fa'][$this->getId()];
+       $store = ['otp' => $otp, 'time' => time(), 'strikes' => 0];
+       return $store;
+    }
+
+    // Validate OPT
+    // On strict mode check strikes and timeout
+    protected function _validate($otp, $strict=true) {
+        $store = &$_SESSION['_2fa'][$this->getId()];
+        // Track and check the attempts
+        $store['strikes'] += 1;   
+        if ($strict && $store['strikes'] > $this->getMaxStrikes())
+            throw new ExpiredOTP(__('Too many attempts'));
+
+        // Check timeout - if expired throw an exception.
+        if ($strict 
+                && ($timeout=$this->getTimeout())
+                && ($store['time']+($timeout*60)) < time())
+            throw new ExpiredOTP(__('Expired OTP'));
+
+        // Check the OTP
+        return (!strcmp($store['otp'], $otp));
+    }
+
+    // Called on a successfull validation for house keeping e.g clear 2fa
+    // flags
+    protected function onValidate($user) {
+         $user->clear2FA();
+    }
+
+    // Get a form the user uses to setup 2fa
+    function getSetupForm($data=null) {
+        if (!$this->_setupForm) {
+            $this->_setupForm = new SimpleForm($this->getSetupOptions(), $data);
+        }
+        return $this->_setupForm;
+    }
+
+    // Get a form the user uses to input OTP
+    function getInputForm($data=null) {
+        if (!$this->_inputForm) {
+            $this->_inputForm = new SimpleForm($this->getInputOptions(), $data);
+        }
+        return $this->_inputForm;
+    }
+
+    static function register($class) {
+        if (is_string($class) && class_exists($class))
+            $class = new $class();
+
+        if (!is_object($class)
+                || !($class instanceof TwoFactorAuthenticationBackend))
+            return false;
+
+        return static::_register($class);
+    }
+
+    static function _register($class) {
+        if (isset(static::$registry[$class::$id]))
+            return false;
+
+        static::$registry[$class::$id] = $class;
+    }
+
+    static function allRegistered() {
+        return static::$registry;
+    }
+
+    static function getBackend($id) {
+
+        if ($id
+                && ($backends = static::allRegistered())
+                && isset($backends[$id]))
+            return $backends[$id];
+    }
+
+    static function lookup($id) {
+        return static::getBackend($id);
+    }
+}
+
+class ExpiredOTP extends Exception {}
+
+/*
+ * user type container classes to aid in registry segmentation
+ *
+ */
+abstract class Staff2FABackend extends TwoFactorAuthenticationBackend {
+    static private $_registry = array();
+   
+    static function _register($class) {
+        if (isset(static::$_registry[$class::$id]))
+            return false;
+
+        static::$_registry[$class::$id] = $class;
+    }
+
+    static function allRegistered() {
+        return array_merge(self::$_registry, parent::allRegistered());
+    }
+
+
+    abstract function send($user);
+    abstract function validate($form, $user);
+}
+
+abstract class User2FABackend extends TwoFactorAuthenticationBackend {
+    static private $_registry = array();
+
+    static function _register($class) {
+        if (isset(static::$_registry[$class::$id]))
+            return false;
+
+        static::$_registry[$class::$id] = $class;
+    }
+
+    static function allRegistered() {
+        return array_merge(self::$_registry, parent::allRegistered());
+    }
+
+    abstract function send($user);
+    abstract function validate($form, $user);
+}
+
+/*
+ * Email2FABackend
+ *
+ * Email based two factor authentication. 
+ * 
+ * This is the default 2FA that works out of the box once users configure
+ * it.
+ *
+ */
+
+class Email2FABackend extends TwoFactorAuthenticationBackend {
+    static $id = "2fa-email";
+    static $name = /* @trans */ 'Email';
+    static $desc = /* @trans */ 'Verification codes are sent by email';
+
+    protected function getSetupOptions() {
+        return array(
+            'email' => new TextboxField(array(
+                'id'=>2, 'label'=>__('Email Address'), 'required'=>true, 'default'=>'',
+                'validator'=>'email', 'hint'=>__('Valid email address'),
+                'configuration'=>array('size'=>40, 'length'=>40),
+            )),
+        );
+    }
+
+    protected function getInputOptions() {
+        return array(
+            'token' => new TextboxField(array(
+                'id'=>1, 'label'=>__('Verification Code'), 'required'=>true, 'default'=>'',
+                'validator'=>'number', 
+                'hint'=>__('Please enter the code you were sent'),
+                'configuration'=>array(
+                    'size'=>40, 'length'=>40,
+                    'autocomplete' => 'one-time-code',
+                    'inputmode' => 'numeric',
+                    'pattern' => '[0-9]*',
+                    'validator-error' => __('Invalid Code format'),
+                    ),
+            )),
+        );
+    }
+
+    function validate($form, $user) {
+        // Make sure form is valid and token exists
+        if (!($form->isValid() 
+                    && ($clean=$form->getClean())
+                    && $clean['token']))
+            return false;
+
+        // upstream validation might throw an exception due to expired token
+        // or too many attempts (timeout). It's the responsibility of the
+        // caller to catch and handle such exceptions.
+        if (!$this->_validate($clean['token']))
+            return false;
+
+        // Validator doesn't do house cleaning - it's our responsibility
+        $this->onValidate($user);
+        return true;
+    }
+
+
+    function send($user) {
+        global $cfg;
+
+        // Get backend configuration for this user
+        if (!$cfg || !($info = $user->get2FAConfig($this->getId())))
+            return false;
+
+        // Email to send the OTP via
+        if (!($email = $cfg->getAlertEmail() ?: $cfg->getDefaultEmail()))
+            return false;
+
+        // get configuration 
+        $config = $info['config'];
+        // Generate OTP
+        $otp = Misc::randNumber(6);
+        // Stash it in the session
+        $this->store($otp);
+
+        // Send the OTP. Hard coded for now.
+        // TODO: User email template like pw-reset
+        $msg = sprintf('%s: %s',
+                'Your verification code',
+                $otp);
+        $email->sendAlert($config['email'], 'Verification Code', $msg);
+
+        // MD5 here is not meant to be secure here - just done to avoid plain leaks
+        return md5($otp);
+    }
+}
+// Register email2fa for both agents and users (parent class)
+TwoFactorAuthenticationBackend::register('Email2FABackend');
+?>

--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -1,16 +1,22 @@
 <?php
 
+require_once(INCLUDE_DIR.'class.2fa.php');
+
 interface AuthenticatedUser {
     // Get basic information
     function getId();
     function getUsername();
     function getUserType();
 
+
     // Get password reset timestamp
     function getPasswdResetTimestamp();
 
     //Backend used to authenticate the user
     function getAuthBackend();
+
+    // Get 2FA Backend
+    function get2FABackend();
 
     //Authentication key
     function setAuthKey($key);
@@ -42,6 +48,9 @@ implements AuthenticatedUser {
 
     //Backend used to authenticate the user
     abstract function getAuthBackend();
+
+    // Get 2FA Backend
+    abstract function get2FABackend();
 
     //Authentication key
     function setAuthKey($key) {

--- a/include/class.client.php
+++ b/include/class.client.php
@@ -241,6 +241,11 @@ class EndUser extends BaseAuthenticatedUser {
         return UserAuthenticationBackend::getBackend($authkey);
     }
 
+    function get2FABackend() {
+        //TODO: support 2FA on client portal
+        return null;
+    }
+
     function getTicketStats() {
         if (!isset($this->_stats))
             $this->_stats = $this->getStats();

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -450,8 +450,19 @@ class OsticketConfig extends Config {
         return $this->get('overdue_grace_period');
     }
 
+    // This is here for legacy reasons - default osTicket Password Policy
+    // uses it, if previously set.
     function getPasswdResetPeriod() {
         return $this->get('passwd_reset_period');
+    }
+
+
+    function getStaffPasswordPolicy() {
+        return $this->get('agent_passwd_policy');
+    }
+
+    function getClientPasswordPolicy() {
+        return $this->get('client_passwd_policy');
     }
 
     function isRichTextEnabled() {
@@ -1316,7 +1327,7 @@ class OsticketConfig extends Config {
             return false;
 
         return $this->updateAll(array(
-            'passwd_reset_period'=>$vars['passwd_reset_period'],
+            'agent_passwd_policy'=>$vars['agent_passwd_policy'],
             'staff_max_logins'=>$vars['staff_max_logins'],
             'staff_login_timeout'=>$vars['staff_login_timeout'],
             'staff_session_timeout'=>$vars['staff_session_timeout'],
@@ -1343,6 +1354,7 @@ class OsticketConfig extends Config {
             return false;
 
         return $this->updateAll(array(
+            'client_passwd_policy'=>$vars['client_passwd_policy'],
             'client_max_logins'=>$vars['client_max_logins'],
             'client_login_timeout'=>$vars['client_login_timeout'],
             'client_session_timeout'=>$vars['client_session_timeout'],

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -465,6 +465,10 @@ class OsticketConfig extends Config {
         return $this->get('client_passwd_policy');
     }
 
+    function require2FAForAgents() {
+         return $this->get('require_agent_2fa');
+    }
+
     function isRichTextEnabled() {
         return $this->get('enable_richtext');
     }
@@ -1334,6 +1338,7 @@ class OsticketConfig extends Config {
             'staff_ip_binding'=>isset($vars['staff_ip_binding'])?1:0,
             'allow_pw_reset'=>isset($vars['allow_pw_reset'])?1:0,
             'pw_reset_window'=>$vars['pw_reset_window'],
+            'require_agent_2fa'=>$vars['require_agent_2fa'],
             'agent_name_format'=>$vars['agent_name_format'],
             'hide_staff_name'=>isset($vars['hide_staff_name']) ? 1 : 0,
             'agent_avatar'=>$vars['agent_avatar'],

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -186,6 +186,23 @@ extends VerySimpleModel {
                 'updated__lt' => SqlFunction::NOW()->minus(SqlInterval::SECOND($period)),
             ))->delete();
     }
+
+    function getConfigsByNamespace($namespace=false, $key, $value=false) {
+        $filter = array();
+
+         $filter['key'] = $key;
+
+         if ($namespace)
+            $filter['namespace'] = $namespace;
+
+         if ($value)
+            $filter['value'] = $value;
+
+         $token = ConfigItem::objects()
+            ->filter($filter);
+
+         return $namespace ? $token[0] : $token;
+    }
 }
 
 class OsticketConfig extends Config {

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1515,7 +1515,8 @@ class PasswordField extends TextboxField {
 
     function __construct($options=array()) {
         parent::__construct($options);
-        $this->set('validator', 'password');
+        if (!isset($options['validator']))
+            $this->set('validator', 'password');
     }
 
     function parse($value) {

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -72,6 +72,10 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             return $this->_config[$field];
     }
 
+    function getConfigObj() {
+        return new Config('staff.'.$this->getId());
+    }
+
     function getConfig() {
 
         if (!isset($this->_config) && $this->getId()) {
@@ -90,6 +94,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         }
 
         return $this->_config;
+    }
+
+    function updateConfig($vars) {
+        $config = $this->getConfigObj();
+        $config->updateAll($vars);
+        $this->_config = null;
     }
 
     function __toString() {
@@ -166,6 +176,21 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             $bk = $this->backend;
 
         return StaffAuthenticationBackend::getBackend($bk);
+    }
+
+    function get2FABackendId() {
+        return $this->default_2fa;
+    }
+
+    function get2FABackend() {
+        return Staff2FABackend::getBackend($this->get2FABackendId());
+    }
+
+    // gets configured backends
+    function get2FAConfig($id) {
+        $config =  $this->getConfig();
+        return isset($config[$id]) ?
+            JsonDataParser::decode($config[$id]) : array();
     }
 
     function setAuthKey($key) {
@@ -776,6 +801,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         $_config->updateAll(array(
                     'datetime_format' => $vars['datetime_format'],
                     'default_from_name' => $vars['default_from_name'],
+                    'default_2fa' => $vars['default_2fa'],
                     'thread_view_order' => $vars['thread_view_order'],
                     'default_ticket_queue_id' => $vars['default_ticket_queue_id'],
                     'reply_redirect' => ($vars['reply_redirect'] == 'Queue') ? 'Queue' : 'Ticket',

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -389,6 +389,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         return $this->change_passwd;
     }
 
+    function force2faConfig() {
+        global $cfg;
+
+        return ($cfg->require2FAForAgents() && !$this->get2FABackend());
+    }
+
     function getDepartments() {
         // TODO: Cache this in the agent's session as it is unlikely to
         //       change while logged in

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -55,16 +55,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
     var $_perm;
 
     function __onload() {
-
-        // WE have to patch info here to support upgrading from old versions.
-        $time = null;
-        if (isset($this->passwdreset) && $this->passwdreset)
-            $time=strtotime($this->passwdreset);
-        elseif (isset($this->added) && $this->added)
-            $time=strtotime($this->added);
-
-        if ($time)
-            $this->passwd_change = time()-$time; //XXX: check timezone issues.
     }
 
     function get($field, $default=false) {
@@ -228,11 +218,22 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         return $this->save();
     }
 
-    /* check if passwd reset is due. */
-    function isPasswdResetDue() {
-        global $cfg;
-        return ($cfg && $cfg->getPasswdResetPeriod()
-                    && $this->passwd_change>($cfg->getPasswdResetPeriod()*30*24*60*60));
+    function getPasswdResetTimestamp() {
+        if (!isset($this->passwd_change)) {
+            // WE have to patch info here to support upgrading from old versions.
+            if (isset($this->passwdreset) && $this->passwdreset)
+                $this->passwd_change = strtotime($this->passwdreset);
+            elseif (isset($this->added) && $this->added)
+                $this->passwd_change = strtotime($this->added);
+            elseif (isset($this->created) && $this->created)
+                $this->passwd_change = strtotime($this->created);
+        }
+
+        return $this->passwd_change;
+    }
+
+    static function checkPassword($new, $current=null) {
+        osTicketStaffAuthentication::checkPassword($new, $current);
     }
 
     function setPassword($new, $current=false) {
@@ -246,7 +247,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             || !$bk instanceof AuthBackend
         ) {
             // Fallback to osTicket authentication token udpates
-            $bk = new osTicketAuthentication();
+            $bk = new osTicketStaffAuthentication();
         }
 
         // And now for the magic
@@ -273,10 +274,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             return $something->checkStaffPerm($this);
 
         return true;
-    }
-
-    function isPasswdChangeDue() {
-        return $this->isPasswdResetDue();
     }
 
     function getRefreshRate() {

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -193,17 +193,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             JsonDataParser::decode($config[$id]) : array();
     }
 
-    function is2FAConfigured($id) {
-        $config = $this->getConfig();
-
-        if (isset($config[$id])) {
-           $config = json_decode($config[$id], true);
-           return array_key_exists('verified', $config);
-        }
-
-        return false;
-    }
-
     function setAuthKey($key) {
         $this->authkey = $key;
     }
@@ -404,12 +393,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         global $cfg;
 
         $id = $this->get2FABackendId();
-        $config = ConfigItem::getConfigsByNamespace('staff.'.$this->getId(), $id);
+        $config = $this->get2FAConfig($id);
 
         //2fa is required and
         //1. agent doesn't have default_2fa or
         //2. agent has default_2fa, but that default_2fa is not configured
-        return ($cfg->require2FAForAgents() && !$id || ($id && is_null($config)));
+        return ($cfg->require2FAForAgents() && !$id || ($id && empty($config)));
     }
 
     function getDepartments() {

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1352,6 +1352,14 @@ extends AbstractForm {
                     new Q(array('welcome_email' => false)),
                     VisibilityConstraint::HIDDEN
                 ),
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
             'passwd2' => new PasswordField(array(
                 'placeholder' => __('Confirm Password'),
@@ -1363,6 +1371,14 @@ extends AbstractForm {
                     new Q(array('welcome_email' => false)),
                     VisibilityConstraint::HIDDEN
                 ),
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
             'change_passwd' => new BooleanField(array(
                 'default' => true,
@@ -1399,10 +1415,26 @@ extends AbstractForm {
                 'label' => __('Enter a new password'),
                 'placeholder' => __('New Password'),
                 'required' => true,
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
             'passwd2' => new PasswordField(array(
                 'placeholder' => __('Confirm Password'),
                 'required' => true,
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
             )),
         );
 
@@ -1589,6 +1621,14 @@ extends AbstractForm {
                 'configuration' => array(
                     'placeholder' => __("Temporary Password"),
                 ),
+                'validator' => '',
+                'validators' => function($self, $v) {
+                    try {
+                        Staff::checkPassword($v, null);
+                    } catch (BadPassword $ex) {
+                        $self->addError($ex->getMessage());
+                    }
+                },
                 'visibility' => new VisibilityConstraint(
                     new Q(array('welcome_email' => false))
                 ),

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1273,10 +1273,13 @@ class UserAccount extends VerySimpleModel {
         if ($vars['passwd1'] || $vars['passwd2']) {
             if (!$vars['passwd1'])
                 $errors['passwd1'] = __('New password is required');
-            elseif ($vars['passwd1'] && strlen($vars['passwd1'])<6)
-                $errors['passwd1'] = __('Must be at least 6 characters');
-            elseif ($vars['passwd1'] && strcmp($vars['passwd1'], $vars['passwd2']))
-                $errors['passwd2'] = __('Passwords do not match');
+            else {
+                try {
+                    self::checkPassword($vars['passwd1']);
+                } catch (BadPassword $ex) {
+                    $errors['passwd1'] =  $ex->getMessage();
+                }
+            }
         }
 
         // Make sure the username is not an email.
@@ -1359,10 +1362,15 @@ class UserAccount extends VerySimpleModel {
                 && !isset($vars['sendemail'])) {
             if (!$vars['passwd1'])
                 $errors['passwd1'] = 'Temporary password required';
-            elseif ($vars['passwd1'] && strlen($vars['passwd1'])<6)
-                $errors['passwd1'] = 'Must be at least 6 characters';
             elseif ($vars['passwd1'] && strcmp($vars['passwd1'], $vars['passwd2']))
                 $errors['passwd2'] = 'Passwords do not match';
+            else {
+                try {
+                    self::checkPassword($vars['passwd1']);
+                } catch (BadPassword $ex) {
+                    $errors['passwd1'] =  $ex->getMessage();
+                }
+            }
         }
 
         if ($errors) return false;
@@ -1395,6 +1403,10 @@ class UserAccount extends VerySimpleModel {
             $account->sendConfirmEmail();
 
         return $account;
+    }
+
+    static function checkPassword($new, $current=null) {
+        osTicketClientAuthentication::checkPassword($new, $current);
     }
 
 }

--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -177,10 +177,26 @@ class StaffSession extends Staff {
         return $staff;
     }
 
+    function clear2FA() {
+        $_SESSION['_auth']['staff']['2fa'] = null;
+        return true;
+    }
+
+    // If 2fa is set then it means it's pending
+    function is2FAPending() {
+        if (!isset($_SESSION['_auth']['staff']['2fa']))
+            return false;
+
+        return true;
+    }
+
     function isValid(){
-        global $_SESSION, $cfg;
+        global $cfg;
 
         if(!$this->getId() || $this->session->getSessionId()!=session_id())
+            return false;
+
+        if ($this->is2FAPending())
             return false;
 
         return $this->session->isvalidSession($this->token,$cfg->getStaffTimeout(),$cfg->enableStaffIPBinding())?true:false;

--- a/include/i18n/en_US/help/tips/dashboard.my_profile.yaml
+++ b/include/i18n/en_US/help/tips/dashboard.my_profile.yaml
@@ -27,6 +27,14 @@ username:
       - title: Change a username as an Administrator
         href: /scp/staff.php
 
+config2fa:
+    title: Two Factor Authentication
+    content: >
+        Two Factor Authentication adds an extra layer of security
+        when logging into the helpdesk. Once you correctly submit
+        your username and password, you will need to enter a token
+        to finish logging into the helpdesk.
+
 time_zone:
     title: Time Zone
     content: >
@@ -83,11 +91,11 @@ confirm_new_password:
 signature:
     title: Signature
     content: >
-        Create an optional <span class="doc-desc-title">Signature</span> 
-        that perhaps appears at the end of your Ticket Responses. Whether this 
-        <span class="doc-desc-title">Signature</span> appears, or not, depends 
-        on the <span class="doc-desc-title">Email Template</span> that will be 
-        used in a Ticket Response. 
+        Create an optional <span class="doc-desc-title">Signature</span>
+        that perhaps appears at the end of your Ticket Responses. Whether this
+        <span class="doc-desc-title">Signature</span> appears, or not, depends
+        on the <span class="doc-desc-title">Email Template</span> that will be
+        used in a Ticket Response.
     links:
       - title: Create Emails Templates in the Admin Panel
         href: /scp/templates.php

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -39,19 +39,12 @@ disable_agent_collabs:
         This setting is global for all User created Tickets via API, Piping, and Fetching.
 
 # Authentication settings
-password_reset:
-    title: Password Expiration Policy
+agent_password_policy:
+    title: Password Management Policy
     content: >
-        Sets how often (in months) Agents will be required to change
-        their password. If disabled (set to "No expiration"), passwords will
-        not expire.
-
-password_expiration_policy:
-    title: Password Expiration Policy
-    content: >
-        Choose how often Agents will be required to change their password. If
-        disabled (i.e., <span class="doc-desc-opt">No Expiration</span>), passwords
-        will not expire.
+        Chose a <span class="doc-desc-title">Password Policy</span> for <span class="doc-desc-title">Agents</span>.
+        <br><br>
+        Additional policies can be added by installing <span class="doc-desc-title">Password Policy</span> plugins.
 
 allow_password_resets:
     title: Allow Password Resets

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -78,3 +78,11 @@ bind_staff_session_to_ip:
         upon Log In.
         <br><br>
         This setting is not recommened for users assigned IP addresses dynamically.
+
+require_agent_2fa:
+     title: Require Two Factor Authentication
+     content: >
+         Enable this feature if you would like to have an extra layer of authentication
+         set up for Agents when they log into the helpdesk. Once they correctly submit
+         their username and password, they will be required to submit a token to finish
+         logging into the helpdesk.

--- a/include/i18n/en_US/help/tips/settings.users.yaml
+++ b/include/i18n/en_US/help/tips/settings.users.yaml
@@ -21,6 +21,13 @@ client_name_format:
         will use it for names if no other format is specified.
 
 # Authentication settings
+client_password_policy:
+    title: Password Management Policy
+    content: >
+        Chose a <span class="doc-desc-title">Password Policy</span> for <span class="doc-desc-title">Users</span>.
+        <br><br>
+        Additional policies can be added by installing <span class="doc-desc-title">Password Policy</span> plugins.
+
 client_session_timeout:
     title: User Session Timeout
     content: >

--- a/include/i18n/en_US/help/tips/staff.agent.yaml
+++ b/include/i18n/en_US/help/tips/staff.agent.yaml
@@ -20,6 +20,14 @@ username:
         that is unique to your <span class="doc-desc-title">Help
         Desk</span>.
 
+reset2fa:
+    title: Reset Two Factor Authentication
+    content: >
+        In the event that an Agent loses the ability to log into the helpdesk
+        using their current 2FA configuration, an Admin can reset the Agent's
+        2FA configuration so that they can reconfigure it upon their next
+        successful login.
+
 email_address:
     title: Email Address
     content: >

--- a/include/i18n/en_US/templates/page/email2fa-staff.yaml
+++ b/include/i18n/en_US/templates/page/email2fa-staff.yaml
@@ -1,0 +1,24 @@
+#
+# email2fa-staff.yaml
+#
+# Template of the email sent to staff members when using the Email
+# Two Factor Authentication
+---
+notes: >
+    This template defines the email sent to Staff who use Email for
+    Two Factor Authentication
+name: "osTicket Two Factor Authentication"
+body: >
+    <h3><strong>Hi %{staff.name.first},</strong></h3>
+    <div>
+    You have just logged into for the helpdesk at %{url}.<br />
+    <br />
+    Use the verification code below to finish logging into the helpdesk.<br />
+    <br />
+    %{otp}<br />
+    <br />
+    <em style="font-size: small">Your friendly Customer Support System</em>
+    <br />
+    <img src="cid:b56944cb4722cc5cda9d1e23a3ea7fbc" alt="Powered by
+    osTicket" width="126" height="19" style="width: 126px" />
+    </div>

--- a/include/staff/login.tpl.php
+++ b/include/staff/login.tpl.php
@@ -1,6 +1,11 @@
 <?php
 include_once(INCLUDE_DIR.'staff/login.header.php');
 $info = ($_POST && $errors)?Format::htmlchars($_POST):array();
+
+
+if ($thisstaff && $thisstaff->is2FAPending())
+    $msg = "2FA Pending";
+
 ?>
 <div id="brickwall"></div>
 <div id="loginBox">
@@ -14,21 +19,39 @@ $info = ($_POST && $errors)?Format::htmlchars($_POST):array();
     <h3 id="login-message"><?php echo Format::htmlchars($msg); ?></h3>
     <div class="banner"><small><?php echo ($content) ? Format::display($content->getLocalBody()) : ''; ?></small></div>
     <form action="login.php" method="post" id="login" onsubmit="attemptLoginAjax(event)">
-        <?php csrf_token(); ?>
-        <input type="hidden" name="do" value="scplogin">
-        <fieldset>
-        <input type="text" name="userid" id="name" value="<?php
-            echo $info['userid']; ?>" placeholder="<?php echo __('Email or Username'); ?>"
-            autofocus autocorrect="off" autocapitalize="off">
-        <input type="password" name="passwd" id="pass" placeholder="<?php echo __('Password'); ?>" autocorrect="off" autocapitalize="off">
-            <h3 style="display:inline"><a id="reset-link" class="<?php
-                if (!$show_reset || !$cfg->allowPasswordReset()) echo 'hidden';
-                ?>" href="pwreset.php"><?php echo __('Forgot My Password'); ?></a></h3>
-            <button class="submit button pull-right" type="submit"
+        <?php csrf_token();
+        if ($thisstaff
+                &&  $thisstaff->is2FAPending()
+                && ($bk=$thisstaff->get2FABackend())
+                && ($form=$bk->getInputForm($_POST))) {
+            // Render 2FA input form
+            include STAFFINC_DIR . 'templates/dynamic-form-simple.tmpl.php';
+            ?>
+            <fieldset style="padding-top:10px;">
+            <input type="hidden" name="do" value="2fa">
+            <button class="submit button pull-center" type="submit"
                 name="submit"><i class="icon-signin"></i>
-                <?php echo __('Log In'); ?>
+                <?php echo __('Verify'); ?>
             </button>
-        </fieldset>
+             </fieldset>
+        <?php
+        } else { ?>
+            <input type="hidden" name="do" value="scplogin">
+            <fieldset>
+            <input type="text" name="userid" id="name" value="<?php
+                echo $info['userid']; ?>" placeholder="<?php echo __('Email or Username'); ?>"
+                autofocus autocorrect="off" autocapitalize="off">
+            <input type="password" name="passwd" id="pass" placeholder="<?php echo __('Password'); ?>" autocorrect="off" autocapitalize="off">
+                <h3 style="display:inline"><a id="reset-link" class="<?php
+                    if (!$show_reset || !$cfg->allowPasswordReset()) echo 'hidden';
+                    ?>" href="pwreset.php"><?php echo __('Forgot My Password'); ?></a></h3>
+                <button class="submit button pull-right" type="submit"
+                    name="submit"><i class="icon-signin"></i>
+                    <?php echo __('Log In'); ?>
+                </button>
+            </fieldset>
+        <?php
+        } ?>
     </form>
 <?php
 $ext_bks = array();
@@ -101,12 +124,14 @@ if (count($ext_bks)) { ?>
         var form = $(e.target),
             data = objectifyForm(form.serializeArray())
         data.ajax = 1;
+        $('button[type=submit]', form).attr('disabled', 'disabled');
         $.ajax({
             url: form.attr('action'),
             method: 'POST',
             data: data,
             cache: false,
             success: function(json) {
+                 $('button[type=submit]', form).removeAttr('disabled');
                 if (!typeof(json) === 'object' || !json.status)
                     return;
                 switch (json.status) {

--- a/include/staff/login.tpl.php
+++ b/include/staff/login.tpl.php
@@ -18,6 +18,10 @@ if ($thisstaff && $thisstaff->is2FAPending())
     </a></h1>
     <h3 id="login-message"><?php echo Format::htmlchars($msg); ?></h3>
     <div class="banner"><small><?php echo ($content) ? Format::display($content->getLocalBody()) : ''; ?></small></div>
+    <div id="loading" style="display:none;" class="dialog">
+        <h1><i class="icon-spinner icon-spin icon-large"></i>
+        <?php echo __('Loading');?></h1>
+    </div>
     <form action="login.php" method="post" id="login" onsubmit="attemptLoginAjax(event)">
         <?php csrf_token();
         if ($thisstaff
@@ -87,6 +91,7 @@ if (count($ext_bks)) { ?>
     });
 
     function attemptLoginAjax(e) {
+        $('#loading').show();
         var objectifyForm = function(formArray) { //serialize data function
             var returnArray = {};
             for (var i = 0; i < formArray.length; i++) {
@@ -101,6 +106,7 @@ if (count($ext_bks)) { ?>
             var oldEffect = $.fn.effect;
             $.fn.effect = function (effectName) {
                 if (effectName === "shake") {
+                    $('#loading').hide();
                     var old = $.effects.createWrapper;
                     $.effects.createWrapper = function (element) {
                         var result;

--- a/include/staff/login.tpl.php
+++ b/include/staff/login.tpl.php
@@ -20,7 +20,7 @@ if ($thisstaff && $thisstaff->is2FAPending())
     <div class="banner"><small><?php echo ($content) ? Format::display($content->getLocalBody()) : ''; ?></small></div>
     <div id="loading" style="display:none;" class="dialog">
         <h1><i class="icon-spinner icon-spin icon-large"></i>
-        <?php echo __('Loading');?></h1>
+        <?php echo __('Verifying');?></h1>
     </div>
     <form action="login.php" method="post" id="login" onsubmit="attemptLoginAjax(event)">
         <?php csrf_token();

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -121,6 +121,49 @@ if ($avatar->isChangeable()) { ?>
             <div class="error"><?php echo $errors['username']; ?></div>
           </td>
         </tr>
+
+<?php
+if (($bks=Staff2FABackend::allRegistered())) {
+    $current = $staff->get2FABackendId();
+    $required2fa = $cfg->require2FAForAgents();
+    $_config = $staff->getConfig();
+?>
+        <tr>
+          <td <?php if ($required2fa) echo 'class="required"'; ?>><?php echo __('Default 2FA'); ?>:</td>
+          <td>
+            <select name="default_2fa" id="default2fa-selection"
+              style="width:300px">
+              <?php
+              if (!$required2fa) { ?>
+              <option value="">&mdash; <?php echo __('Disable'); ?> &mdash;</option>
+              <?php
+              }
+             foreach ($bks as $bk) {
+                 $configured = (isset($_config[$bk->getId()]) &&
+                     $_config[$bk->getId()]['verified']);
+                 ?>
+              <option value="<?php echo $bk->getId(); ?>" <?php
+                if ($current == $bk->getId() && $configured)
+                  echo ' selected="selected" '; ?>
+                <?php
+                if (!$configured)
+                   echo ' disabled="disabled" '; ?>
+                 ><?php
+                echo $bk->getName(); ?></option>
+             <?php } ?>
+            </select>
+            &nbsp;
+            <button type="button" id="config2fa-button" class="action-button" onclick="javascript:
+            $.dialog('ajax.php/staff/'+<?php echo $staff->getId();
+                    ?>+'/2fa/configure', 201);">
+              <i class="icon-gear"></i> <?php echo __('Configure Options'); ?>
+            </button>
+            <i class="offset help-tip icon-question-sign" href="#config2fa"></i>
+            <div class="error"><?php echo $errors['default_2fa']; ?></div>
+          </td>
+        </tr>
+<?php
+} ?>
       </tbody>
       <!-- ================================================ -->
       <tbody>

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -139,7 +139,8 @@ if (($bks=Staff2FABackend::allRegistered())) {
               <?php
               }
              foreach ($bks as $bk) {
-                 $configured = $staff->is2FAConfigured($bk->getId());
+                 $configuration = $staff->get2FAConfig($bk->getId());
+                 $configured = $configuration['verified'];
                  ?>
               <option id="<?php echo $bk->getId(); ?>"
                       value="<?php echo $bk->getId(); ?>" <?php

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -139,8 +139,7 @@ if (($bks=Staff2FABackend::allRegistered())) {
               <?php
               }
              foreach ($bks as $bk) {
-                 $configured = (isset($_config[$bk->getId()]) &&
-                     $_config[$bk->getId()]['verified']);
+                 $configured = $staff->is2FAConfigured($bk->getId());
                  ?>
               <option id="<?php echo $bk->getId(); ?>"
                       value="<?php echo $bk->getId(); ?>" <?php

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -142,7 +142,8 @@ if (($bks=Staff2FABackend::allRegistered())) {
                  $configured = (isset($_config[$bk->getId()]) &&
                      $_config[$bk->getId()]['verified']);
                  ?>
-              <option value="<?php echo $bk->getId(); ?>" <?php
+              <option id="<?php echo $bk->getId(); ?>"
+                      value="<?php echo $bk->getId(); ?>" <?php
                 if ($current == $bk->getId() && $configured)
                   echo ' selected="selected" '; ?>
                 <?php

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -83,20 +83,23 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                         </th>
                     </tr>
                     <tr>
-                        <td><?php echo __('Password Expiration Policy'); ?>:</td>
+                        <td><?php echo __('Password Policy'); ?>:</td>
                         <td>
-                            <select name="passwd_reset_period">
-                            <option value="0"> &mdash; <?php echo __('No expiration'); ?> &mdash;</option>
+                            <select name="agent_passwd_policy">
+                            <option value=" "> &mdash; <?php echo __('All Active Policies'); ?> &mdash;</option>
                             <?php
-                                for ($i = 1; $i <= 12; $i++) {
-                                echo sprintf('<option value="%d" %s>%s</option>',
-                                    $i,(($config['passwd_reset_period']==$i)?'selected="selected"':''),
-                                    sprintf(_N('Monthly', 'Every %d months', $i), $i));
+                                foreach (PasswordPolicy::allActivePolicies()
+                                        as $P) {
+                                echo sprintf('<option value="%s" %s>%s</option>',
+                                    $P::$id,
+                                    (($config['agent_passwd_policy'] == $P::$id) ? 'selected="selected"' : ''),
+                                    $P->getName());
                                 }
                             ?>
                             </select>
-                            <font class="error"><?php echo $errors['passwd_reset_period']; ?></font>
-                            <i class="help-tip icon-question-sign" href="#password_expiration_policy"></i>
+                            <font class="error"><?php echo
+                            $errors['agent_passwd_policy']; ?></font>
+                            <i class="help-tip icon-question-sign" href="#agent_password_policy"></i>
                         </td>
                     </tr>
                     <tr>

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -120,6 +120,19 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                         </td>
                     </tr>
                     <tr>
+                        <td><?php echo __('Multifactor Authentication'); ?>:</td>
+                        <td>
+                            <input type="checkbox" name="require_agent_2fa" <?php
+                            echo $config['require_agent_2fa'] ? 'checked="checked"' : ''; ?>>
+                            &nbsp;
+                            <?php
+                            echo __('Require agents to turn on 2FA');
+                            ?>
+                            &nbsp;<i class="help-tip icon-question-sign"
+                            href="#require_agent_2fa"></i>
+                        </td>
+                    </tr>
+                    <tr>
                         <td><?php echo __('Agent Excessive Logins'); ?>:</td>
                         <td>
                             <select name="staff_max_logins">

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -223,6 +223,7 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                     <?php $manage_content(__('Agent Welcome Email'), 'registration-staff'); ?>
                     <?php $manage_content(__('Sign-in Login Banner'), 'banner-staff'); ?>
                     <?php $manage_content(__('Password Reset Email'), 'pwreset-staff'); ?>
+                    <?php $manage_content(__('Two Factor Authentication Email'), 'email2fa-staff'); ?>
                 </tbody>
             </table>
         </div>

--- a/include/staff/settings-users.inc.php
+++ b/include/staff/settings-users.inc.php
@@ -89,6 +89,26 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config)
             <i class="help-tip icon-question-sign" href="#registration_method"></i>
             </td>
         </tr>
+		<tr>
+			<td><?php echo __('Password Policy'); ?>:</td>
+			<td>
+				<select name="client_passwd_policy">
+				<option value=" "> &mdash; <?php echo __('All Active Policies'); ?> &mdash;</option>
+				<?php
+					foreach (PasswordPolicy::allActivePolicies()
+							as $P) {
+					echo sprintf('<option value="%s" %s>%s</option>',
+						$P::$id,
+						(($config['client_passwd_policy'] == $P::$id) ? 'selected="selected"' : ''),
+						$P->getName());
+					}
+				?>
+				</select>
+				<font class="error"><?php echo
+				$errors['client_passwd_policy']; ?></font>
+				<i class="help-tip icon-question-sign" href="#client_password_policy"></i>
+			</td>
+		</tr>
         <tr><td><?php echo __('User Excessive Logins'); ?>:</td>
             <td>
                 <select name="client_max_logins">

--- a/include/staff/staff.inc.php
+++ b/include/staff/staff.inc.php
@@ -163,6 +163,35 @@ if (count($bks) > 1) {
         </tr>
 <?php
 } ?>
+<?php
+if ($bks=Staff2FABackend::allRegistered() && $current = $staff->get2FABackend()) {
+    $_config = $staff->getConfig();
+?>
+        <tr>
+          <td><?php echo __('Default 2FA'); ?>:</td>
+          <td>
+              <input type="text" size="40" style="width:300px"
+                name="default_2fa" disabled value="<?php echo $current->getName(); ?>" />
+            &nbsp;
+            <button type="button" id="reset-2fa" class="action-button" onclick="javascript:
+                if (confirm('<?php echo __('You sure?'); ?>')) {
+                    $.ajax({
+                        url: 'ajax.php/staff/'+<?php echo $staff->getId(); ?>+'/reset-2fa',
+                        type: 'POST',
+                        data: {'staffId':<?php echo $staff->getId(); ?>},
+                        success: function(data) {
+                            location.reload();
+                        }
+                    });
+                }
+                return false;">
+              <i class="icon-gear"></i> <?php echo __('Reset 2FA'); ?>
+            </button>
+            <i class="offset help-tip icon-question-sign" href="#reset2fa"></i>
+          </td>
+        </tr>
+<?php
+} ?>
       </tbody>
       <!-- ================================================ -->
       <tbody>

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -19,15 +19,10 @@ if ($info['error']) {
     <tbody>
       <?php
       foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
-          if ($isVerified = $staff->is2FAConfigured($bk->getId())) {
-          ?>
-          <script type="text/javascript">
-              isVerified = '<?php echo $isVerified;?>';
-              id = '<?php echo $id;?>';
-              enable2fa(isVerified, id);
-          </script>
-          <?php } ?>
-      <tr id="<?php echo $bk->getId(); ?>">
+          $configuration = $staff->get2FAConfig($bk->getId());
+          $isVerified = $configuration['verified'];
+          $vclass = $isVerified ? 'verified' : 'unverified'; ?>
+      <tr id="<?php echo $bk->getId(); ?>" class="2fa-type <?php echo $vclass; ?>">
         <td nowrap width="10px">
           <i class="faded-more <?php echo sprintf('icon-check-%s',
           $isVerified ? 'sign' : 'empty'); ?>"></i>
@@ -84,11 +79,12 @@ if ($auth && $form) {
 </div>
 <div class="clear"></div>
 <script type="text/javascript">
-function enable2fa(isVerified, id) {
-    document.getElementById(id).disabled=false;
-}
-
 $(function() {
+    var ids = $('.verified').map(function() {
+        id2fa = $(this).attr('id');
+        document.getElementById(id2fa).disabled=false;
+    });
+
     $('a.config2fa').click( function(e) {
         e.preventDefault();
         if ($(this).attr('href').length > 1) {

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -18,11 +18,8 @@ if ($info['error']) {
 <table class="table">
     <tbody>
       <?php
-      $config = $staff->getConfig();
       foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
-          $isVerified = (isset($config[$bk->getId()]) &&
-                  $config[$bk->getId()]['verified']);
-          if ($isVerified) {
+          if ($isVerified = $staff->is2FAConfigured($bk->getId())) {
           ?>
           <script type="text/javascript">
               isVerified = '<?php echo $isVerified;?>';
@@ -89,7 +86,6 @@ if ($auth && $form) {
 <script type="text/javascript">
 function enable2fa(isVerified, id) {
     document.getElementById(id).disabled=false;
-    document.getElementById(id).selected=true;
 }
 
 $(function() {

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -22,7 +22,14 @@ if ($info['error']) {
       foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
           $isVerified = (isset($config[$bk->getId()]) &&
                   $config[$bk->getId()]['verified']);
+          if ($isVerified) {
           ?>
+          <script type="text/javascript">
+              isVerified = '<?php echo $isVerified;?>';
+              id = '<?php echo $id;?>';
+              enable2fa(isVerified, id);
+          </script>
+          <?php } ?>
       <tr id="<?php echo $bk->getId(); ?>">
         <td nowrap width="10px">
           <i class="faded-more <?php echo sprintf('icon-check-%s',
@@ -30,7 +37,7 @@ if ($info['error']) {
           <span data-name="label"></span>
         </td>
         <td width="300px">
-            <a class="config2fa" 
+            <a class="config2fa"
                 href="<?php echo sprintf('#staff/%d/2fa/configure/%s',
                 $staff->getId(), urlencode($bk->getId())); ?>"> <?php echo $bk->getName(); ?>
               </a>
@@ -55,8 +62,8 @@ if ($auth && $form) {
  <div><?php echo Format::htmlchars($instruction); ?></div>
  <br>
 <form class="bk" method="post" action="<?php echo sprintf('#staff/%d/2fa/configure/%s',
-    $staff->getId(), $auth->getId()); ?>">    
-    <input type="hidden" name="state" value="<?php 
+    $staff->getId(), $auth->getId()); ?>">
+    <input type="hidden" name="state" value="<?php
         echo $state ?: 'validate'; ?>" />
     <?php
     echo csrf_token();
@@ -80,6 +87,11 @@ if ($auth && $form) {
 </div>
 <div class="clear"></div>
 <script type="text/javascript">
+function enable2fa(isVerified, id) {
+    document.getElementById(id).disabled=false;
+    document.getElementById(id).selected=true;
+}
+
 $(function() {
     $('a.config2fa').click( function(e) {
         e.preventDefault();
@@ -107,4 +119,3 @@ $(function() {
 
 });
 </script>
-

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -1,0 +1,110 @@
+<?php
+$title = __('Manage 2FA Options');
+if ($auth)
+    $title = sprintf('%s %s %s', $auth->getName(), '2FA', __('Setup'));
+?>
+<h3 class="drag-handle"><?php echo $title; ?></h3>
+<a class="close" href=""><i class="icon-remove-circle"></i></a>
+<hr/>
+<?php
+if ($info['error']) {
+    echo sprintf('<p id="msg_error">%s</p>', $info['error']);
+} elseif ($info['warning']) {
+    echo sprintf('<p id="msg_warning">%s</p>', $info['warning']);
+} elseif ($info['notice']) {
+    echo sprintf('<p id="msg_notice">%s</p>', $info['notice']);
+} ?>
+<div id="backends" <?php if ($auth) echo 'class="hidden"'; ?>>
+<table class="table">
+    <tbody>
+      <?php
+      $config = $staff->getConfig();
+      foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
+          $isVerified = (isset($config[$bk->getId()]) &&
+                  $config[$bk->getId()]['verified']);
+          ?>
+      <tr id="<?php echo $bk->getId(); ?>">
+        <td nowrap width="10px">
+          <i class="faded-more <?php echo sprintf('icon-check-%s',
+          $isVerified ? 'sign' : 'empty'); ?>"></i>
+          <span data-name="label"></span>
+        </td>
+        <td width="300px">
+            <a class="config2fa" 
+                href="<?php echo sprintf('#staff/%d/2fa/configure/%s',
+                $staff->getId(), urlencode($bk->getId())); ?>"> <?php echo $bk->getName(); ?>
+              </a>
+              <div align="left" class="faded"><?php
+              echo Format::htmlchars($bk->getDescription()); ?></div>
+        </td>
+      </tr>
+      <?php
+      } ?>
+    </tbody>
+ </table>
+<hr>
+</div>
+<div id="backend" <?php if (!$auth) echo 'class="hidden"'; ?>>
+<?php
+if ($auth && $form) {
+    if ($state == 'verify')
+        $instruction = __('Enter the token sent to you and click Verify');
+    else
+        $instruction = __('Complete the form below and then click Next to verify the setup');
+    ?>
+ <div><?php echo Format::htmlchars($instruction); ?></div>
+ <br>
+<form class="bk" method="post" action="<?php echo sprintf('#staff/%d/2fa/configure/%s',
+    $staff->getId(), $auth->getId()); ?>">    
+    <input type="hidden" name="state" value="<?php 
+        echo $state ?: 'validate'; ?>" />
+    <?php
+    echo csrf_token();
+    include STAFFINC_DIR . 'templates/dynamic-form-simple.tmpl.php';
+    ?>
+    <br>
+    <hr>
+    <p class="full-width">
+        <span class="buttons pull-left">
+            <input type="reset" value="<?php echo __('Reset'); ?>">
+            <input type="button" name="close" value="<?php echo __('Cancel'); ?>" class="close">
+        </span>
+        <span class="buttons pull-right">
+            <input type="submit" value="<?php echo ($state == 'verify') ?
+            __('Verify') : __('Next'); ?>">
+        </span>
+    </p>
+ </form>
+ <?php
+} ?>
+</div>
+<div class="clear"></div>
+<script type="text/javascript">
+$(function() {
+    $('a.config2fa').click( function(e) {
+        e.preventDefault();
+        if ($(this).attr('href').length > 1) {
+            var url = 'ajax.php/'+$(this).attr('href').substr(1);
+            $.dialog(url, [201, 204], function (xhr) {
+                window.location.href = window.location.href;
+            }, {
+                onshow: function() { $('#user-search').focus(); }
+            });
+        } else {
+            $('div#backends').hide();
+            $('div#backend').fadeIn();
+        }
+        return false;
+     });
+
+    $(document).on('click', 'input.close', function (e) {
+        e.preventDefault();
+        alert('Alert');
+        $('div#backend').hide();
+        $('div#backends').fadeIn();
+        return false;
+     });
+
+});
+</script>
+

--- a/include/staff/templates/navigation.tmpl.php
+++ b/include/staff/templates/navigation.tmpl.php
@@ -1,5 +1,5 @@
 <?php
-if(($tabs=$nav->getTabs()) && is_array($tabs)){
+if($nav && ($tabs=$nav->getTabs()) && is_array($tabs)){
     foreach($tabs as $name =>$tab) {
         if ($tab['href'][0] != '/')
             $tab['href'] = ROOT_PATH . 'scp/' . $tab['href'];

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -292,7 +292,8 @@ $dispatcher = patterns('',
         url_get('^/(?P<id>\d+)/perms', 'getAgentPerms'),
         url('^/reset-permissions', 'resetPermissions'),
         url('^/change-department', 'changeDepartment'),
-        url('^/(?P<id>\d+)/avatar/change', 'setAvatar')
+        url('^/(?P<id>\d+)/avatar/change', 'setAvatar'),
+        url('^/(?P<id>\d+)/2fa/configure(?:/(?P<mfid>.+))?$', 'configure2FA')
     )),
     url('^/queue/', patterns('ajax.search.php:SearchAjaxAPI',
         url('^(?P<id>\d+/)?preview$', 'previewQueue'),

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -293,7 +293,8 @@ $dispatcher = patterns('',
         url('^/reset-permissions', 'resetPermissions'),
         url('^/change-department', 'changeDepartment'),
         url('^/(?P<id>\d+)/avatar/change', 'setAvatar'),
-        url('^/(?P<id>\d+)/2fa/configure(?:/(?P<mfid>.+))?$', 'configure2FA')
+        url('^/(?P<id>\d+)/2fa/configure(?:/(?P<mfid>.+))?$', 'configure2FA'),
+        url('^/(?P<id>\d+)/reset-2fa', 'reset2fA')
     )),
     url('^/queue/', patterns('ajax.search.php:SearchAjaxAPI',
         url('^(?P<id>\d+/)?preview$', 'previewQueue'),

--- a/scp/profile.php
+++ b/scp/profile.php
@@ -44,6 +44,15 @@ if($thisstaff->forcePasswdChange() && !$errors['err'])
             $thisstaff->getFirstName()
         )
     );
+elseif($thisstaff->force2faConfig() && !$errors['err'])
+    $errors['err'] = str_replace(
+        '<a>',
+        sprintf('<a data-dialog="ajax.php/staff/%d/2fa/configure" href="#">', $thisstaff->getId()),
+        sprintf(
+            __('<b>Hi %s</b> - You must <a>configure and save Two Factor Authentication </a>!'),
+            $thisstaff->getFirstName()
+        )
+    );
 elseif($thisstaff->onVacation() && !$warn)
     $warn=sprintf(__("<b>Welcome back %s</b>! You are listed as 'on vacation' Please let your manager know that you are back."),$thisstaff->getFirstName());
 

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -136,6 +136,10 @@ if($thisstaff->forcePasswdChange() && !$exempt) {
     $sysnotice = __('Password change required to continue');
     require('profile.php'); //profile.php must request this file as require_once to avoid problems.
     exit;
+} elseif ($thisstaff->force2faConfig() && !$exempt) {
+    $sysnotice = __('Two Factor Authentication configuration required to continue');
+    require('profile.php');
+    exit;
 }
 $ost->setWarning($sysnotice);
 $ost->setPageTitle(__('osTicket :: Staff Control Panel'));


### PR DESCRIPTION
This PR rewrites and  borrows from work done by @aydreeihn in PR #5538. Main highlights being -  adding  true 2FA Backends as opposed to piggybacking on Authentication Backends and smoother integration to the login process.

TODO:

- [x] Add email template for email-2fa to Admin Panel > Setting > Agents > Templates
- [x] Add tooltips as needed
- [x] Add docs on how the feature works
- [x] Bug fixes 

