### PR TITLE
issue: EmailTest Draft

### DIFF
--- a/scp/emailtest.php
+++ b/scp/emailtest.php
@@ -29,12 +29,12 @@ if($_POST){
     if(!$_POST['subj'])
         $errors['subj']=__('Subject required');
 
-    if(!$_POST['message'])
-        $errors['message']=__('Message required');
+    if(!$_POST['body'])
+        $errors['body']=__('Message required');
 
     if(!$errors && $email){
         if($email->send($_POST['email'],$_POST['subj'],
-                Format::sanitize($_POST['message']),
+                Format::sanitize($_POST['body']),
                 null, array('reply-tag'=>false))) {
             $msg=Format::htmlchars(sprintf(__('Test email sent successfully to <%s>'),
                 $_POST['email']));
@@ -117,10 +117,10 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
             <td colspan=2>
                 <div style="padding-top:0.5em;padding-bottom:0.5em">
                 <em><strong><?php echo __('Message');?></strong>: <?php echo __('email message to send.');?></em>&nbsp;<span class="error">*&nbsp;<?php echo $errors['message']; ?></span></div>
-                <textarea class="richtext draft draft-delete" name="message" cols="21"
+                <textarea class="richtext draft draft-delete" name="body" cols="21"
                     rows="10" style="width: 90%;" <?php
-    list($draft, $attrs) = Draft::getDraftAndDataAttrs('email.diag', false, $info['message']);
-    echo $attrs; ?>><?php echo $draft ?: $info['message'];
+    list($draft, $attrs) = Draft::getDraftAndDataAttrs('email.diag', false, $info['body']);
+    echo $attrs; ?>><?php echo $draft ?: $info['body'];
                  ?></textarea>
             </td>
         </tr>


### PR DESCRIPTION
This addresses a very minor issue where the draft save on EmailTest throws an error. This is due to changes made in #5694 where `message` was removed from `$field_list` (security reasons). This updates the name of the textarea from `message` to `body`. This allows the `_findDraftBody()` method to find the body successfully and continue on. This also updates every reference of `message` to `body` in this instance.