### PR TITLE
Issue: Custom Dept/Custom Assignee Exports

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3465,7 +3465,15 @@ class AssigneeField extends ChoiceField {
 
     function to_php($value, $id=false) {
         if (is_string($value))
-            $value = JsonDataParser::parse($value);
+            $value = JsonDataParser::parse($value) ?: $value;
+
+        if (is_string($value) && strpos($value, ',')) {
+            $values = array();
+            list($key, $V) = array_map('trim', explode(',', $value));
+
+            $values[$key] = $V;
+            $value = $values;
+        }
 
         $type = '';
         if (is_array($id)) {
@@ -3477,8 +3485,11 @@ class AssigneeField extends ChoiceField {
         if (is_array($value)) {
             $type = key($value)[0];
             if (!$id)
-                $id = key($value)[1];
+                $id = substr(key($value), 1);
         }
+
+        if (!$type && is_numeric($value))
+            return Staff::lookup($value);
 
         switch ($type) {
         case 's':

--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -2381,7 +2381,7 @@ extends VerySimpleModel {
             return '';
 
         $val = $f->to_php($f->from_query($row, $this->primary));
-        if (!is_string($val))
+        if (!is_string($val) || is_numeric($val))
             $val = $f->display($val);
 
         return $val;


### PR DESCRIPTION
This commit fixes an issue with exporting Custom Department or Custom Assignee fields. In the exports, the fields were exporting as IDs instead of the actual field value.

Custom Department Field:
In from_query, if the value is just a dept_id instead of the department name, the field should pass the display function.

Custom Assignee Field:
- In to_php, we were missing logic needed to parse cdata into an array if the value was saved as 'id,value'
Ex: t34,Team1
First, we need to make sure not to accidentally clear out this value if the JsonDataParser doesn't work.
Next, this string needs to be set to an array like this in order to render properly:
['t34'] => 'Team1'

- If there is an Assigntee type, we should use substr to remove the letter from the array key in the event that the id for the field is more than one number
Ex: t34
The type should be 't' and the id should be 34.
Using key($value)[1] would set the id to just 3

- If the value coming into AssigneeField::to_php is the staff_id, meaning the value is just a number and we are not sending a type through, we should look up and return the Staff object.

Thanks @JediKev for helping me out on this one!