### PR TITLE
issue: Email Template Internal Notes

### DIFF
--- a/include/staff/template.inc.php
+++ b/include/staff/template.inc.php
@@ -78,11 +78,11 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
             uasort($_tpls, function($a,$b) {
                 return strcmp($a['group'].$a['name'], $b['group'].$b['name']);
             });
-         foreach($_tpls as $cn=>$info){
-             if (!$info['name'])
+         foreach($_tpls as $cn=>$i){
+             if (!$i['name'])
                  continue;
-             if (!$current_group || $current_group != $info['group']) {
-                $current_group = $info['group']; ?>
+             if (!$current_group || $current_group != $i['group']) {
+                $current_group = $i['group']; ?>
         <tr>
             <th colspan="2">
             <em><strong><?php echo isset($_groups[$current_group])
@@ -93,15 +93,15 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
 <?php } # end if ($current_group)
             if (isset($impl[$cn])) {
                 echo sprintf('<tr><td colspan="2">&nbsp;<strong><a href="templates.php?id=%d&a=manage">%s</a></strong>, <span class="faded">%s</span><br/>&nbsp;%s</td></tr>',
-                $impl[$cn]->getId(), Format::htmlchars(__($info['name'])),
+                $impl[$cn]->getId(), Format::htmlchars(__($i['name'])),
                 sprintf(__('Updated %s'), Format::datetime($impl[$cn]->getLastUpdated())),
-                Format::htmlchars(__($info['desc'])));
+                Format::htmlchars(__($i['desc'])));
             } else {
                 echo sprintf('<tr><td colspan=2>&nbsp;<strong><a
                     href="templates.php?tpl_id=%d&a=implement&code_name=%s"
                     >%s</a></strong><br/>&nbsp%s</td></tr>',
-                    $template->getid(),$cn,format::htmlchars(__($info['name'])),
-                    format::htmlchars(__($info['desc'])));
+                    $template->getid(),$cn,format::htmlchars(__($i['name'])),
+                    format::htmlchars(__($i['desc'])));
             }
          } # endfor
         } else { ?>


### PR DESCRIPTION
This addresses issue #3796 where adding Internal Notes when creating or updating an Email Template do not appear. This is due to the `$info` variable being overwritten by a `foreach(){}`. This changes the `foreach(){}` variable from `$info` to `$i` so the original `$info` variable is not overwritten.