### PR TITLE
mail: Reply to Ticket Owner Only

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3394,7 +3394,7 @@ implements RestrictedAccess, Threadable, Searchable {
             // is the only recipient on a ticket with collabs
             if (count($recipients) == 1
                     && $this->getNumCollaborators()
-                    && ($contact = $recipients->pop()->getContact())
+                    && ($contact = $recipients->offsetGet(0)->getContact())
                     && ($contact instanceof TicketOwner))
                 $variables['recipient.ticket_link'] =
                     $contact->getTicketLink();


### PR DESCRIPTION
This PR addresses a bug that results in a ticket reply not being sent to ticket owner on a ticket with disabled collaborators or when ticket owner is the only selected recipient.