### PR TITLE
Submit dialog on Enter keydown

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -592,6 +592,13 @@ jQuery.fn.exists = function() { return this.length>0; };
 $.pjax.defaults.timeout = 30000;
 $(document).keydown(function(e) {
 
+   if (e.keyCode == 13 && !$('#overlay').is(':hidden')) {
+        $('div.dialog input[type=button].confirm').click();
+
+        e.preventDefault();
+        e.stopPropagation();
+        return false;
+    }
     if (e.keyCode == 27 && !$('#overlay').is(':hidden')) {
         $('div.dialog').hide();
         $.toggleOverlay(false);


### PR DESCRIPTION
When deleting a lot of entries, being able to hit Enter on each confirmation prompt instead of moving and pointing the cursor will save time. Moreover, using Enter to confirm is a convention widespread across many operating systems.

I took the existing code you had for the Esc keydown and matched it to use the Enter key to click the confirm button. If you can think of a better way to accomplish this, then of course go for it.