### PR TITLE
issue: SCP Login Redirect

### DIFF
--- a/scp/login.php
+++ b/scp/login.php
@@ -102,6 +102,9 @@ elseif (!$thisstaff || !($thisstaff->getId() || $thisstaff->isValid())) {
         $msg = $_SESSION['_staff']['auth']['msg'];
     }
 }
+elseif ($thisstaff && $thisstaff->isValid()) {
+    Http::redirect($dest);
+}
 
 // Browsers shouldn't suggest saving that username/password
 Http::response(422);


### PR DESCRIPTION
This addresses issue #5741 where when logged in as an Agent and visiting `scp/login.php` directly it does not redirect you to the Ticket Queues, instead it shows the login modal. This adds a check to `scp/login.php` to see if there is a valid Agent Session and if so we redirect to the Ticket Queues.