### PR TITLE
Don't capitalize Queue menu items

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -418,7 +418,6 @@ a time {
     padding-bottom:2px;
     display:inline-block;
     text-decoration:none;
-    text-transform:capitalize;
 }
 .customQ-dropdown a.truncate {
     min-width: 140px;


### PR DESCRIPTION
In other languages are capitalized "Queue" menu items a little ugly.

"Assigned to me" is "Mir zugewiesen" in German. But the CSS rules from the SCP make it to "Mir Zugewiesen" witch looks ugly.

It also inconsistent, since the heading use the normal case from the DB entry.