### PR TITLE
oops: Local Inline Images

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -455,14 +455,18 @@ class Format {
         // Allowed Inline External Image Extensions
         $allowed = array('gif', 'png', 'jpg', 'jpeg');
         $exclude = !$cfg->allowExternalImages();
+        $local = false;
 
         $input = preg_replace_callback('/<img ([^>]*)(src="([^"]+)")([^>]*)\/?>/',
-            function($match) use ($allowed, $exclude, $display) {
+            function($match) use ($local, $allowed, $exclude, $display) {
+                if (strpos($match[3], 'cid:') !== false)
+                    $local = true;
+
                 // Split the src URL and get the extension
                 $url = explode('.', explode('?', $match[3])[0]);
                 $ext = preg_split('/[^A-Za-z]/', end($url))[0];
 
-                if (($exclude && $display) || !in_array($ext, $allowed))
+                if (!$local && (($exclude && $display) || !in_array($ext, $allowed)))
                     return '';
                 else
                     return $match[0];


### PR DESCRIPTION
This addresses an issue caused by d98c2d0 where local inline images are stripped from the thread entries. This adds a check for the `cid` tag and if exists we know it’s a local image and we will allow it.