### PR TITLE
Authcode: Ticket Access Link

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -53,28 +53,34 @@ implements EmailContact, ITicketUser, TemplateVariable {
     }
 
     function getVar($tag) {
-        global $cfg;
-
         switch (strtolower($tag)) {
         case 'ticket_link':
-            $qstr = array();
             $ticket = $this->getTicket();
-            if ($cfg && $cfg->isAuthTokenEnabled()
-                    && $ticket
-                    && !$ticket->getNumCollaborators()) {
-                $qstr['auth'] = $ticket->getAuthToken($this);
-                return sprintf('%s/view.php?%s',
+            return $this->getTicketLink(($ticket &&
+                        !$ticket->getNumCollaborators()));
+            break;
+        }
+    }
+
+    function getTicketLink($authtoken=true) {
+        global $cfg;
+
+        $ticket = $this->getTicket();
+        if ($authtoken
+                && $ticket
+                && $cfg->isAuthTokenEnabled()) {
+            $qstr = array();
+            $qstr['auth'] = $ticket->getAuthToken($this);
+            return sprintf('%s/view.php?%s',
                         $cfg->getBaseUrl(),
                         Http::build_query($qstr, false)
                         );
-            } else {
-                return sprintf('%s/tickets.php?id=%s',
-                        $cfg->getBaseUrl(),
-                        $ticket ? $ticket->getId() : 0
-                        );
-            }
-            break;
         }
+
+        return sprintf('%s/view.php?id=%s',
+                $cfg->getBaseUrl(),
+                $ticket ? $ticket->getId() : 0
+                );
     }
 
     function getId() { return ($this->user) ? $this->user->getId() : null; }

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1330,6 +1330,9 @@ implements RestrictedAccess, Threadable, Searchable {
             'ticket' => $this,
             'user' => $user,
             'recipient' => $user,
+            // Get ticket link, with authcode, directly to bypass collabs
+            // check
+            'recipient.ticket_link' => $user->getTicketLink(),
         );
 
         $lang = $user->getLanguage(UserAccount::LANG_MAILOUTS);

--- a/view.php
+++ b/view.php
@@ -39,6 +39,8 @@ elseif (isset($_GET['auth']) || isset($_GET['t'])) {
 
 if (@$user && is_object($user) && $user->getTicketId())
     Http::redirect('tickets.php?id='.$user->getTicketId());
+elseif ($thisclient && isset($_GET['id']) && is_numeric($_GET['t']))
+    Http::redirect('tickets.php?id='.$_GET['id']);
 
 $nav = new UserNav();
 $nav->setActiveNav('status');


### PR DESCRIPTION
osTicket provides ability to add ticket access link that can auto-login users (if auth codes feature is enable), but the auth code is not added when a ticket has collaborators. This is done on purpose to avoid access token leak, because one email is sent to all recipients. As workaround, a user can request ticket Access Link, individually, but the system still assumed that multiple recipients are getting the link based on number of collaborators on the ticket - meaning auth code is not added.

This commit addresses the issue by making sure Access Link requests bypass collaborators check.