### PR TITLE
Show ticket status translation in Ticket View/Edit V2

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -1439,12 +1439,6 @@ implements CustomListItem, TemplateVariable, Searchable {
 
         return $this->getLocalName();
 
-        return sprintf('<a class="preview" href="#"
-                data-preview="#list/%d/items/%d/preview">%s</a>',
-                $this->getListId(),
-                $this->getId(),
-                $this->getLocalName()
-                );
     }
 
     function update($vars, &$errors) {

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -81,7 +81,7 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
                 <?php
                 $criteria = array('states' => array('open'));
                 foreach (TicketStatusList::getStatuses($criteria) as $status) {
-                    $name = $status->getName();
+                    $name = $status->getLocalName();
                     if (!($isenabled = $status->isEnabled()))
                         $name.=' '.__('(disabled)');
 

--- a/include/staff/templates/status-options.tmpl.php
+++ b/include/staff/templates/status-options.tmpl.php
@@ -66,7 +66,7 @@ if (!$nextStatuses)
                 ><i class="<?php
                         echo $actions[$status->getState()]['icon'] ?: 'icon-tag';
                     ?>"></i> <?php
-                        echo __($status->getName()); ?></a>
+                        echo $status->getLocalName(); ?></a>
         </li>
     <?php
     } ?>

--- a/include/staff/templates/ticket-status.tmpl.php
+++ b/include/staff/templates/ticket-status.tmpl.php
@@ -60,7 +60,7 @@ $action = $info['action'] ?: ('#tickets/status/'. $state);
                                         $s->getId(),
                                         ($info['status_id'] == $s->getId())
                                          ? 'selected="selected"' : '',
-                                        $s->getName()
+                                        $s->getLocalName()
                                         );
                             }
                             ?>

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -423,7 +423,7 @@ print $response_form->getField('attachments')->render();
                                 $s->getId(),
                                 $selected
                                  ? 'selected="selected"' : '',
-                                __($s->getName()));
+                                $s->getLocalName());
                     }
                     ?>
                     </select>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -329,11 +329,11 @@ if($ticket->isOverdue())
                               onclick="javascript:
                                   saveDraft();"
                               >
-                              <?php echo $ticket->getStatus(); ?>
+                              <?php echo ($S = $ticket->getStatus()) ? $S->getLocalName() : ''; ?>
                           </a>
                         </td>
                       <?php } else { ?>
-                          <td><?php echo ($S = $ticket->getStatus()) ? $S->display() : ''; ?></td>
+                          <td><?php echo ($S = $ticket->getStatus()) ? $S->getLocalName() : ''; ?></td>
                       <?php } ?>
                 </tr>
                 <tr>
@@ -1109,7 +1109,7 @@ if ($errors['err'] && isset($_POST['a'])) {
                                 $s->getId(),
                                 $selected
                                  ? 'selected="selected"' : '',
-                                __($s->getName()),
+                                $s->getLocalName(),
                                 $selected
                                 ? (' ('.__('current').')') : ''
                                 );
@@ -1199,7 +1199,7 @@ if ($errors['err'] && isset($_POST['a'])) {
                             echo sprintf('<option value="%d" %s>%s%s</option>',
                                     $s->getId(),
                                     $selected ? 'selected="selected"' : '',
-                                    __($s->getName()),
+                                    $s->getLocalName(),
                                     $selected ? (' ('.__('current').')') : ''
                                     );
                         }


### PR DESCRIPTION
Use the local name more often for ticket status in ticket view/edit.

We use custom ticket statuses with German translations. But many places in osTicket show still the English name. This PR fix at least some parts in the Ticket View/Edit.