### PR TITLE
Fix department translations in dashboard

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -77,7 +77,6 @@ class OverviewReport {
 
     function getPlotData() {
         list($start, $stop) = $this->getDateRange();
-        $states = array("created", "closed", "reopened", "assigned", "overdue", "transferred");
         $event_ids = Event::getIds();
 
         # Fetch all types of events over the timeframe

--- a/include/class.report.php
+++ b/include/class.report.php
@@ -212,15 +212,15 @@ class OverviewReport {
         case 'dept':
             $headers = array(__('Department'));
             $header = function($row) { return Dept::getLocalNameById($row['dept_id'], $row['dept__name']); };
-            $pk = 'dept__id';
+            $pk = 'dept_id';
             $stats = $stats
                 ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                ->values('dept__id', 'dept__name', 'dept__flags')
-                ->distinct('dept__id');
+                ->values('dept_id', 'dept__name', 'dept__flags')
+                ->distinct('dept_id');
             $times = $times
                 ->filter(array('dept_id__in' => $thisstaff->getDepts()))
-                ->values('dept__id')
-                ->distinct('dept__id');
+                ->values('dept_id')
+                ->distinct('dept_id');
             break;
         case 'topic':
             $headers = array(__('Help Topic'));


### PR DESCRIPTION
We had the problem, that in the dashboard osTicket only show one name for all departments.

I found the problem: With `dept__id` was use a wrong array key.