### PR TITLE
security: Reported Vulns July-August 2020

### DIFF
--- a/include/ajax.draft.php
+++ b/include/ajax.draft.php
@@ -16,6 +16,7 @@ class DraftAjaxAPI extends AjaxController {
         if (!($draft = Draft::create($vars)) || !$draft->save())
             Http::response(500, 'Unable to create draft');
 
+        header('Content-Type: application/json; charset=UTF-8');
         echo JsonDataEncoder::encode(array(
             'draft_id' => $draft->getId(),
         ));
@@ -27,6 +28,7 @@ class DraftAjaxAPI extends AjaxController {
 
         $body = Format::viewableImages($draft->getBody());
 
+        header('Content-Type: application/json; charset=UTF-8');
         echo JsonDataEncoder::encode(array(
             'body' => $body,
             'draft_id' => $draft->getId(),
@@ -126,8 +128,9 @@ class DraftAjaxAPI extends AjaxController {
         if (!($f = AttachmentFile::lookup($id)))
             return Http::response(500, 'Unable to attach image');
 
+        header('Content-Type: application/json; charset=UTF-8');
         echo JsonDataEncoder::encode(array(
-            $f->getName() => array(
+            Format::sanitize($f->getName()) => array(
             'content_id' => 'cid:'.$f->getKey(),
             'id' => $f->getKey(),
             // Return draft_id to connect the auto draft creation
@@ -369,6 +372,7 @@ class DraftAjaxAPI extends AjaxController {
                 'title' => $f->getName(),
             );
         }
+        header('Content-Type: application/json; charset=UTF-8');
         echo JsonDataEncoder::encode($files);
     }
 

--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -382,6 +382,7 @@ class DynamicFormsAjaxAPI extends AjaxController {
         if (!$impl instanceof FileUploadField)
             Http::response(400, 'Upload to a non file-field');
 
+        header('Content-Type: application/json; charset=UTF-8');
         return JsonDataEncoder::encode(
             array('id'=>$impl->ajaxUpload())
         );
@@ -404,6 +405,7 @@ class DynamicFormsAjaxAPI extends AjaxController {
             ->first()->getConfiguration();
         $field = new FileUploadField();
         $field->_config = $config;
+        header('Content-Type: application/json; charset=UTF-8');
         return JsonDataEncoder::encode(
             array('id'=>$field->ajaxUpload($thisstaff ? true : false))
         );

--- a/include/ajax.i18n.php
+++ b/include/ajax.i18n.php
@@ -49,6 +49,7 @@ class i18nAjaxAPI extends AjaxController {
         $json = JsonDataEncoder::encode($phrases) ?: '{}';
         //Http::cacheable(md5($json), $lm);
 
+        header('Content-Type: application/json; charset=UTF-8');
         return $json;
     }
 
@@ -124,6 +125,7 @@ class i18nAjaxAPI extends AjaxController {
         $json = JsonDataEncoder::encode($langs);
         Http::cacheable(md5($json), $cfg->lastModified());
 
+        header('Content-Type: application/json; charset=UTF-8');
         return $json;
     }
 
@@ -142,6 +144,7 @@ class i18nAjaxAPI extends AjaxController {
         $json = JsonDataEncoder::encode($langs);
         Http::cacheable(md5($json), $cfg->lastModified());
 
+        header('Content-Type: application/json; charset=UTF-8');
         return $json;
     }
 }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -230,6 +230,7 @@ class OsticketConfig extends Config {
         'max_open_tickets' => 0,
         'files_req_auth' => 1,
         'force_https' => '',
+        'allow_external_images' => 1,
     );
 
     function __construct($section=null) {
@@ -1035,6 +1036,10 @@ class OsticketConfig extends Config {
         return $this->get('require_topic_to_close');
     }
 
+    function allowExternalImages() {
+        return ($this->get('allow_external_images'));
+    }
+
     function getDefaultTicketQueueId() {
         return $this->get('default_ticket_queue', 1);
     }
@@ -1417,6 +1422,7 @@ class OsticketConfig extends Config {
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],
             'default_ticket_queue'=>$vars['default_ticket_queue'],
+            'allow_external_images'=>isset($vars['allow_external_images'])?1:0,
         ));
     }
 

--- a/include/class.file.php
+++ b/include/class.file.php
@@ -633,6 +633,8 @@ class AttachmentFile extends VerySimpleModel {
 
         //Basic validation.
         foreach($attachments as $i => &$file) {
+            $file['name'] = Format::sanitize($file['name']);
+
             //skip no file upload "error" - why PHP calls it an error is beyond me.
             if($file['error'] && $file['error']==UPLOAD_ERR_NO_FILE) {
                 unset($attachments[$i]);

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -234,6 +234,8 @@ extends VerySimpleModel {
     }
 
     function addRule($what, $how, $val,$extra=array()) {
+        if (isset($extra['notes']))
+            $extra['notes'] = Format::sanitize($extra['notes']);
         $rule = array_merge($extra,array('what'=>$what, 'how'=>$how, 'val'=>$val));
         $rule = new FilterRule($rule);
         $this->rules->add($rule);

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -411,13 +411,29 @@ class Format {
 
     //Format text for display..
     function display($text, $inline_images=true, $balance=true) {
+        global $cfg;
+
+        // Exclude external images?
+        $exclude = !$cfg->allowExternalImages();
+        // Allowed image extensions
+        $allowed = array('gif', 'png', 'jpg', 'jpeg');
+
         // Make showing offsite images optional
         $text = preg_replace_callback('/<img ([^>]*)(src="http[^"]+")([^>]*)\/>/',
-            function($match) {
-                // Drop embedded classes -- they don't refer to ours
-                $match = preg_replace('/class="[^"]*"/', '', $match);
-                return sprintf('<span %s class="non-local-image" data-%s %s></span>',
-                    $match[1], $match[2], $match[3]);
+            function($match) use ($exclude, $allowed) {
+                $m = array();
+                // Split the src URL and get the extension
+                preg_match('/src="([^"]+)"/', $match[2], $m);
+                $url = explode('.', explode('?', $m[1])[0]);
+                $ext = preg_split('/[^A-Za-z]/', end($url))[0];
+
+                if (!$exclude && in_array($ext, $allowed)) {
+                    // Drop embedded classes -- they don't refer to ours
+                    $match = preg_replace('/class="[^"]*"/', '', $match);
+                    return sprintf('<span %s class="non-local-image" data-%s %s></span>',
+                        $match[1], $match[2], $match[3]);
+                } else
+                    return '';
             },
             $text);
 
@@ -431,6 +447,29 @@ class Format {
             return self::viewableImages($text);
 
         return $text;
+    }
+
+    function stripExternalImages($input, $display=false) {
+        global $cfg;
+
+        // Allowed Inline External Image Extensions
+        $allowed = array('gif', 'png', 'jpg', 'jpeg');
+        $exclude = !$cfg->allowExternalImages();
+
+        $input = preg_replace_callback('/<img ([^>]*)(src="([^"]+)")([^>]*)\/?>/',
+            function($match) use ($allowed, $exclude, $display) {
+                // Split the src URL and get the extension
+                $url = explode('.', explode('?', $match[3])[0]);
+                $ext = preg_split('/[^A-Za-z]/', end($url))[0];
+
+                if (($exclude && $display) || !in_array($ext, $allowed))
+                    return '';
+                else
+                    return $match[0];
+            },
+            $input);
+
+        return $input;
     }
 
     function striptags($var, $decode=true) {

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1647,6 +1647,9 @@ implements TemplateVariable {
         if (!($body = Format::strip_emoticons($vars['body']->getClean())))
             $body = '-'; //Special tag used to signify empty message as stored.
 
+        // Ensure valid external images
+        $body = Format::stripExternalImages($body);
+
         $poster = $vars['poster'];
         if ($poster && is_object($poster))
             $poster = (string) $poster;
@@ -2890,7 +2893,7 @@ class HtmlThreadEntryBody extends ThreadEntryBody {
         case 'email':
             return $this->body;
         case 'pdf':
-            return Format::clickableurls($this->body);
+            return Format::clickableurls(Format::stripExternalImages($this->body, true));
         default:
             return Format::display($this->body, true, !$this->options['balanced']);
         }

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -80,6 +80,7 @@ core:
     ticket_number_format: '######'
     ticket_sequence_id: 0
     queue_bucket_counts: 0
+    allow_external_images: 1
     task_number_format: '#'
     task_sequence_id: 2
     log_level: 2

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -124,6 +124,15 @@ require_topic_to_close:
     content: >
         If Enabled, a Ticket must have a Help Topic in order to be Closed by an Agent
 
+allow_external_images:
+    title: Allow External Images
+    content: >
+        If Enabled, the system will allow external inline images that have a valid image
+        extension (.png, .jpg, .jpeg, .gif). If Disabled, the system will exclude
+        any external inline images. One caveat to note, is if the setting is Disabled we
+        will still store external inline images that have a valid image extension in case
+        the setting is re-enabled in the future.
+
 assigned_tickets:
     title: Assigned Tickets
     content: >

--- a/include/staff/apikey.inc.php
+++ b/include/staff/apikey.inc.php
@@ -15,7 +15,7 @@ if($api && $_REQUEST['a']!='add'){
     $info['isactive']=isset($info['isactive'])?$info['isactive']:1;
     $qs += array('a' => $_REQUEST['a']);
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 <form action="apikeys.php?<?php echo Http::build_query($qs); ?>" method="post" class="save">
  <?php csrf_token(); ?>

--- a/include/staff/banrule.inc.php
+++ b/include/staff/banrule.inc.php
@@ -17,7 +17,7 @@ if($rule && $_REQUEST['a']!='add'){
     $qs += array('a' => $_REQUEST['a']);
 }
 
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 <form action="banlist.php?<?php echo Http::build_query($qs); ?>" method="post" class="save">
  <?php csrf_token(); ?>

--- a/include/staff/cannedresponse.inc.php
+++ b/include/staff/cannedresponse.inc.php
@@ -110,7 +110,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
         <tr>
             <td colspan=2>
                 <textarea class="richtext no-bar" name="notes" cols="21"
-                    rows="8" style="width: 80%;"><?php echo $info['notes']; ?></textarea>
+                    rows="8" style="width: 80%;"><?php echo Format::sanitize($info['notes']); ?></textarea>
             </td>
         </tr>
     </tbody>

--- a/include/staff/category.inc.php
+++ b/include/staff/category.inc.php
@@ -33,7 +33,7 @@ if($category && $_REQUEST['a']!='add'){
     $submit_text=__('Add');
     $qs += array('a' => $_REQUEST['a']);
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 
 ?>
 <form action="categories.php?<?php echo Http::build_query($qs); ?>" method="post" class="save">

--- a/include/staff/dynamic-list.inc.php
+++ b/include/staff/dynamic-list.inc.php
@@ -16,7 +16,7 @@ if ($list) {
     $newcount=4;
 }
 
-$info=Format::htmlchars(($errors && $_POST) ? array_merge($info,$_POST) : $info);
+$info=Format::htmlchars(($errors && $_POST) ? array_merge($info,$_POST) : $info, true);
 
 ?>
 <form action="" method="post" class="save">

--- a/include/staff/email.inc.php
+++ b/include/staff/email.inc.php
@@ -32,7 +32,7 @@ if($email && $_REQUEST['a']!='add'){
         $info['smtp_auth'] = 1;
     $qs += array('a' => $_REQUEST['a']);
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 <h2><?php echo $title; ?>
     <?php if (isset($info['email'])) { ?><small>

--- a/include/staff/faq.inc.php
+++ b/include/staff/faq.inc.php
@@ -250,7 +250,7 @@ echo $attrs; ?>><?php echo $draft ?: $answer;
     </div>
     <div style="margin-top:10px"></div>
     <textarea class="richtext no-bar" name="notes" cols="21"
-        rows="8" style="width: 80%;"><?php echo $info['notes']; ?></textarea>
+        rows="8" style="width: 80%;"><?php echo Format::sanitize($info['notes']); ?></textarea>
 </div>
 
 <p style="text-align:center;">

--- a/include/staff/filter.inc.php
+++ b/include/staff/filter.inc.php
@@ -21,7 +21,7 @@ if($filter && $_REQUEST['a']!='add'){
     $info['rules'] = array();
     $qs += array('a' => $_REQUEST['a']);
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 <form action="filters.php?<?php echo Http::build_query($qs); ?>" method="post" class="save">
     <?php csrf_token(); ?>

--- a/include/staff/page.inc.php
+++ b/include/staff/page.inc.php
@@ -184,7 +184,7 @@ else
     <em><strong><?php echo __('Internal Notes'); ?></strong>:
       <?php echo __("Be liberal, they're internal"); ?></em>
     <textarea class="richtext no-bar" name="notes" cols="21"
-      rows="8" style="width: 80%;"><?php echo $info['notes']; ?></textarea>
+      rows="8" style="width: 80%;"><?php echo Format::sanitize($info['notes']); ?></textarea>
   </div>
 </div>
 

--- a/include/staff/role.inc.php
+++ b/include/staff/role.inc.php
@@ -15,7 +15,7 @@ if ($role) {
     $newcount=4;
 }
 
-$info = Format::htmlchars(($errors && $_POST) ? array_merge($info, $_POST) : $info);
+$info = Format::htmlchars(($errors && $_POST) ? array_merge($info, $_POST) : $info, true);
 
 ?>
 <form action="" method="post" class="save">

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -235,6 +235,13 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td><?php echo __('Allow External Images'); ?>:</td>
+            <td>
+                <input type="checkbox" name="allow_external_images" <?php echo $config['allow_external_images']?'checked="checked"':''; ?>>
+                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#allow_external_images"></i>
+            </td>
+        </tr>
+        <tr>
             <th colspan="2">
                 <em><b><?php echo __('Attachments');?></b>:  <?php echo __('Size and maximum uploads setting mainly apply to web tickets.');?></em>
             </th>

--- a/include/staff/slaplan.inc.php
+++ b/include/staff/slaplan.inc.php
@@ -18,7 +18,7 @@ if($sla && $_REQUEST['a']!='add'){
     $info['disable_overdue_alerts']=isset($info['disable_overdue_alerts'])?$info['disable_overdue_alerts']:0;
     $qs += array('a' => $_REQUEST['a']);
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 <form action="slas.php?<?php echo Http::build_query($qs); ?>" method="post" class="save">
  <?php csrf_token(); ?>

--- a/include/staff/template.inc.php
+++ b/include/staff/template.inc.php
@@ -17,7 +17,7 @@ if($template && $_REQUEST['a']!='add'){
     $info['lang_id'] = $cfg->getPrimaryLanguage();
     $qs += array('a' => $_REQUEST['a']);
 }
-$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 ?>
 <form action="templates.php?<?php echo Http::build_query($qs); ?>" method="post" class="save">
  <?php csrf_token(); ?>


### PR DESCRIPTION
This addresses a vulnerability reported by @heinhtetaung where Internal Note contents are not correctly sanitized if errors are returned. This adds `true` as the second argument to `Format::htmlchars()` so that all content is sanitized properly. In some cases however we cannot blanket sanitize all the content as Inline Images, etc. tend to get obfuscated. So in those cases this adds `Format::sanitize()` to the Internal Notes directly.

This addresses an issue where we are not sanitizing the Internal Notes when adding a new Banlist item. This adds a check for `$extra['notes']` and if exists we will sanitize the content before it is saved. This will ensure no malicious content is saved in the database.

This mitigates an SSRF security vulnerability reported by [Talat Mehmood](https://twitter.com/Blackbatsecuri1) where we do not check if the src URL for external inline images contain a valid image extension when displaying. This means if someone puts something like `<img src="mymalicioussite.com/badscript.js">` in the body of their message, when someone clicks Show Images or when the ticket is printed the server will call the src URL to get the "image" data for display. This is a problem as this could load malicious code/scripts in the browser. This adds a new setting called `Allow External Images` and if Disabled we will not allow any external images in Threads. If this setting is Enabled (default), we will only allow `<img>` src URLs with valid image extensions (`png`,`jpg`,`jpeg`,`gif`).

This mitigates an XSS vulnerability reported by [The NAVEX Project](https://sisl.lab.uic.edu/projects/chess/) where if an attachment is uploaded via Draft AJAX, the filename stored/returned in the response is not sanitized. This updates `DraftAjaxAPI::_uploadInlineImage()` to sanitize the filename before it's returned in the JSON encoded response. This also updates `AttachmentFile::format()` to sanitize the filename before saving to the backend. In addition this forces the `application/json` Content-Type on all AJAX responses that return strictly JSON; this adds another layer of protection.