### PR TITLE
Issue: Echoing Default Dept Status

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -864,6 +864,9 @@ implements TemplateVariable, Searchable {
         else
           FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', true);
 
+        if ($this->getId() == $cfg->getDefaultDeptId())
+            $vars['status'] = 'active';
+
         switch ($vars['status']) {
           case 'active':
             $this->setFlag(self::FLAG_ACTIVE, true);


### PR DESCRIPTION
This commit fixes an issue introduced with PR #5755 where we just echo the status of the Default Department so that you don't have the option to disable/archive it. When we update a Department, if $vars['flags'] isn't present, we clear out the flags to 0 and then set them according to the other vars set. Since we are just echoing the status name for the default department, $vars['status'] is NULL, so when you save the department, it ends up being disabled (we can't put the flag back). So if we're updating the default department, we need to confirm that it is the default and then manually set $vars['status'] to 'active' so that the flag is set correctly.