### PR TITLE
issue: Client-Side Reply Draft Saving

### DIFF
--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -173,7 +173,7 @@ if ((!$ticket->isClosed() || $ticket->isReopenable()) && !$blockReply) { ?>
          echo __('To best assist you, we request that you be specific and detailed'); ?></em>
         <font class="error">*&nbsp;<?php echo $errors['message']; ?></font>
         </p>
-        <textarea name="message" id="message" cols="50" rows="9" wrap="soft"
+        <textarea name="<?php echo $messageField->getFormName(); ?>" id="message" cols="50" rows="9" wrap="soft"
             class="<?php if ($cfg->isRichTextEnabled()) echo 'richtext';
                 ?> draft" <?php
 list($draft, $attrs) = Draft::getDraftAndDataAttrs('ticket.client', $ticket->getId(), $info['message']);

--- a/tickets.php
+++ b/tickets.php
@@ -76,7 +76,7 @@ if ($_POST && is_object($ticket) && $ticket->getId()) {
         if(!$ticket->checkUserAccess($thisclient)) //double check perm again!
             $errors['err']=__('Access Denied. Possibly invalid ticket ID');
 
-        $_POST['message'] = ThreadEntryBody::clean($_POST['message']);
+        $_POST['message'] = ThreadEntryBody::clean($_POST[$messageField->getFormName()]);
         if (!$_POST['message'])
             $errors['message'] = __('Message required');
 


### PR DESCRIPTION
This addresses an issue where Draft saving for the Post a Reply box on the Client Portal returns the error `Draft body not found in request`. This is due to using the generic name of `message` instead of the hashed Form name. This updates the code to set the hashed Form name using `$messageField->getFormName()`.