### PR TITLE
DynamicField name

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1053,8 +1053,14 @@ implements RestrictedAccess, Threadable, Searchable {
     function getDynamicFieldById($fid) {
         foreach (DynamicFormEntry::forTicket($this->getId()) as $form) {
             foreach ($form->getFields() as $field)
-                if ($field->getId() == $fid)
+                if ($field->getId() == $fid) {
+                    // This is to prevent SimpleForm using index name as
+                    // field name when one is not set.
+                    if (!$field->get('name'))
+                        $field->set('name', "field_$fid");
+
                     return $field;
+                }
         }
     }
 


### PR DESCRIPTION
This PR addresses an issue where `ticket__cdata` table gets dropped due to sql error on field update. The field name mismatch is a result of `SimpleForm` forcing field name (variable) by using field index name when none is set.
