### PR TITLE
Fix form placeholder not enclosed in double quotes

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4333,8 +4333,8 @@ class TextboxWidget extends Widget {
         if (isset($config['autofocus']))
             $autofocus = 'autofocus';
         // placeholder
-        $attrs['placeholder'] = $this->field->getLocal('placeholder',
-                $config['placeholder']);
+        $attrs['placeholder'] = '"' . $this->field->getLocal('placeholder',
+                $config['placeholder']) . '"';
 
         $type = static::$input_type;
         $types = array(


### PR DESCRIPTION
Fixes #5729 by adding the necessary double quotes, as it is done for all other `$attrs`-entries.