### PR TITLE
export: Duplicate Results

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -856,6 +856,9 @@ class CustomQueue extends VerySimpleModel {
         else
             $query->order_by('-created');
 
+        // Distinct ticket_id to avoid duplicate results
+        $query->distinct('ticket_id');
+
         // Render Util
         $render = function ($row) use($columns) {
             if (!$row) return false;


### PR DESCRIPTION
This addresses an issue where some complex queue criteria returns duplicate tickets in export results. This adds `distinct('ticket_id')` to the export query to ensure there are no duplicate results.