### PR TITLE
issue: Edit Entry Dropped Attachments

### DIFF
--- a/include/class.thread_actions.php
+++ b/include/class.thread_actions.php
@@ -215,6 +215,13 @@ JS
         if (!$entry)
             return false;
 
+        // Move the attachments to the new entry
+        $old->attachments->filter(array(
+            'inline' => false,
+        ))->update(array(
+            'object_id' => $entry->id
+        ));
+
         // Note, anything that points to the $old entry as PID should remain
         // that way for email header lookups and such to remain consistent
 
@@ -231,13 +238,6 @@ JS
             $old->delete();
             $old = $original;
         }
-
-        // Move the attachments to the new entry
-        $old->attachments->filter(array(
-            'inline' => false,
-        ))->update(array(
-            'object_id' => $entry->id
-        ));
 
         // Mark the new entry as edited (but not hidden nor guarded)
         $entry->flags = ($old->flags & ~(ThreadEntry::FLAG_HIDDEN | ThreadEntry::FLAG_GUARDED))


### PR DESCRIPTION
This addresses an issue where editing your own Thread Entry and clicking Save two separate times drops the attachment(s). This is due to the order of operations in the backend where if editing your own Thread Entry we delete the previous entry and set `$old` to the original Thread Entry (parent of the previous entry). This causes the attachment lookup to search for the wrong `object_id` which obviously finds no attachments. This moves the attachment lookup before we delete the previous entry so we can search with the appropriate ID.