### PR TITLE
Issue: Prevent Deleting All Topics

### DIFF
--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -443,6 +443,16 @@ implements TemplateVariable, Searchable {
             $errors['number_format'] =
                 'Ticket number format requires at least one hash character (#)';
 
+        //Make sure at least 1 Topic is Public
+        $publicTopics = Topic::getHelpTopics(true);
+        if ((count($publicTopics) == 1) && array_key_exists($this->getId(), $publicTopics) && ($vars['ispublic'] == 0))
+            $errors['ispublic'] = __('At least one Topic must be Public');
+
+        //Make sure at least 1 Topic is Active
+        $activeTopics = Topic::getHelpTopics(false, false);
+        if ((count($activeTopics) == 1) && array_key_exists($this->getId(), $activeTopics) && ($vars['status'] != 'active'))
+            $errors['status'] = __('At least one Topic must be Active');
+
         if ($errors)
             return false;
 

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -79,9 +79,6 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
                         echo sprintf('<option value="%d" %s>%s</option>',
                                 $id, ($info['topicId']==$id)?'selected="selected"':'', $name);
                     }
-                } else { ?>
-                    <option value="0" ><?php echo __('General Inquiry');?></option>
-                <?php
                 } ?>
             </select>
             <font class="error">*&nbsp;<?php echo $errors['topicId']; ?></font>

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -65,7 +65,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                   <option value="disabled"<?php echo ($info['status'] == __('Disabled'))?'selected="selected"':'';?>><?php echo __('Disabled'); ?></option>
                   <option value="archived"<?php echo ($info['status'] == __('Archived'))?'selected="selected"':'';?>><?php echo __('Archived'); ?></option>
                 </select>
-                &nbsp;<span class="error">*&nbsp;</span> <i class="help-tip icon-question-sign" href="#htstatus"></i>
+                &nbsp;<span class="error">*&nbsp;<?php echo $errors['status']; ?></span> <i class="help-tip icon-question-sign" href="#htstatus"></i>
             </td>
         </tr>
         <tr>
@@ -75,7 +75,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
             <td>
                 <input type="radio" name="ispublic" value="1" <?php echo $info['ispublic']?'checked="checked"':''; ?>> <?php echo __('Public'); ?>
                 <input type="radio" name="ispublic" value="0" <?php echo !$info['ispublic']?'checked="checked"':''; ?>> <?php echo __('Private/Internal'); ?>
