### PR TITLE
authtoken: Add ticket link when recipient is ticket owner

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3390,6 +3390,15 @@ implements RestrictedAccess, Threadable, Searchable {
                 && ($tpl = $dept->getTemplate())
                 && ($msg=$tpl->getReplyMsgTemplate())) {
 
+            // Add ticket link (possibly with authtoken) if the ticket owner
+            // is the only recipient on a ticket with collabs
+            if (count($recipients) == 1
+                    && $this->getNumCollaborators()
+                    && ($contact = $recipients->pop()->getContact())
+                    && ($contact instanceof TicketOwner))
+                $variables['recipient.ticket_link'] =
+                    $contact->getTicketLink();
+
             $msg = $this->replaceVars($msg->asArray(),
                 $variables + array('recipient' => $this->getOwner())
             );


### PR DESCRIPTION
This commit adds ticket link (possibly with authtoken) to replies -  if the ticket owner is the only recipient selected on a ticket with collaborators.
