### PR TITLE
Drop nested table from open new ticket

### DIFF
--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -80,9 +80,6 @@ if ($_POST)
                 <div class="error"><?php echo $errors['user']; ?></div>
             </th>
         </tr>
-        <tr>
-          <td>
-            <table class="form_table" width="940" border="0" cellspacing="0" cellpadding="2">
               <?php
               if ($user) { ?>
                   <tr><td><?php echo __('User'); ?>:</td><td>
@@ -186,9 +183,6 @@ if ($_POST)
           </td>
         </tr>
       <?php } ?>
-    </table>
-          </td>
-        </tr>
     </tbody>
     <tbody>
         <tr>


### PR DESCRIPTION
The *Open a New Ticket* form has a ugly layout in the *User and Collaborators* section because of a nested table:

![osticket-nested-table](https://user-images.githubusercontent.com/497880/95988476-3c1e5180-0e29-11eb-8c05-26d5ba2b835c.png)

This PR should fix it. 