### PR TITLE
oops: Task Missing Parentheses

### DIFF
--- a/include/upgrader/streams/core/f1ccd3bb-f5692e24.task.php
+++ b/include/upgrader/streams/core/f1ccd3bb-f5692e24.task.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('TICKET_EMAIL_INFO_TABLE')
+if (!defined('TICKET_EMAIL_INFO_TABLE'))
     define('TICKET_EMAIL_INFO_TABLE', TABLE_PREFIX.'ticket_email_info');
 
 /*


### PR DESCRIPTION
This addresses an issue where there is a missing parentheses in an upgrade task. This is due to me 3heading the commit and forgetting to run the lint tests so the missing parentheses was not revealed. This adds the missing parentheses so the lint tests pass and there are no PHP errors/warnings.