### PR TITLE
issue: "New Task Alert" email template typo

### DIFF
--- a/include/i18n/en_US/templates/email/task.alert.yaml
+++ b/include/i18n/en_US/templates/email/task.alert.yaml
@@ -32,7 +32,7 @@ body: |
     <br>
     <br>
     <hr>
-    <div>To view or respond to the ticket, please <a
+    <div>To view or respond to the task, please <a
     href="%{task.staff_link}">login</a> to the support system</div>
     <em style="font-size: small">Your friendly Customer Support System</em>
     <br>


### PR DESCRIPTION
This amend a typo in the default "New Task Alert" email template (Admin Panel > Emails > Templates > _osTicket Default Template (HTML)_ > click New Task Alert). This replace the occurrence of _ticket_ with _task_.