### PR TITLE
Issue: Task Inline Transfer

### DIFF
--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -367,6 +367,7 @@ if (!$ticket) { ?>
 
                     <tr>
                         <th><?php echo __('Department');?>:</th>
+                        <?php if ($role->hasPerm(Task::PERM_TRANSFER)) {?>
                         <td>
                             <a class="task-action" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Transfer'); ?>"
                               data-redirect="tasks.php?id=<?php echo $task->getId(); ?>"
@@ -375,6 +376,9 @@ if (!$ticket) { ?>
                                   saveDraft();"
                               ><?php echo Format::htmlchars($task->dept->getName()); ?>
                         </td>
+                        <?php }else {?>
+                          <td><?php echo Format::htmlchars($task->dept->getName()); ?></td>
+                        <?php } ?>
                     </tr>
                     <?php
                     if ($task->isOpen()) { ?>


### PR DESCRIPTION
This commit fixes an issue where we were not checking role permissions for inline edit on Tasks. If an Agent without the role permission to Transfer Tasks tried to click the Deparment to transfer it, it popped up a blank modal and said 'Permission Denied'. Now, the Department will not have the edit link if they don't have the permission.