### PR TITLE
mpdf: Logo Overlap

### DIFF
--- a/include/staff/templates/ticket-print.tmpl.php
+++ b/include/staff/templates/ticket-print.tmpl.php
@@ -137,6 +137,7 @@ img.avatar {
     </tr></table>
 </htmlpagefooter>
 
+<div>&nbsp;</div>
 <!-- Ticket metadata -->
 <h1>Ticket #<?php echo $ticket->getNumber(); ?></h1>
 <table class="meta-data" cellpadding="0" cellspacing="0">


### PR DESCRIPTION
This addresses a small annoyance where the logo overlaps the date-timestamp and looks ugly for bigger logos. This adds a blank line between the two so the formatting looks nice again, no matter what size it is.