### PR TITLE
Feature fix signal object created

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3176,9 +3176,12 @@ implements RestrictedAccess, Threadable, Searchable {
           //when user replies, this is where collabs notified
           $ticket->notifyCollaborators($message, array('signature' => ''));
         }
-
-        if (!($alerts && $autorespond))
-            return $message; //Our work is done...
+        if (!($alerts && $autorespond)) {
+            //Our work is done..., but don't forget our plugins
+            $type = array('type' => 'message', 'uid' => $vars['userId']);
+            Signal::send('object.created', $this, $type);
+            return $message; 
+        }
 
         $dept = $ticket->getDept();
         $variables = array(


### PR DESCRIPTION
If a new message is appended to a ticket (e.g. via E-Mail), normally the Signal object.created is sent. But in case no alerts or autorespond is neccessary, the method Ticket::postMessage is left early without sending the signal. Thus my plugin does not have the ability to still re-open Tickets even on auto-reply (like mailer daemon errors).

This PR makes sure the signal is sent also in this case.