### PR TITLE
issue: Assign To Sort Alphabetically

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1012,6 +1012,8 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             ));
         }
 
+        $agents = self::nsort($agents);
+
         if (isset($criteria['namesOnly'])) {
             $clean = array();
             foreach ($agents as $a) {


### PR DESCRIPTION
This addresses a small issue where Agents were not sorted alphabetically when Assigning/Re-Assigning a Ticket or Task. This is especially frustrating when you have an enormous list of Agents. This adds `nsort()` to `getDeptAgents()` so we can sort the Agents by the system's Name Format.