### PR TITLE
issue: Export Memory Limit

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -815,6 +815,9 @@ class CustomQueue extends VerySimpleModel {
                 || !($fields=$this->getExportFields()))
             return false;
 
+        // Do not store results in memory
+        $query->setOption(QuerySet::OPT_NOCACHE, true);
+
         // See if we have cached export preference
         if (isset($_SESSION['Export:Q'.$this->getId()])) {
             $opts = $_SESSION['Export:Q'.$this->getId()];


### PR DESCRIPTION
This addresses an issue where exporting large datasets (eg. 100,000+ Closed Tickets) gives you a blank CSV once complete. This is due to PHP running out of memory which results in no data being written to the CSV at all. This sets the `QuerySet::OPT_NOCACHE` option to `true` so the result sets are not stored in memory. Essentially, storing large result sets in memory is no bueno.