### PR TITLE
Issue: Disabled Dept on Email

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -169,28 +169,6 @@ implements TemplateVariable, Searchable {
         return !!($this->flags & self::FLAG_ACTIVE);
     }
 
-    function clearInactiveDept($dept_id) {
-      global $cfg;
-
-      $topics = Topic::objects()->filter(array('dept_id'=>$dept_id))->values_flat('topic_id');
-      if ($topics) {
-        foreach ($topics as $topic_id) {
-          $topic = Topic::lookup($topic_id[0]);
-          $topic->dept_id = $cfg->getDefaultDeptId();
-          $topic->save();
-        }
-      }
-
-      $emails = Email::objects()->filter(array('dept_id'=>$dept_id))->values_flat('email_id');
-      if ($emails) {
-        foreach ($emails as $email_id) {
-          $email = Email::lookup($email_id[0]);
-          $email->dept_id = $cfg->getDefaultDeptId();
-          $email->save();
-        }
-      }
-    }
-
     function getEmailId() {
         return $this->email_id;
     }

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4222,6 +4222,9 @@ implements RestrictedAccess, Threadable, Searchable {
         // topic
         if ($vars['emailId'] && ($email=Email::lookup($vars['emailId']))) {
             $deptId = $deptId ?: $email->getDeptId();
+            $dept = Dept::lookup($deptId);
+            if ($dept && !$dept->isActive())
+                $deptId = $cfg->getDefaultDeptId();
             $priority = $form->getAnswer('priority');
             if (!$priority || !$priority->getIdValue())
                 $form->setAnswer('priority', null, $email->getPriorityId());

--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -95,11 +95,15 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info);
                 <?php echo __('Status');?>:
             </td>
             <td>
+                <?php if ($dept->getId() == $cfg->getDefaultDeptId())
+                    echo $dept->getStatus();
+                else { ?>
                 <select name="status">
                   <option value="active"<?php echo (!strcasecmp($info['status'], 'active'))?'selected="selected"':'';?>><?php echo __('Active'); ?></option>
                   <option value="disabled"<?php echo (!strcasecmp($info['status'], 'disabled'))?'selected="selected"':'';?>><?php echo __('Disabled'); ?></option>
                   <option value="archived"<?php echo (!strcasecmp($info['status'], 'archived'))?'selected="selected"':'';?>><?php echo __('Archived'); ?></option>
                 </select>
+                <?php } ?>
                 &nbsp;<span class="error">&nbsp;</span> <i class="help-tip icon-question-sign" href="#status"></i>
             </td>
         </tr>

--- a/scp/departments.php
+++ b/scp/departments.php
@@ -166,8 +166,6 @@ if($_REQUEST['id'] && !($dept=Dept::lookup($_REQUEST['id'])))
                                 $type = array('type' => 'edited', 'status' => 'Archived');
                                 Signal::send('object.edited', $d, $type);
                                 $num++;
-                                //set dept_id to default for topics/emails using archived dept
-                                Dept::clearInactiveDept($d->getId());
                               }
                             }
                             if ($num > 0) {


### PR DESCRIPTION
This commit finishes fixing an issue we had with disabling or archiving a Department that is assigned to an Email. At one time, we were setting the Department in the Email to the default Department if an Email's Department was disabled or archived. Part of this was removed in #4588. If we are going to leave the Department in the Email, we need to make sure that Tickets fetched from that email are not assigned to the Disabled/Archived Department. This commit will check the deptId that comes in and if the Department is not active, the Ticket will be assigned to the default Department.

It also makes it so that you cannot change the status of the Default Department to Archived or Disabled. Rather than showing up as a selection, we will just show the Department's status.