### PR TITLE
Partially revert commit 077d26f6d0bb15

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1174,7 +1174,7 @@ class FormField {
                 'id' => $this->get('id')]);
 
         // Force pseudo-random name for Dynamicforms on POST (Web Tickets)
-        if ($_POST
+        if (0 && $_POST
                 && !defined('APICALL')
                 && isset($this->ht['form'])
                 && ($this->ht['form'] instanceof DynamicForm))


### PR DESCRIPTION
This commit partially reverts 077d26f6d0bb15 by disabling forced random form name for now. We will revisit the enhancement in the near future. 