### PR TITLE
i18n: Redactor Files Not Included

### DIFF
--- a/include/cli/modules/i18n.php
+++ b/include/cli/modules/i18n.php
@@ -209,9 +209,9 @@ class i18n_Compiler extends Module {
             $langs[] = $short;
         }
         foreach ($langs as $l) {
-            if (file_exists(I18N_DIR . "vendor/redactor{$lang}.js")) {
+            if (file_exists(I18N_DIR . "vendor/redactor/{$lang}.js")) {
                 $phar->addFromString('js/redactor.js', file_get_contents(
-                    I18N_DIR . "support/redactor/{$lang}.js"));
+                    I18N_DIR . "vendor/redactor/{$lang}.js"));
                 break;
             }
         }


### PR DESCRIPTION
This addresses an issue where upon building the language packs, the Redactor i18n files are not included. This is due to the wrong file paths being used to check if the file exists and to get the file contents. This updates all the file paths to point to the correct directory.