### PR TITLE
issue: Ticket Merge Select2

### DIFF
--- a/include/staff/templates/merge-tickets.tmpl.php
+++ b/include/staff/templates/merge-tickets.tmpl.php
@@ -100,7 +100,7 @@ foreach ($tickets as $t) {
         var select = $(this).parent().find('select'),
             $sel = select.find('option:selected'),
             id = $sel.val();
-            data = $sel.data();
+            data = select.select2('data');
             for(var key in data) {
                  ticket_id = data[key]['ticket_id'];
                  ticketLink = '<?php echo Ticket::getLink('');?>';


### PR DESCRIPTION
This addresses an issue where the Select2 upgrade apparently changed the way you get data from the selection. This updates the call to get data from `data = $sel.data();` to `data = select.select2('data');`.