### PR TITLE
Issue: Saving Forms/Help Topic Forms

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -78,7 +78,7 @@ class DynamicFormsAjaxAPI extends AjaxController {
         $preserve = $field->flags & $p_mask;
 
         // Set admin-configured flag states
-        $flags = array_reduce($_POST['flags'],
+        $flags = array_reduce($_POST['flags'] ?: array(),
             function($a, $b) { return $a | $b; }, 0);
         $field->flags = $flags | $preserve;
 

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -388,7 +388,7 @@ foreach ($forms as $F) {
         <tr>
             <td><input type="checkbox" name="fields[]" value="<?php
                 echo $f->get('id'); ?>" <?php
-                if ($f->isEnabled()) echo 'checked="checked"'; ?>/></td>
+                if (!$f->_disabled) echo 'checked="checked"'; ?>/></td>
             <td><?php echo $f->get('label'); ?></td>
             <td><?php $t=FormField::getFieldType($f->get('type')); echo __($t[0]); ?></td>
             <td><?php echo $f->getVisibilityDescription(); ?></td>


### PR DESCRIPTION
- Fix error: array_reduce() expects parameter 1 to be array, null given
- On Help Topic forms, the only fields that should be unchecked in the 'Enable' column are the fields that the Admin specifically unchecked. We don't need the fields that are disabled from Manage Forms to display as unchecked when viewing the Help Topic form because if you save the Help Topic form with them unchecked and then go enable the fields in Manage Forms, the fields will still be disabled in the Help Topic form which may not be what the Admin would expect to happen. They remain disabled in the Help Topic form because they end up being added to the disabled array in the extra column of the Help Topic form.

Note: isEnabled returns !$this->_disabled && $this->hasFlag(self::FLAG_ENABLED)