### PR TITLE
issue: trackDisabledFields() $vars Variable

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4140,7 +4140,7 @@ implements RestrictedAccess, Threadable, Searchable {
             // entries, disable and track the requested disabled fields.
             if ($vars['topicId']) {
                 if ($__topic=Topic::lookup($vars['topicId'])) {
-                    $topic_forms = $__topic->trackDisabledFields($form);
+                    $topic_forms = $__topic->trackDisabledFields($form, $vars);
                 }
             }
 
@@ -4272,7 +4272,7 @@ implements RestrictedAccess, Threadable, Searchable {
             $topic = $cfg->getDefaultTopic();
         }
         if ($topic)
-            $topic->trackDisabledFields($form);
+            $topic->trackDisabledFields($form, $vars);
 
         // Intenal mapping magic...see if we need to override anything
         if (isset($topic)) {

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -195,7 +195,8 @@ implements TemplateVariable, Searchable {
         return $disabled;
     }
 
-    function trackDisabledFields($form=null) {
+    function trackDisabledFields($form=null, $vars=null) {
+        $topic_forms = array();
         foreach ($this->getForms() as $index=>$topicForm) {
             $disabled = Ticket::getDisabledFields($topicForm);
             // Special handling for the ticket form — disable fields


### PR DESCRIPTION
This addresses an issue where lint testing shows uninitialized variables. This adds the variables that were missing from the `trackDisabledFields()` method.