### PR TITLE
issue: Dashboard Export Date Range

### DIFF
--- a/include/class.report.php
+++ b/include/class.report.php
@@ -44,7 +44,7 @@ class OverviewReport {
         if ($translate) {
             $format = str_replace(
                     array('y', 'Y', 'm'),
-                    array('yy', 'yyyy', 'mm'),
+                    array('y', 'yy', 'mm'),
                     $format);
         }
 


### PR DESCRIPTION
This addresses an issue where choosing a Report Timeframe in the Dashboard and clicking Refresh defaults the date to 2020 (yikes, please don't make us relive it). In addition, the CSVs exported from the selected time periods are blank. This is due to a date formatting issue in `OverviewReport::getStartDate()`. This updates the replacement format from `array('yy', 'yyyy', 'mm')` to `array('y', 'yy', 'mm')`.