### PR TITLE
issue: MailFetch Inline Disposition

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -452,7 +452,12 @@ class MailFetcher {
                     || !$this->findFilename($struct->dparameters))) {
 
             $partNumber=$partNumber?$partNumber:1;
-            if(($text=imap_fetchbody($this->mbox, $mid, $partNumber))) {
+            if(!($text=imap_fetchbody($this->mbox, $mid, $partNumber))
+                    && $partNumber == 1
+                    && $struct->disposition == 'inline')
+                $text=imap_body($this->mbox, $mid);
+
+            if ($text) {
                 if($struct->encoding==3 or $struct->encoding==4) //base64 and qp decode.
                     $text=$this->decode($text, $struct->encoding);
 


### PR DESCRIPTION
This is a rewrite of #5733 that addresses issue #3884 where `imap_fetchbody()` is not sufficient with some emails. This updates `MailFetcher::getPart()` to check the MIME part's disposition and part number, if the disposition is `inline` and the part number is `1` then we will use `imap_body()` instead.