### PR TITLE
issue: Draft Save

### DIFF
--- a/include/ajax.draft.php
+++ b/include/ajax.draft.php
@@ -388,8 +388,15 @@ class DraftAjaxAPI extends AjaxController {
                 return $focus;
             }
         }
+
+        // Get ThreadEntry field name.
+        $tform = TicketForm::objects()->one()->getForm();
+        $tfield = $tform->getField('message')->getFormName();
+        // Get Task Description field name.
+        $aform = TaskForm::objects()->one()->getForm();
+        $afield = $aform->getField('description')->getFormName();
         $field_list = array('response', 'note', 'answer', 'body',
-             'message', 'issue', 'description');
+             $tfield, 'issue', $afield);
         foreach ($field_list as $field) {
             if (isset($vars[$field])) {
                 return $vars[$field];

--- a/include/ajax.tasks.php
+++ b/include/ajax.tasks.php
@@ -110,6 +110,7 @@ class TasksAjaxAPI extends AjaxController {
                 $vars['default_formdata'] = $form->getClean();
                 $vars['internal_formdata'] = $iform->getClean();
                 $desc = $form->getField('description');
+                $vars['description'] = $desc->getClean();
                 if ($desc
                         && $desc->isAttachmentsEnabled()
                         && ($attachments=$desc->getWidget()->getAttachments()))


### PR DESCRIPTION
This addresses a small issue introduced with #5694 where Drafts do not save when creating a New Ticket via Staff/Client side. This is due to a field name mismatch in `include/ajax.draft.php`. We are expecting `message` but we get the hashed name instead. This addresses another issue where Drafts do not save when creating a New Task. We are expecting `description` but we get the hashed name instead. This adds the hashed names to the array of possible fields which allows the system to find the Draft bodies and save the Drafts successfully.

This also addresses an issue where the Task Description is missing when creating new Tasks. This is due to a field name mismatch when #5694 was applied. This gets the clean value to ensure the content is saved.