### PR TITLE
Restrict user searches based on perms

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -26,6 +26,8 @@ class UsersAjaxAPI extends AjaxController {
     /* Assumes search by basic info for now */
     function search($type = null, $fulltext=false) {
 
+        global $thisstaff;
+        
         if(!isset($_REQUEST['q'])) {
             Http::response(400, __('Query argument is required'));
         }
@@ -45,8 +47,14 @@ class UsersAjaxAPI extends AjaxController {
 
         if (!$type || !strcasecmp($type, 'remote')) {
             foreach (AuthenticationBackend::searchUsers($q) as $u) {
-                if (!trim($u['email']))
+                $umail = trim($u['email']);
+                if (!$umail)
                     // Email is required currently
+                    continue;
+                if ((!$thisstaff->hasPerm(User::PERM_DIRECTORY)) &&
+                    ($q != $umail))
+                    // If agent can't search user directory,
+                    // they must type full email to get a match
                     continue;
                 $name = new UsersName(array('first' => $u['first'], 'last' => $u['last']));
                 $matches[] = array('email' => $u['email'], 'name'=>(string) $name,
@@ -105,6 +113,11 @@ class UsersAjaxAPI extends AjaxController {
                         break;
                     }
                 }
+                if ((!$thisstaff->hasPerm(User::PERM_DIRECTORY)) &&
+                    ($q != $email))
+                    // If agent can't search user directory,
+                    // they must type full email to get a match
+                    continue;
                 $name = Format::htmlchars(new UsersName($name));
                 $matches[] = array('email'=>$email, 'name'=>$name, 'info'=>"$email - $name",
                     "id" => $id, "/bin/true" => $_REQUEST['q']);


### PR DESCRIPTION
This edit makes it so that if the agent typing into a user-search field does not have permission to search the user directory, they will not be presented a list of all users (and emails) after only a few characters. Instead, they must type a user's entire email before the user shows up as a match. This prevents users without the proper permissions from harvesting the entire user list just by searching on a few characters. We currently use this edit is our local implementation of osTicket at WGS.