### PR TITLE
issue: Release Notes Links

### DIFF
--- a/include/i18n/en_US/templates/ticket/upgraded.yaml
+++ b/include/i18n/en_US/templates/ticket/upgraded.yaml
@@ -13,7 +13,7 @@ subject: osTicket Upgraded!
 message: |
     <p>
     osTicket upgraded successfully! Please refer to the Release Notes
-    (https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes) for more information about
+    (https://github.com/osTicket/osTicket/releases) for more information about
     changes and new features.
     </p><p>
     Be sure to join the <a href="https://forum.osticket.com">osTicket

--- a/include/upgrader/done.inc.php
+++ b/include/upgrader/done.inc.php
@@ -10,7 +10,7 @@ $_SESSION['ost_upgrader']=null;
         <p><?php echo __('Congratulations! osTicket upgrade has been completed successfully.');?></p>
         <p><?php echo sprintf(__('Please refer to %s for more information about changes and/or new features.'),
             sprintf('<a href="%s" target="_blank">%s</a>',
-                'https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes',
+                'https://github.com/osTicket/osTicket/releases',
                 __('Release Notes')
         ));?></p>
         </div>
@@ -32,7 +32,7 @@ $_SESSION['ost_upgrader']=null;
             echo sprintf(__('You can now go to %s to enable the system and explore the new features. For complete and up-to-date release notes see the %s'),
                 sprintf('<a href="'. ROOT_PATH . 'scp/settings.php" target="_blank">%s</a>', __('Admin Panel')),
                 sprintf('<a href="%s" target="_blank">%s</a>',
-                    'https://docs.osticket.com/en/latest/Developer%20Documentation/Changelog.html?highlight=notes',
+                    'https://github.com/osTicket/osTicket/releases',
                     __('osTicket Docs')));?></p>
             <p><b><?php echo __('Stay up to date');?></b>: <?php echo __("It's important to keep your osTicket installation up to date. Get announcements, security updates and alerts delivered directly to you!");?>
             <?php echo sprintf(__('%1$s Get in the loop %2$s today and stay


### PR DESCRIPTION
This addresses a small issue where the links to the Release Notes were pointing the old location in the Docs. This updates the links to point to the Github Releases page where it shows all Release Notes for all versions.