### PR TITLE
PluginSupport: Add more Signals with documentation

### DIFF
--- a/include/class.signal.php
+++ b/include/class.signal.php
@@ -25,6 +25,56 @@
  * the codebase there exists a Signal::send() for the same named signal.
  */
 class Signal {
+    
+    /**
+     * Is called during creation of the template HTML header of the staff
+     * pages (include/staff/footer.inc.php) before the closing head tag.
+     * Use echo to append your own markup to the page.
+     * $object: null,
+     * $data: null
+     * @var string 
+     */
+    public static $SIGNAL_STAFF_HEADER = "tmpl.staff.header";
+    
+    /**
+     * Is called during creation of the template HTML footer of the staff
+     * pages (include/staff/header.inc.php) before the closing body tag.
+     * Use echo to append your own markup to the page.
+     * $object: null,
+     * $data: null
+     * @var string 
+     */
+    public static $SIGNAL_STAFF_FOOTER = "tmpl.staff.footer";
+    
+    /**
+     * Called whenever a thread-entry was converted to HTML before outputting
+     * in the template.
+     * Use this in order to enhance/filter the html shown in ticket threads
+     * $object: ThreadEntryBody (include/class.thread.php)
+     * $data: ["html" => html as string]
+     * @var string 
+     */
+    public static $SIGNAL_THREADENTRY_TOHTML = "threadentry.tohtml";
+    
+    /**
+     * Called when the status-template dialog (e.g. close) is rendered
+     * (include/staff/templates/task-status.tmpl.php)
+     * @var string
+     * $object: null
+     * $data: info array
+     */
+    public static $SIGNAL_TASK_STATUS = "tmpl.task-status";
+    
+    /**
+     * Called when the status-template dialog (e.g. close) is rendered
+     * (include/staff/templates/ticket-status.tmpl.php)
+     * @var string
+     * $object: null
+     * $data: info array
+     */
+    public static $SIGNAL_TICKET_STATUS = "tmpl.ticket-status";
+    
+    
     static private $subscribers = array();
 
     /**

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2770,7 +2770,9 @@ class ThreadEntryBody /* extends SplString */ {
     }
 
     function toHtml() {
-        return $this->display('html');
+        $data = ["html" => $this->display("html")];
+        Signal::send(Signal::$SIGNAL_THREADENTRY_TOHTML,$this,$data);
+        return $data["html"];
     }
 
     function prepend($what) {

--- a/include/staff/footer.inc.php
+++ b/include/staff/footer.inc.php
@@ -72,6 +72,9 @@ if ($thisstaff
     <script type="text/javascript" src="ajax.php/i18n/<?php
         echo $thisstaff->getLanguage(); ?>/js"></script>
 <?php } ?>
+        
+<?php Signal::send(Signal::$SIGNAL_STAFF_FOOTER, null); ?>
+        
 </body>
 </html>
 <?php } # endif X_PJAX ?>

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -59,6 +59,8 @@ if (osTicket::is_ie())
         echo "\n\t".implode("\n\t", $headers)."\n";
     }
     ?>
+    
+    <?php Signal::send(Signal::$SIGNAL_STAFF_HEADER, $ost); ?>
 </head>
 <body>
 <div id="container">

--- a/include/staff/templates/task-status.tmpl.php
+++ b/include/staff/templates/task-status.tmpl.php
@@ -56,6 +56,7 @@ $action = $info[':action'] ?: ('#tasks/mass/'. $action);
             </tbody>
         </table>
         <hr>
+        <?php Signal::send(Signal::$SIGNAL_TASK_STATUS, null, $info);?>
         <p class="full-width">
             <span class="buttons pull-left">
                 <input type="reset" value="<?php echo __('Reset'); ?>">

--- a/include/staff/templates/ticket-status.tmpl.php
+++ b/include/staff/templates/ticket-status.tmpl.php
@@ -103,6 +103,7 @@ $action = $info['action'] ?: ('#tickets/status/'. $state);
            <?php } ?>
         </table>
         <hr>
+        <?php Signal::send(Signal::$SIGNAL_TICKET_STATUS, null, $info); ?>
         <p class="full-width">
             <span class="buttons pull-left">
                 <input type="reset" value="<?php echo __('Reset'); ?>">


### PR DESCRIPTION
This is a follow up of #4676

I added a few signals I need for my own plugins and added also some documentation in the signal class as comments for the constant signal-strings.

If you consider merging, please let me know, I am willing to add documentation for all other existing signal calls in order to make plugin development easier for future developers.