### PR TITLE
issue: Form Field Help Text Not Null

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -659,7 +659,7 @@ class DynamicFormField extends VerySimpleModel {
         // See if field impl. need to save or override anything
         $config = $this->getImpl()->to_config($config);
         $this->set('configuration', JsonDataEncoder::encode($config));
-        $this->set('hint', Format::sanitize($vars['hint']));
+        $this->set('hint', Format::sanitize($vars['hint']) ?: NULL);
 
         return true;
     }


### PR DESCRIPTION
This addresses a small issue where removing all content from the Help Text portion for a Form Field and Saving Changes shows extra padding between the Field Label and input field on Ticket creation. This is due to when saving the empty content we save as an empty string which is not `NULL`. So when we render the Form Field and grab the Help Text it’s not `NULL` so we display the empty content. This adds a ternary operator when saving the `hint` content that says if there is actual content after sanitizing then save the content otherwise save `NULL`.