### PR TITLE
Issue: Topic Help Tip

### DIFF
--- a/include/i18n/en_US/help/tips/manage.helptopic.yaml
+++ b/include/i18n/en_US/help/tips/manage.helptopic.yaml
@@ -24,11 +24,19 @@ topic:
     content: >
         Unique Help Topic name.
 
-status:
+htstatus:
     title: Status
     content: >
         If disabled or archived, this <span class="doc-desc-title">Help Topic</span>
         will not be available.
+
+status:
+    title: Ticket Status
+    content: >
+        Select the Ticket Status assigned to new tickets related to this <span
+        class="doc-desc-title">Help Topic</span>.
+        <br><br>
+        Ticket Filters can override new Ticket Status.
 
 type:
     title: Type

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -65,7 +65,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                   <option value="disabled"<?php echo ($info['status'] == __('Disabled'))?'selected="selected"':'';?>><?php echo __('Disabled'); ?></option>
                   <option value="archived"<?php echo ($info['status'] == __('Archived'))?'selected="selected"':'';?>><?php echo __('Archived'); ?></option>
                 </select>
-                &nbsp;<span class="error">*&nbsp;</span> <i class="help-tip icon-question-sign" href="#status"></i>
+                &nbsp;<span class="error">*&nbsp;</span> <i class="help-tip icon-question-sign" href="#htstatus"></i>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
This commit fixes an issue where we had 2 hrefs in the Help Topic help tips called #status, so the 'New Ticket Options' status tip was incorrect. Now there are 2 separate hrefs and help tips.