### PR TITLE
issue: markAs Popup Manager (No Access)

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1597,7 +1597,7 @@ class TicketsAjaxAPI extends AjaxController {
         if (!($ticket=Ticket::lookup($tid)))
             Http::response(404, __('No such ticket'));
 
-        if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_MARKANSWERED) && !$thisstaff->isManager())
+        if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_MARKANSWERED) && !$thisstaff->isManager($ticket->getDept()))
             Http::response(403, __('Permission denied'));
 
         $errors = array();

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -532,8 +532,8 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
                 || $this->hasPerm(Ticket::PERM_CLOSE, false);
     }
 
-    function isManager() {
-        return (($dept=$this->getDept()) && $dept->getManagerId()==$this->getId());
+    function isManager($dept=null) {
+        return (($dept=$dept?:$this->getDept()) && $dept->getManagerId()==$this->getId());
     }
 
     function isStaff() {


### PR DESCRIPTION
This addresses an issue where if an Agent does not have access to a Department but is the Manager of the Department and they go to mark a Ticket as Answered/Unanswered a blank popup appears. This is due to `isManager()` only checking the Agent’s Primary Department for Manager access. This updates the method to accept a Department object and if one is passed we will check this for Manager access, otherwise we will default to the Agent’s Primary Department.