### PR TITLE
Ticket Merge Translation Improvement

### DIFF
--- a/include/staff/templates/merge-tickets.tmpl.php
+++ b/include/staff/templates/merge-tickets.tmpl.php
@@ -15,7 +15,7 @@
 <b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
 <hr/><?php echo sprintf(__(
 'Choose which Tickets to %s. The Ticket on top will be the Parent Ticket. Sort the order of the Tickets by clicking and dragging them.'
-), ($title == 'merge' ? 'merge into this one' : 'link'));
+), ($title == 'merge' ? __('merge into this one') : __('link')));
 ?>
 <br/>
 <br/>


### PR DESCRIPTION
This commit is based off of PR #5494 and ensures that all of the text on the Merge/Link modal will be translated.