### PR TITLE
Issue: Canned Response, Marked Answered

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3343,8 +3343,10 @@ implements RestrictedAccess, Threadable, Searchable {
         Signal::send('object.created', $this, $type);
 
         /* email the user??  - if disabled - then bail out */
-        if (!$alert)
+        if (!$alert) {
+            $this->markUnAnswered();
             return $response;
+        }
 
         //allow agent to send from different dept email
         if (!$vars['from_email_id']


### PR DESCRIPTION
This commit fixes an issue where if an Agent creates a Ticket on behalf of a user and includes a Canned Reply, the Ticket is opened as already being answered. The postReply method is supposed to return the response and then go back to the postCannedReply function, and then the next line would mark it as unanswered, but it was never making it back into postCannedReply.