### PR TITLE
issue: Agent Password Reset With No Existing Password

### DIFF
--- a/scp/pwreset.php
+++ b/scp/pwreset.php
@@ -41,7 +41,10 @@ if($_POST) {
         case 'sendmail':
             if (($staff=Staff::lookup($_POST['userid']))) {
                 if (!$staff->hasPassword()) {
-                    $msg = __('Unable to reset password. Contact your administrator');
+                    if ($staff->sendResetEmail('registration-staff', false) !== false)
+                        $msg = __('Registration email sent successfully.');
+                    else
+                        $msg = __('Unable to reset password. Contact your administrator');
                 }
                 elseif (!$staff->sendResetEmail()) {
                     $tpl = 'pwreset.sent.php';


### PR DESCRIPTION
This addresses an issue where if an Agent never finishes registering their account via the link in the Registration Email and tries to reset their password, the system says `Unable to reset password. Contact your administrator`. This is due to no password being set in the first place; we cannot reset a password that doesn't exist. This adds a check for the Agent's password when requesting password reset and if none set we will resend the Registration Email. This will ensure the Agent can set a password and login successfully.