-                &nbsp;<span class="error">*&nbsp;</span> <i class="help-tip icon-question-sign" href="#type"></i>
+                &nbsp;<span class="error">*&nbsp;<?php echo $errors['ispublic']; ?></span> <i class="help-tip icon-question-sign" href="#type"></i>
             </td>
         </tr>
         <tr>

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -63,6 +63,10 @@ if($_POST){
             if (!$errors) {
                 $count=$_POST['ids']?count($_POST['ids']):0;
 
+                $activeTopics = Topic::getHelpTopics(false, false);
+                $allTopics = count(Topic::getAllHelpTopics());
+                $diff = array_intersect($_POST['ids'], array_keys($activeTopics));
+
                 switch(strtolower($_POST['a'])) {
                     case 'enable':
                         $topics = Topic::objects()->filter(array(
@@ -94,22 +98,30 @@ if($_POST){
                         }
                         break;
                     case 'disable':
+                        $num=0;
                         $topics = Topic::objects()->filter(array(
                           'topic_id__in'=>$_POST['ids'],
                         ))->exclude(array(
                             'topic_id'=>$cfg->getDefaultTopicId()
                         ));
-                        foreach ($topics as $t) {
-                          $t->setFlag(Topic::FLAG_ARCHIVED, false);
-                          $t->setFlag(Topic::FLAG_ACTIVE, false);
-                          $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
-                          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
-                          if($t->save()) {
-                              $type = array('type' => 'edited', 'status' => 'Disabled');
-                              Signal::send('object.edited', $t, $type);
-                              $num++;
-                          }
+
+                        if (($count >= $allTopics) ||
+                            (count($diff) == count($activeTopics))) {
+                            $errors['err'] = __('At least one Topic must be Active');
+                        } else {
+                            foreach ($topics as $t) {
+                              $t->setFlag(Topic::FLAG_ARCHIVED, false);
+                              $t->setFlag(Topic::FLAG_ACTIVE, false);
+                              $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
+                              FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
+                              if($t->save()) {
+                                  $type = array('type' => 'edited', 'status' => 'Disabled');
+                                  Signal::send('object.edited', $t, $type);
+                                  $num++;
+                              }
+                            }
                         }
+
                         if ($num > 0) {
                             if($num==$count)
                                 $msg = sprintf(__('Successfully disabled %s'),
@@ -118,27 +130,35 @@ if($_POST){
                                 $warn = sprintf(__('%1$d of %2$d %3$s disabled'), $num, $count,
                                     _N('selected help topic', 'selected help topics', $count));
                         } else {
-                            $errors['err'] = sprintf(__('Unable to disable %s'),
+                            $errors['err'] = $errors['err'] ?: sprintf(__('Unable to disable %s'),
                                 _N('selected help topic', 'selected help topics', $count));
                         }
                         break;
                     case 'archive':
+                        $num=0;
                         $topics = Topic::objects()->filter(array(
                           'topic_id__in'=>$_POST['ids'],
                         ))->exclude(array(
                             'topic_id'=>$cfg->getDefaultTopicId()
                         ));
-                        foreach ($topics as $t) {
-                          $t->setFlag(Topic::FLAG_ARCHIVED, true);
-                          $t->setFlag(Topic::FLAG_ACTIVE, false);
-                          $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
-                          FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
-                          if($t->save()) {
-                            $type = array('type' => 'edited', 'status' => 'Archived');
-                            Signal::send('object.edited', $t, $type);
-                            $num++;
-                          }
+
+                        if (($count >= $allTopics) ||
+                            (count($diff) == count($activeTopics))) {
+                            $errors['err'] = __('At least one Topic must be Active');
+                        } else {
+                            foreach ($topics as $t) {
+                              $t->setFlag(Topic::FLAG_ARCHIVED, true);
+                              $t->setFlag(Topic::FLAG_ACTIVE, false);
+                              $filter_actions = FilterAction::objects()->filter(array('type' => 'topic', 'configuration' => '{"topic_id":'. $t->getId().'}'));
+                              FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_HT', true);
+                              if($t->save()) {
+                                $type = array('type' => 'edited', 'status' => 'Archived');
+                                Signal::send('object.edited', $t, $type);
+                                $num++;
+                              }
+                            }
                         }
+
                         if ($num > 0) {
                             if($num==$count)
                                 $msg = sprintf(__('Successfully archived %s'),
@@ -147,23 +167,32 @@ if($_POST){
                                 $warn = sprintf(__('%1$d of %2$d %3$s archived'), $num, $count,
                                     _N('selected help topic', 'selected help topics', $count));
                         } else {
-                            $errors['err'] = sprintf(__('Unable to archive %s'),
+                            $errors['err'] = $errors['err'] ?: sprintf(__('Unable to archive %s'),
                                 _N('selected help topic', 'selected help topics', $count));
                         }
                         break;
                     case 'delete':
+                        $i=1;
                         $topics = Topic::objects()->filter(array(
                             'topic_id__in'=>$_POST['ids']
                         ));
 
-                        foreach ($topics as $t)
-                            $t->delete();
+                        //dont allow deletion of all topics
+                        if (($count >= $allTopics) ||
+                             count($diff) == count($activeTopics)) {
+                            $errors['err'] = __('At least one Topic must be Active');
+                        } else {
+                            foreach($topics as $t) {
+                                if($t->getId()!=$cfg->getDefaultTopicId() && $t->delete())
+                                    $i++;
+                            }
+                        }
 
-                        if($topics && $topics->count()==$count)
+                        if($i==($count + 1))
                             $msg = sprintf(__('Successfully deleted %s.'),
                                 _N('selected help topic', 'selected help topics', $count));
-                        elseif($topics>0)
-                            $warn = sprintf(__('%1$d of %2$d %3$s deleted'), $topics, $count,
+                        elseif($i>1)
+                            $warn = sprintf(__('%1$d of %2$d %3$s deleted'), ($i-1), $count,
                                 _N('selected help topic', 'selected help topics', $count));
                         elseif(!$errors['err'])
                             $errors['err']  = sprintf(__('Unable to delete %s.'),


### PR DESCRIPTION
This commit makes sure that we always have at least 1 Public and Active Help Topic

Mass Process:
- Do not allow deletion of all Topics
- Do not allow archiving/disabling all Topics
- Allow changing Topics from Disabled to Archived and vice versa

Note: If you try to archive, disable, or delete all Topics OR all Active Topics at once, it will throw the error that at least 1 topic must be active.

Topic Update:
- Do not allow changing Topic to Private if it's the only one that's Public
- Do not allow archiving/disabling if it's the only active Topic
- Allow changing Topics from Disabled to Archived and vice versa

It also gets rid of code we had in place in the Client Portal that would put a 'General Inquiry' Topic in the list if all Topics had been deleted. It didn't have an id to get a Topic form, so it still wouldn't allow for Ticket creation.