### PR TITLE
Don't use a default comment on ticket assignment

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2022,7 +2022,6 @@ implements RestrictedAccess, Threadable, Searchable {
             return false;
 
         $user_comments = (bool) $comments;
-        $comments = $comments ?: _S('Ticket Assignment');
         $assigner = $thisstaff ?: _S('SYSTEM (Auto Assignment)');
 
         //Log an internal note - no alerts on the internal note.


### PR DESCRIPTION
When you assign a ticket or a task to a agent/team you can add a optional comment.

When you leave the comment empty, the ticket assignment use "*Ticket Assignment*" as default comment and the task assignment add no default comment.

This is inconsistent! So this PR remove the default "*Ticket Assignment*" comment, since it is not helpful on a ticket assignment mail. ;-)