### PR TITLE
issue: Track Fields Disabled By System Default Help Topic

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4140,25 +4140,7 @@ implements RestrictedAccess, Threadable, Searchable {
             // entries, disable and track the requested disabled fields.
             if ($vars['topicId']) {
                 if ($__topic=Topic::lookup($vars['topicId'])) {
-                    foreach ($__topic->getForms() as $index=>$topicForm) {
-                        $disabled = self::getDisabledFields($topicForm);
-                        // Special handling for the ticket form — disable fields
-                        // requested to be disabled as per the help topic.
-                        if ($topicForm->get('type') == 'T') {
-                            $formId = $topicForm->getId();
-                            self::setDisabledFields($disabled[$formId], $form);
-                            $form->sort = $index;
-                        }
-                        else {
-                            $topicForm = $topicForm->instanciate($index);
-                            $topicForm->setSource($vars);
-                            $topic_forms[] = $topicForm;
-                        }
-                        // Track fields currently disabled
-                        $topicForm->extra = JsonDataEncoder::encode(array(
-                            'disable' => call_user_func_array('array_merge', $disabled)
-                        ));
-                    }
+                    $topic_forms = $__topic->trackDisabledFields($form);
                 }
             }
 
@@ -4289,6 +4271,8 @@ implements RestrictedAccess, Threadable, Searchable {
             // This may return NULL, no big deal
             $topic = $cfg->getDefaultTopic();
         }
+        if ($topic)
+            $topic->trackDisabledFields($form);
 
         // Intenal mapping magic...see if we need to override anything
         if (isset($topic)) {

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -183,6 +183,26 @@ implements TemplateVariable, Searchable {
         return $this->_forms;
     }
 
+    function trackDisabledFields($form=null) {
+        foreach ($this->getForms() as $index=>$topicForm) {
+            $disabled = Ticket::getDisabledFields($topicForm);
+            // Special handling for the ticket form — disable fields
+            // requested to be disabled as per the help topic.
+            if ($topicForm->get('type') == 'T') {
+                $formId = $topicForm->getId();
+                Ticket::setDisabledFields($disabled[$formId], $form);
+                $form->sort = $index;
+            }
+            else {
+                $topicForm = $topicForm->instanciate($index);
+                $topicForm->setSource($vars);
+                $topic_forms[] = $topicForm;
+            }
+        }
+
+        return $topic_forms;
+    }
+
     function autoRespond() {
         return !$this->noautoresp;
     }

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -183,6 +183,18 @@ implements TemplateVariable, Searchable {
         return $this->_forms;
     }
 
+    function getDisabledFieldsIds() {
+        $disabled = array();
+        foreach ($this->forms->select_related('form') as $form) {
+            $extra = JsonDataParser::decode($form->extra);
+
+            if (!empty($extra['disable']))
+                $disabled[$form->form_id] = $extra['disable'];
+        }
+
+        return $disabled;
+    }
+
     function trackDisabledFields($form=null) {
         foreach ($this->getForms() as $index=>$topicForm) {
             $disabled = Ticket::getDisabledFields($topicForm);

--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -103,13 +103,19 @@ if ($thisclient && $thisclient->isGuest()
 <!-- Custom Data -->
 <?php
 $sections = $forms = array();
+$disabled = $ticket->getTopic()->getDisabledFieldsIds();
 foreach (DynamicFormEntry::forTicket($ticket->getId()) as $i=>$form) {
-    // Skip core fields shown earlier in the ticket view
-    $answers = $form->getAnswers()->exclude(Q::any(array(
+    $q = Q::any(array(
         'field__flags__hasbit' => DynamicFormField::FLAG_EXT_STORED,
         'field__name__in' => array('subject', 'priority'),
         Q::not(array('field__flags__hasbit' => DynamicFormField::FLAG_CLIENT_VIEW)),
-    )));
+    ));
+    // Exclude Disabled Fields
+    if (!empty($disabled[$form->form_id]))
+        $q->add(array('field__id__in' => $disabled[$form->form_id]));
+
+    // Skip core fields shown earlier in the ticket view
+    $answers = $form->getAnswers()->exclude($q);
     // Skip display of forms without any answers
     foreach ($answers as $j=>$a) {
         if ($v = $a->display())


### PR DESCRIPTION
This addresses an issue where Tickets that get assigned the System Default Help Topic (mainly emails) have Disabled Fields (disabled by Help Topic) appear in the Client Portal on Edit. This is due to not running through the Disabling of Fields for the Default Help Topic. This moves the section to track Disabled Fields to a new method called `trackDisabledFields()` in class Topic that can be reused. This also adds a check for the Default Help Topic and if set, we will run through the new method.

This also addresses an issue where having a Field that is Disabled by Help Topic and has a Default Value appears in the Ticket Header in the Client Portal. This is due to the system not checking for Disabled Fields per Help Topic, rather just checking for any entries with values. This adds a check to see if any Fields are Disabled by Help Topic, if so, we will exclude them from the Ticket Header in the Client Portal. This adds a new method called `getDisabledFieldsIds()` that retrieves an array of Form ID and disabled Field IDs (eg. `array(form_id => array(disabled_field_ids))`).