### PR TITLE
Issue: User Custom Dept Field

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3190,16 +3190,30 @@ class DepartmentField extends ChoiceField {
           }
         }
 
-        $active = $thisstaff->getDepartmentNames(true);
+        if ($thisstaff) {
+            $active = $thisstaff->getDepartmentNames(true);
 
-        $choices = array();
-        if ($options['filterVisibility'])
-            $depts = $thisstaff->getDepartmentNames();
-        else {
-            $depts = Dept::getDepartments(null, true, Dept::DISPLAY_DISABLED);
-            return $depts;
+            $choices = array();
+            if ($options['filterVisibility'])
+                $depts = $thisstaff->getDepartmentNames();
+            else {
+                $depts = Dept::getDepartments(null, true, Dept::DISPLAY_DISABLED);
+                return $depts;
+            }
+        } else {
+            $active_depts = Dept::objects()
+              ->filter(array('flags__hasbit' => Dept::FLAG_ACTIVE))
+              ->values('id', 'name')
+              ->order_by('name');
+
+            $choices = array();
+            if ($depts = Dept::getDepartments(null, true, Dept::DISPLAY_DISABLED)) {
+              //create array w/queryset
+              $active = array();
+              foreach ($active_depts as $dept)
+                $active[$dept['id']] = $dept['name'];
+            }
         }
-
 
          //add selected dept to list
          if($current_id)


### PR DESCRIPTION
This fixes an issue introduced with the new Visibility Permissions. It did not account for the possibility that Users may be able to view a Custom Department field when creating a Ticket in the Client Portal. In that event, we must make sure we can get active Departments that should show up as choices in custom Dept fields.