### PR TITLE
Issue: Collaborator Adding New Collabs

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3115,7 +3115,8 @@ implements RestrictedAccess, Threadable, Searchable {
 
                 if (($cuser=User::fromVars($recipient))) {
                   if (!$existing = Collaborator::getIdByUserId($cuser->getId(), $ticket->getThreadId())) {
-                    if ($c=$ticket->addCollaborator($cuser, $info, $errors, false)) {
+                    $_errors = array();
+                    if ($c=$ticket->addCollaborator($cuser, $info, $_errors, false)) {
                       $c->setCc($c->active);
 
                       // FIXME: This feels very unwise — should be a


### PR DESCRIPTION
This commit fixes an issue where if a Collaborator does a reply all to a Ticket and the reply includes the Ticket Owner as well as a new Collaborator, the new Collaborator was not added because of the error 'Ticket Owner cannot be a Collaborator' not being cleared out.