### PR TITLE
Issue: Spaces in List Items

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -829,6 +829,12 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
         return $this->save();
     }
 
+    function save($refetch=false) {
+        $this->value = trim($this->value);
+
+        return parent::save($refetch);
+    }
+
     function delete() {
         # Don't really delete, just unset the list_id to un-associate it with
         # the list


### PR DESCRIPTION
This commit fixes an issue we had with list items that began or ended with a space. If the list was being used in a Typeahead or Input field, the values couldn't be selected if they didn't match with the spaces exactly. This commit strips the leading and trailing spaces before saving the list items.