### PR TITLE
issue: Get Team Members For Alerts

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -849,7 +849,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
             if ($cfg->alertStaffONTaskAssignment())
                 $recipients[] = $assignee;
         } elseif (($assignee instanceof Team) && $assignee->alertsEnabled()) {
-            if ($cfg->alertTeamMembersONTaskAssignment() && ($members=$assignee->getMembers()))
+            if ($cfg->alertTeamMembersONTaskAssignment() && ($members=$assignee->getMembersForAlerts()))
                 $recipients = array_merge($recipients, $members);
             elseif ($cfg->alertTeamLeadONTaskAssignment() && ($lead=$assignee->getTeamLead()))
                 $recipients[] = $lead;
@@ -936,7 +936,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                     $recipients[] = $this->getStaff();
                 elseif ($this->getTeamId()
                     && ($team=$this->getTeam())
-                    && ($members=$team->getMembers())
+                    && ($members=$team->getMembersForAlerts())
                 ) {
                     $recipients = array_merge($recipients, $members);
                 }
@@ -1209,7 +1209,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                 $recipients[] = $assignee;
 
             if ($team = $this->getTeam())
-                $recipients = array_merge($recipients, $team->getMembers());
+                $recipients = array_merge($recipients, $team->getMembersForAlerts());
         }
 
         // Dept manager

--- a/include/class.team.php
+++ b/include/class.team.php
@@ -88,6 +88,17 @@ implements TemplateVariable {
         return $this->_members;
     }
 
+    function getMembersForAlerts() {
+        $alertmembers = array();
+        $members = $this->members->filter(array(
+            'flags__hasbit' => TeamMember::FLAG_ALERTS,
+        ));
+        foreach ($members as $m)
+            $alertmembers[] = $m->staff;
+
+        return $alertmembers;
+    }
+
     function hasMember($staff) {
         return $this->members
             ->filter(array('staff_id'=>$staff->getId()))

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1704,7 +1704,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     && ($acct_manager = $org->getAccountManager())
                 ) {
                     if ($acct_manager instanceof Team)
-                        $recipients = array_merge($recipients, $acct_manager->getMembers());
+                        $recipients = array_merge($recipients, $acct_manager->getMembersForAlerts());
                     else
                         $recipients[] = $acct_manager;
                 }
@@ -1964,7 +1964,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 $recipients[] = $assignee;
 
             if ($team = $this->getTeam())
-                $recipients = array_merge($recipients, $team->getMembers());
+                $recipients = array_merge($recipients, $team->getMembersForAlerts());
         }
 
         // Dept manager
@@ -2057,7 +2057,7 @@ implements RestrictedAccess, Threadable, Searchable {
             if ($cfg->alertStaffONAssignment())
                 $recipients[] = $assignee;
         } elseif (($assignee instanceof Team) && $assignee->alertsEnabled()) {
-            if ($cfg->alertTeamMembersONAssignment() && ($members=$assignee->getMembers()))
+            if ($cfg->alertTeamMembersONAssignment() && ($members=$assignee->getMembersForAlerts()))
                 $recipients = array_merge($recipients, $members);
             elseif ($cfg->alertTeamLeadONAssignment() && ($lead=$assignee->getTeamLead()))
                 $recipients[] = $lead;
@@ -2124,7 +2124,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 }
                 elseif ($this->getTeamId()
                     && ($team = $this->getTeam())
-                    && ($members = $team->getMembers())
+                    && ($members = $team->getMembersForAlerts())
                 ) {
                     $recipients=array_merge($recipients, $members);
                 }
@@ -2705,7 +2705,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     $recipients[] = $this->getStaff();
                 elseif ($this->getTeamId()
                     && ($team=$this->getTeam())
-                    && ($members=$team->getMembers())
+                    && ($members=$team->getMembersForAlerts())
                 ) {
                     $recipients = array_merge($recipients, $members);
                 }
@@ -3184,7 +3184,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 if ($staff = $ticket->getStaff())
                     $recipients[] = $staff;
                 elseif ($team = $ticket->getTeam())
-                    $recipients = array_merge($recipients, $team->getMembers());
+                    $recipients = array_merge($recipients, $team->getMembersForAlerts());
             }
 
             // Dept manager
@@ -3200,7 +3200,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     && ($org = $this->getOwner()->getOrganization())
                     && ($acct_manager = $org->getAccountManager())) {
                 if ($acct_manager instanceof Team)
-                    $recipients = array_merge($recipients, $acct_manager->getMembers());
+                    $recipients = array_merge($recipients, $acct_manager->getMembersForAlerts());
                 else
                     $recipients[] = $acct_manager;
             }


### PR DESCRIPTION
This addresses an issue where when sending Alerts to Team Members, we grab all Members regardless of if they have the Alerts checkbox Enabled or not. This adds a new method called `getMembersForAlerts()` that will retrieve a list of all Team Members that have the Alerts checkbox Enabled. This updates all of the `getMembers()` calls to `getMembersForAlerts()` when sending Alerts.