### PR TITLE
issue: getDefaultDeptId() On Null

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -864,7 +864,7 @@ implements TemplateVariable, Searchable {
         else
           FilterAction::setFilterFlags($filter_actions, 'Filter::FLAG_INACTIVE_DEPT', true);
 
-        if ($this->getId() == $cfg->getDefaultDeptId())
+        if ($cfg && ($this->getId() == $cfg->getDefaultDeptId()))
             $vars['status'] = 'active';
 
         switch ($vars['status']) {


### PR DESCRIPTION
This addresses an issue where the system throws a fatal error of `Fatal error: Uncaught Error: Call to a member function getDefaultDeptId() on null` when doing a fresh installation. This was introduced with #5777 and is due to trying get the default Department's ID from the system config when it's not available. This adds a check for `$cfg` before calling it to ensure no fatal errors are thrown.