### PR TITLE
redactor: Improper Formatting When Double Spacing

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -512,6 +512,11 @@ class Format {
             ), '', $text);
     }
 
+    // Insert </br> tag inside empty <p> tags to ensure proper editor spacing
+    function editor_spacing($text) {
+        return preg_replace('/<p><\/p>/', '<p><br></p>', $text);
+    }
+
     //make urls clickable. Mainly for display
     function clickableurls($text, $target='_blank') {
         global $ost;

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2866,7 +2866,7 @@ class HtmlThreadEntryBody extends ThreadEntryBody {
     }
 
     function getClean() {
-        return Format::sanitize(parent::getClean());
+        return Format::sanitize(Format::editor_spacing(parent::getClean()));
     }
 
     function getSearchable() {


### PR DESCRIPTION
This addresses an issue where if using Double Spacing in Redactor and you put 2 or more lines in between paragraphs, the final content shows single spacing formatting. This is due to Redactor using `<p></p>` for the double spaced new lines and HTMLawed does not like that. This adds a new Format function called `editor_spacing()` that uses simple regex to find and replace `<p></p>` with `<p></br></p>` to ensure the formatting stays as typed.