### PR TITLE
issue: NOTLS For IMAP/POP Without SSL

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -86,8 +86,10 @@ class MailFetcher {
             if ($this->authuser)
                 $this->srvstr .= sprintf('/authuser=%s', $this->authuser);
 
-            $this->srvstr.='/novalidate-cert}';
-
+            if (strcasecmp($this->getEncryption(), 'SSL'))
+                $this->srvstr.='/notls}';
+            else
+                $this->srvstr.='/novalidate-cert}';
         }
 
         //Set timeouts


### PR DESCRIPTION
This is a rewrite of #5519 and addresses issue #5020 where in some cases, using IMAP/POP without SSL fails because class MailFetcher is not disabling start-TLS. This adds a new if statement to check if the encryption method is SSL if not, we will add `/notls` to the server string to disable start-TLS.