### PR TITLE
Auth: External authentication service name.

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -120,7 +120,7 @@ class ClientCreateRequest {
     function attemptAutoRegister() {
         global $cfg;
 
-        if (!$cfg)
+        if (!$cfg || !$cfg->isClientRegistrationEnabled())
             return false;
 
         // Attempt to automatically register

--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -586,19 +586,27 @@ abstract class ExternalStaffAuthenticationBackend
     static $sign_in_image_url = false;
     static $service_name = "External";
 
-    function renderExternalLink() { ?>
-        <a class="external-sign-in" title="Sign in with <?php echo static::$service_name; ?>"
+    function getServiceName() {
+        return static::$service_name;
+    }
+
+    function renderExternalLink() {
+        $service = sprintf('%s %s',
+                __('Sign in with'),
+                $this->getServiceName());
+        ?>
+        <a class="external-sign-in" title="<?php echo $service; ?>"
                 href="login.php?do=ext&amp;bk=<?php echo urlencode(static::$id); ?>">
 <?php if (static::$sign_in_image_url) { ?>
         <img class="sign-in-image" src="<?php echo static::$sign_in_image_url;
-            ?>" alt="Sign in with <?php echo static::$service_name; ?>"/>
+            ?>" alt="<?php echo $service; ?>"/>
 <?php } else { ?>
             <div class="external-auth-box">
             <span class="external-auth-icon">
                 <i class="icon-<?php echo static::$fa_icon; ?> icon-large icon-fixed-with"></i>
             </span>
             <span class="external-auth-name">
-                Sign in with <?php echo static::$service_name; ?>
+               <?php echo $service; ?>
             </span>
             </div>
 <?php } ?>


### PR DESCRIPTION
- Allow external authentication backends to make service name configurable.

- Check to make sure client registration is enabled before attempting to auto register clients on client create request. This is important to prevent auth plugins from auto registering clients without checking config settings.