### PR TITLE
issue: ticket.dept.sla Variable sla_id

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -31,7 +31,7 @@ implements TemplateVariable, Searchable {
                 'null' => true,
              ),
             'sla' => array(
-                'constraint' => array('sla_id' => 'SLA.sla_id'),
+                'constraint' => array('sla_id' => 'SLA.id'),
                 'null' => true,
             ),
             'manager' => array(


### PR DESCRIPTION
This addresses an issue where when using the variable `ticket.dept.sla` the system throws a fatal error. This is due to the SLA's relation to Department defined in `include/class.dept.php`. It's defined as `array('sla_id' => 'SLA.sla_id')` which is incorrect as `SLA.sla_id` does not exist. This updates the relation from `array('sla_id' => 'SLA.sla_id')` to `array('sla_id' => 'SLA.id')` so that it uses the appropriate column.