### PR TITLE
issue: Task From Ticket

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1816,6 +1816,7 @@ class TicketsAjaxAPI extends AjaxController {
                 $vars['default_formdata'] = $form->getClean();
                 $vars['internal_formdata'] = $iform->getClean();
                 $desc = $form->getField('description');
+                $vars['description'] = $desc->getClean();
                 if ($desc
                         && $desc->isAttachmentsEnabled()
                         && ($attachments=$desc->getWidget()->getAttachments()))


### PR DESCRIPTION
This addresses an issue where creating a Task from a Ticket does not save the Task Description. This is due to a field name mismatch. This adds `$desc->getClean()` to `$vars['description']` so we have the field name and value ready for `TaskThread::addDescription()`.