### PR TITLE
Issue: Default Delimiter

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -603,7 +603,8 @@ class CsvExporter extends Exporter {
     }
 
     function getDelimiter() {
-        if (isset($this->options['delimiter']))
+        if (isset($this->options['delimiter'])
+                && $this->options['delimiter'])
             return $this->options['delimiter'];
         return Internationalization::getCSVDelimiter();
     }

--- a/include/staff/templates/queue-export.tmpl.php
+++ b/include/staff/templates/queue-export.tmpl.php
@@ -13,7 +13,7 @@ else
 if (isset($cache['delimiter']))
     $delimiter = $cache['delimiter'];
 else
-    $delimiter = ''; //TODO: get user's preference (browswer settings)
+    $delimiter = Internationalization::getCSVDelimiter();
 
 $fields = $queue->getExportFields(false) ?: array();
 if (isset($cache['fields']) && $fields)


### PR DESCRIPTION
This commit fixes an issue where we needed to make sure to put a default delimiter for Ticekt exports. If no delimiter is specified, the default delimiter will be ','