### PR TITLE
issue: Editor Spacing

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2866,7 +2866,13 @@ class HtmlThreadEntryBody extends ThreadEntryBody {
     }
 
     function getClean() {
-        return Format::sanitize(Format::editor_spacing(parent::getClean()));
+        global $thisclient, $thisstaff;
+
+        $clean = ($thisstaff || $thisclient)
+                ? Format::editor_spacing(parent::getClean())
+                : parent::getClean();
+
+        return Format::sanitize($clean);
     }
 
     function getSearchable() {


### PR DESCRIPTION
This addresses an issue where the `editor_spacing` was being applied to emails and web created tickets. This updates the code to check for an Agent or User session and if exists we will run `editor_spacing`; otherwise we will not.