### PR TITLE
issue: Task last_update Var

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1125,7 +1125,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                 return new FormattedDate($this->getCloseDate());
             break;
         case 'last_update':
-            return new FormattedDate($this->last_update);
+            return new FormattedDate($this->updated);
         case 'description':
             return Format::display($this->getThread()->getVar('original') ?: '');
         case 'subject':


### PR DESCRIPTION
This addresses a small issue reported on the Forum where when using the `%{task.last_update}` variable in the Task Email Templates you receive a fatal error of `Uncaught OrmException: Task: last_update: Field not defined in`. This is due to the variable pulling data from `last_udpate` whilst not having a column called `last_update` in the `ost_task` table. This updates the variable to pull data from `updated` as this is the correct column to use in the `ost_task` table.