### PR TITLE
Fix incorrrect compare locked staff at Ticket Preview

### DIFF
--- a/include/staff/templates/ticket-preview.tmpl.php
+++ b/include/staff/templates/ticket-preview.tmpl.php
@@ -10,7 +10,7 @@ $role=$ticket->getRole($thisstaff);
 $error=$msg=$warn=null;
 $thread = $ticket->getThread();
 
-if($lock && $lock->getStaffId()==$thisstaff->getId())
+if($lock && $lock->getStaffId()!==$thisstaff->getId())
     $warn.='&nbsp;<span class="Icon lockedTicket">'
     .sprintf(__('Ticket is locked by %s'), $lock->getStaffName()).'</span>';
 elseif($ticket->isOverdue())


### PR DESCRIPTION
Can't show other staff locking the ticket at Ticket Preview popup, 