### PR TITLE
issue: Custom REGEX Failure

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1453,7 +1453,7 @@ class TextboxField extends FormField {
 
     function validateEntry($value) {
         //check to see if value is the string '0'
-        $value = ($value == '0') ? '&#48' : Format::htmlchars($this->toString($value ?: $this->value));
+        $value = ($value === '0') ? '&#48' : Format::htmlchars($this->toString($value ?: $this->value));
         parent::validateEntry($value);
         $config = $this->getConfiguration();
         $validators = array(


### PR DESCRIPTION
This addresses an issue reported on the Forum where when using a Custom REGEX Validator like `/^[0]\d{6}$/iu` and someone inserts a value like `0000000` the REGEX will fail. This is due to a check where we use the equals operator (`==`) to check if the value is equal to `0` and if so we change the value to `&#48`. This is a problem for values such as `0000000` as technically `0000000` is equal to `0`. This updates the equals comparison operator to the identical comparison operator to ensure that only values that are identical to `0 (string)` are changed to `&#48`.