### PR TITLE
Issue: 'Open' heading don't get translated

### DIFF
--- a/include/client/tickets.inc.php
+++ b/include/client/tickets.inc.php
@@ -182,7 +182,7 @@ foreach (Topic::getHelpTopics(true) as $id=>$name) {
     <i class="icon-file-alt"></i>
     <a class="state <?php if ($status == 'open') echo 'active'; ?>"
         href="?<?php echo Http::build_query(array('a' => 'search', 'status' => 'open')); ?>">
-    <?php echo _P('ticket-status', 'Open'); if ($openTickets > 0) echo sprintf(' (%d)', $openTickets); ?>
+    <?php echo __('Open'); if ($openTickets > 0) echo sprintf(' (%d)', $openTickets); ?>
     </a>
     <?php if ($closedTickets) { ?>
     &nbsp;


### PR DESCRIPTION
In the ticket overview for the users get the `Open` heading not translated.

There seams no `ticket-status` context for the transaltion `Open`. The translation without context works and is also used on many other places in the osTicket code. For example also for the `Closed` heading. 😉