### PR TITLE
issue: Choices Field Sanitization

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4367,7 +4367,7 @@ class TextareaWidget extends Widget {
                 .' placeholder="'.$this->field->getLocal('placeholder', $config['placeholder']).'"'; ?>
             id="<?php echo $this->id; ?>"
             name="<?php echo $this->name; ?>"><?php
-                echo Format::htmlchars($this->value, true);
+                echo Format::htmlchars($this->value, ($config['html']));
             ?></textarea>
         </span>
         <?php


### PR DESCRIPTION
This addresses an issue where ChoicesField configuration is malformed due to sanitization. This adds a check for `$config['html']` and if it's `false` (not set) then we skip heavy sanitization.