### PR TITLE
oops: Change lastupdate To updated For Tasks

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1438,7 +1438,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                     $_errors, $thisstaff, false);
         }
 
-        $this->lastupdate = SqlFunction::NOW();
+        $this->updated = SqlFunction::NOW();
 
         $this->save();
 


### PR DESCRIPTION
This addresses a small issue where we are using the wrong column name of `lastupdate` to update the Task’s last updated date. This updates `lastupdate` to `updated` so the column is updated correctly.