### PR TITLE
Return nicer default mail address

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -67,7 +67,7 @@ class Email extends VerySimpleModel {
         if ($this->mail_encryption == 'SSL')
             $this->mail_proto .= "/".$this->mail_encryption;
 
-        $this->address=$this->name?($this->name.'<'.$this->email.'>'):$this->email;
+        $this->address=$this->name?($this->name.' <'.$this->email.'>'):$this->email;
     }
 
     function getEmail() {


### PR DESCRIPTION
I noticed that *Post Reply* use a ugly default mail address. It use `Support<foo@bar.com>` (without whitespace) instead `Support <foo@bar.com>`. This PR should fix the problem.