### PR TITLE
Fix department translations in tasks overview

### DIFF
--- a/include/staff/tasks.inc.php
+++ b/include/staff/tasks.inc.php
@@ -161,7 +161,7 @@ $tasks->annotate(array(
 ));
 
 $tasks->values('id', 'number', 'created', 'staff_id', 'team_id',
-        'staff__firstname', 'staff__lastname', 'team__name',
+        'staff__firstname', 'staff__lastname', 'team__name', 'dept_id',
         'dept__name', 'cdata__title', 'flags', 'ticket__number', 'ticket__ticket_id');
 // Apply requested quick filter
 


### PR DESCRIPTION
We had the problem, that in the task overview osTicket only show one name for all departments.

Problem is the missing `dept_id` array value.