### PR TITLE
issue: Assignee Field

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3297,13 +3297,18 @@ class AssigneeField extends ChoiceField {
 
     function getWidget($widgetClass=false) {
         $widget = parent::getWidget($widgetClass);
-        if (is_object($widget->value))
-            $widget->value = $widget->value->getId();
+        $value = $widget->value;
+        if (is_object($value)) {
+            $id = $value->getId();
+            if ($value instanceof Staff)
+                $widget->value = 's'.$id;
+            elseif ($value instanceof Team)
+                $widget->value = 't'.$id;
+        }
         return $widget;
     }
 
     function getCriteria() {
-
         if (!isset($this->_criteria)) {
             $this->_criteria = array('available' => true);
             if (($c=parent::getCriteria()))
@@ -3322,7 +3327,12 @@ class AssigneeField extends ChoiceField {
     }
 
     function display($value) {
-        return $this->getAnswer() ? $this->getAnswer()->value : $value;
+        if ($this->getAnswer() && is_string($this->getAnswer()->value)) {
+            $v = JsonDataParser::parse($this->getAnswer()->value);
+            if (is_array($v))
+                $value = $v[key($v)];
+        }
+        return $value;
     }
 
     function getChoices($verbose=false) {
@@ -3359,27 +3369,54 @@ class AssigneeField extends ChoiceField {
         return $this->_choices;
     }
 
+    function getChoice($value) {
+        $choices = $this->getChoices();
+        $selection = array();
+        if ($value && is_object($value)) {
+            $keys = null;
+            if ($value instanceof Staff)
+                $keys = array('Agents', 's'.$value->getId());
+            elseif ($value instanceof Team)
+                $keys = array('Teams', 't'.$value->getId());
+            if ($keys && isset($choices[$keys[0]]))
+                $selection = $choices[$keys[0]][$keys[1]];
+
+            if (!empty($selection))
+                return $selection;
+        }
+
+        return parent::getChoice($value);
+    }
+
     function getValue() {
         if (($value = parent::getValue()) && ($id=$this->getClean())) {
             $name = (is_object($value[key($value)]) && get_class($value[key($value)]) == 'AgentsName') ?
                 $value[key($value)]->name : $value[key($value)];
-            return array($name, substr(key($value), 1));
+            $key = (($value[key($value)] instanceof AgentsName) ? 's' : 't').substr(key($value), 1);
+            return array(array($key => $name), substr(key($value), 1));
         } else
-            return array();
+            return null;
     }
-
 
     function parse($id) {
         return $this->to_php(null, $id);
     }
 
     function to_php($value, $id=false) {
+        if (is_string($value))
+            $value = JsonDataParser::parse($value);
+
         $type = '';
         if (is_array($id)) {
             reset($id);
             $id = key($id);
             $type = $id[0];
             $id = substr($id, 1);
+        }
+        if (is_array($value)) {
+            $type = key($value)[0];
+            if (!$id)
+                $id = key($value)[1];
         }
 
         switch ($type) {
@@ -3394,11 +3431,23 @@ class AssigneeField extends ChoiceField {
         }
     }
 
-
     function to_database($value) {
-        return (is_object($value))
-            ? array($value->getName(), $value->getId())
-            : $value;
+        if (is_object($value)) {
+            $id = $value->getId();
+            if ($value instanceof Staff) {
+                $key = 's'.$id;
+                $name = $value->getName()->name;
+            } elseif ($value instanceof Team) {
+                $key = 't'.$id;
+                $name = $value->getName();
+            }
+
+            return array(JsonDataEncoder::encode(array($key => $name)));
+        }
+        if (is_array($value)) {
+            return array(JsonDataEncoder::encode($value[0]));
+        }
+        return $value;
     }
 
     function toString($value) {
@@ -3407,6 +3456,38 @@ class AssigneeField extends ChoiceField {
 
     function searchable($value) {
         return null;
+    }
+
+    function getKeys($value) {
+        $value = $this->to_database($value);
+        if (is_array($value))
+            return $value[0];
+
+        return (string) $value;
+    }
+
+    function asVar($value, $id=false) {
+        $v = $this->to_php($value, $id);
+        return $v ? $v->getName() : null;
+    }
+
+    function getChanges() {
+        $new = $this->to_database($this->getValue());
+        $old = $this->to_database($this->answer ? $this->answer->getValue()
+                : $this->get('default'));
+        // Compare old and new
+        return ($old == $new)
+            ? false
+            : array($old[0], $new[0]);
+    }
+
+    function whatChanged($before, $after) {
+        if ($before)
+            $before = array($before->getName());
+        if ($after)
+            $after = array($after->getName());
+
+        return parent::whatChanged($before, $after);
     }
 
     function getConfigurationOptions() {


### PR DESCRIPTION
This addresses a list of issues with Custom Assignee Fields:
- The Thread Events do not show the changes
- Custom Columns do not show the current values
- Advanced Search with `includes` and `does not include` criteria does not find proper results
- Exports do not show the current values
- Template Variables do not show the proper values

This overhauls the AssigneeField class to make it like an independent Custom Field. This adds new methods such as `getChoice()`, `getKeys()`, `asVar()`, `getChanges`, and `whatChanged()` to work with AssigneeField specific data instead of relying on the ChoiceField class. This also updates methods like `getWidget()`, `display()`, `getValue()`, `to_php()`, and `to_database()` to ensure all methods work with a unified data format (JSON/Array).