### PR TITLE
typo: Change User Confirmation Popup

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -1293,7 +1293,7 @@ if ($errors['err'] && isset($_POST['a'])) {
     </p>
     <p class="confirm-action" style="display:none;" id="changeuser-confirm">
         <span id="msg_warning" style="display:block;vertical-align:top">
-        <?php echo sprintf(Format::htmlchars(__('%s <%s> will longer have access to the ticket')),
+        <?php echo sprintf(Format::htmlchars(__('%s <%s> will no longer have access to the ticket')),
             '<b>'.Format::htmlchars($ticket->getName()).'</b>', Format::htmlchars($ticket->getEmail())); ?>
         </span>
         <?php echo sprintf(__('Are you sure you want to <b>change</b> ticket owner to %s?'),


### PR DESCRIPTION
This fixes a small typo in the Change User Confirmation Popup. This updates `will longer have access to the ticket` to `will no longer have access to the ticket`.