### PR TITLE
Issue: Ticket Export Delimiters

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1973,7 +1973,7 @@ class TicketsAjaxAPI extends AjaxController {
             $id = $queue->getId();
             $_SESSION['Export:Q'.$id]['fields'] = $_POST['fields'];
             $_SESSION['Export:Q'.$id]['filename'] = $_POST['filename'];
-            $_SESSION['Export:Q'.$id]['delimiter'] = $_POST['delimiter'];
+            $_SESSION['Export:Q'.$id]['delimiter'] = $_POST['csv-delimiter'];
             // Save fields selection if requested
             if ($queue->isSaved() && isset($_POST['save-changes']))
                $queue->updateExports(array_flip($_POST['fields']));
@@ -1993,7 +1993,7 @@ class TicketsAjaxAPI extends AjaxController {
             try {
                 $interval = 5;
                 $options = ['filename' => $filename,
-                    'interval' => $interval];
+                    'interval' => $interval, 'delimiter' => $_POST['csv-delimiter']];
                 // Create desired exporter
                 $exporter = new CsvExporter($options);
                 // Acknowledge the export


### PR DESCRIPTION
This commit fixes an issue we had with changing the delimiter when exporting Tickets as a CSV. In order to save the delimiter to the Agent's session, we needed to match the input field name of 'csv-delimiter' rather than just 'delimiter'. This just makes it so that if the Agent has to do another export, they won't have to reset the delimiter again. Also, in order to correctly pass the delimiter to the options of the CsvExporter class, the delimiter needed to be added to the options array before constructing the new exporter.