### PR TITLE
Oops: Method Inheritance Compatibility

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1201,7 +1201,7 @@ class SLAChoiceField extends AdvancedSearchSelectionField {
         return true;
     }
 
-    function getChoices($verbose=false) {
+    function getChoices($verbose=false, $options=array()) {
         if (!isset($this->_slas))
             $this->_slas = SLA::getSLAs(array('nameOnly' => true));
 


### PR DESCRIPTION
This commit fixes an issue with the getChoices method for the new SLAChoiceField class. It needed the $options variable to be added so that it would match the parent class.