### PR TITLE
issue: Update Autocomplete

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4257,7 +4257,7 @@ class TextboxWidget extends Widget {
         if (isset($config['classes']))
             $classes = 'class="'.$config['classes'].'"';
         if (isset($config['autocomplete']))
-            $autocomplete = 'autocomplete="'.($config['autocomplete']?'on':'off').'"';
+            $autocomplete = 'autocomplete="'.$config['autocomplete'].'"';
         if (isset($config['autofocus']))
             $autofocus = 'autofocus';
         if (isset($config['disabled']))

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1556,6 +1556,7 @@ extends AbstractForm {
                     'validator' => 'email',
                     'placeholder' => __('Email Address — e.g. me@mycompany.com'),
                     'length' => 128,
+                    'autocomplete' => 'email',
                   ),
             )),
             'dept_id' => new ChoiceField(array(
@@ -1591,6 +1592,7 @@ extends AbstractForm {
                 'required' => true,
                 'configuration' => array(
                     'placeholder' => __("Temporary Password"),
+                    'autocomplete' => 'new-password',
                 ),
                 'visibility' => new VisibilityConstraint(
                     new Q(array('welcome_email' => false))
@@ -1601,6 +1603,7 @@ extends AbstractForm {
                 'required' => true,
                 'configuration' => array(
                     'placeholder' => __("Confirm Password"),
+                    'autocomplete' => 'new-password',
                 ),
                 'visibility' => new VisibilityConstraint(
                     new Q(array('welcome_email' => false))

--- a/include/staff/syslogs.inc.php
+++ b/include/staff/syslogs.inc.php
@@ -91,9 +91,9 @@ else
                 <div style="padding-left:2px;">
                     <i class="help-tip icon-question-sign" href="#date_span"></i>
                     <?php echo __('Between'); ?>:
-                    <input class="dp" id="sd" size=15 name="startDate" value="<?php echo Format::htmlchars($_REQUEST['startDate']); ?>" autocomplete=OFF>
+                    <input class="dp" id="sd" size=15 name="startDate" value="<?php echo Format::htmlchars($_REQUEST['startDate']); ?>" autocomplete="off">
                     &nbsp;&nbsp;
-                    <input class="dp" id="ed" size=15 name="endDate" value="<?php echo Format::htmlchars($_REQUEST['endDate']); ?>" autocomplete=OFF>
+                    <input class="dp" id="ed" size=15 name="endDate" value="<?php echo Format::htmlchars($_REQUEST['endDate']); ?>" autocomplete="off">
                     &nbsp;<?php echo __('Log Level'); ?>:&nbsp;<i class="help-tip icon-question-sign" href="#type"></i>
                     <select name='type'>
                         <option value="" selected><?php echo __('All');?></option>


### PR DESCRIPTION
This updates how the autocomplete attribute is set so we can allow specific autocomplete values for individual fields. Before these changes `autocomplete` would be either `on` or `off` only. This also updates old `autocomplete=OFF` references to `autocomplete="off"`.