### PR TITLE
Issue: Missing null check in Staff->updatePerms()

### DIFF
--- a/include/class.role.php
+++ b/include/class.role.php
@@ -297,6 +297,10 @@ class RolePermission {
             $this->perms = array();
     }
 
+    function exists($perm) {
+        return @array_key_exists($perm, $this->perms);
+    }
+
     function has($perm) {
         return (bool) $this->get($perm);
     }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1398,7 +1398,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         }
         $permissions = $this->getPermission();
         foreach ($vars as $k => $val) {
-             if (!array_key_exists($val, $permissions->perms)) {
+             if (!$permissions->exists($val)) {
                  $type = array('type' => 'edited', 'key' => $val);
                  Signal::send('object.edited', $this, $type);
              }
@@ -1406,7 +1406,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
 
         foreach (RolePermission::allPermissions() as $g => $perms) {
             foreach ($perms as $k => $v) {
-                if (!in_array($k, $vars) && array_key_exists($k, $permissions->perms)) {
+                if (!in_array($k, $vars) && $permissions->exists($k)) {
                      $type = array('type' => 'edited', 'key' => $k);
                      Signal::send('object.edited', $this, $type);
                  }


### PR DESCRIPTION
If a agent has no permissions and you will give him/her the first permission, the class Staff->updatePerms() wrote a `array_key_exists() expects parameter 2 to be array, null given` warning.

Problem is, that $permissions->perms is null. With a RolePermission->exists() function is the code easier to read an don't show the warning.