### PR TITLE
Check CSRF token if the normal login form was used

### DIFF
--- a/scp/login.php
+++ b/scp/login.php
@@ -59,7 +59,7 @@ if ($_POST) {
     // use a different CSRF token. This will help ward off both parallel and
     // serial brute force attacks, because new tokens will have to be
     // requested for each attempt.
-    if (!$ost->checkCSRFToken()) {
+    if (isset($_POST['userid']) && !$ost->checkCSRFToken()) {
         $_SESSION['_staff']['auth']['msg'] = __('Valid CSRF Token Required');
         $redirect($_SERVER['REQUEST_URI']);
     }


### PR DESCRIPTION
Some alternative Auth methods, like SAML, do not use the CSRF approach to validate the POST content, and instead has its own mechanism, SAML for example uses a signature validation mechanism.

The checkCSRFToken causes issues when SAML login process happens, where there is no CSRF token at all.

If we only check the CSRF when we know the normal login form was used, like for example, verifying that the POST 'userid' parameters exist, we prevent the SAML scenario to experience issues at the same time we keep the security in the other Auth mechanism.