### PR TITLE
view.php checks wrong parameter for client auth

### DIFF
--- a/view.php
+++ b/view.php
@@ -39,7 +39,7 @@ elseif (isset($_GET['auth']) || isset($_GET['t'])) {
 
 if (@$user && is_object($user) && $user->getTicketId())
     Http::redirect('tickets.php?id='.$user->getTicketId());
-elseif ($thisclient && isset($_GET['id']) && is_numeric($_GET['t']))
+elseif ($thisclient && isset($_GET['id']) && is_numeric($_GET['id']))
     Http::redirect('tickets.php?id='.$_GET['id']);
 
 $nav = new UserNav();


### PR DESCRIPTION
view.php used the parameter `id` for client auth but checked the parameter `t` for numeric.

This fix problems with *LDAP Authentication and Lookup* and *HTTP Passthru Authentication* plugin.