### PR TITLE
issue: New Message Alert Recipients

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3167,7 +3167,6 @@ implements RestrictedAccess, Threadable, Searchable {
         $options = array('thread'=>$message);
         // If enabled...send alert to staff (New Message Alert)
         if ($cfg->alertONNewMessage()
-            && $dept->getNumMembersForAlerts()
             && ($email = $dept->getAlertEmail())
             && ($tpl = $dept->getTemplate())
             && ($msg = $tpl->getNewMessageAlertMsgTemplate())


### PR DESCRIPTION
This addresses an issue where a User updates a Ticket that is assigned but no alert is sent to the Assigned Agent/Team. This is due to `getNumMembersForAlerts()` that returns the number of members that can receive alerts for the Department. This method returns `0` if there are no Primary Members and the Department Alert settings are set to "Department members only" which causes the system to return before we send the New Message alert. This method is not necessary for New Message Alerts as we only alert the Last Respondent, Assigned Agent/Team, Department Manager, and/or Org Account Manager. This removes the method from `Ticket::postMessage()` so that we continue to check for recipients and send the alerts.