### PR TITLE
Issue: Viewing Email Templates

### DIFF
--- a/include/staff/tpl.inc.php
+++ b/include/staff/tpl.inc.php
@@ -39,7 +39,6 @@ $tpl=$msgtemplates[$selected];
 <div class="pull-right">
     <span style="font-size:10pt"><?php echo __('Viewing'); ?>:</span>
     <select id="tpl_options" name="id" style="width:250px;">
-        <option value="">&mdash; <?php echo __('Select Setting Group'); ?> &mdash;</option>
         <?php
         $impl = $group->getTemplates();
         $current_group = false;


### PR DESCRIPTION
This commit addresses Issue #5663 where there was a default selection option in the list of Email Templates that would display empty template fields that could not be saved.