### PR TITLE
security: Parent Ticket Access (Client)

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -449,8 +449,15 @@ implements RestrictedAccess, Threadable, Searchable {
             return true;
         }
         // 3) If the ticket is a child of a merge
-        if ($this->isParent() && $this->getMergeType() != 'visual')
-            return true;
+        if ($this->isParent() && $this->getMergeType() != 'visual') {
+            $children = Ticket::objects()
+                    ->filter(array('ticket_pid'=>$this->getId()))
+                    ->order_by('sort');
+
+            foreach ($children as $child)
+                if ($child->checkUserAccess($user))
+                    return true;
+        }
 
         return false;
     }


### PR DESCRIPTION
This addresses a vulnerability reported by Daniel Treffenstädt (MuonPi Team) where any User can get access to any Parent Ticket by ID (not Number) even if they don't have access to the Parent or any Children. This is due to checking if the ticket is a parent and is merged (not linked) without checking for access to the children. This updates the check to grab all children and check the User's access to each. If the User has access to one of the children they are allowed access to the Parent, however if they do not have access to one of the children they are denied access.