### PR TITLE
Issue: Topic->getHelpTopics() don't return localized names when $allData = true

### DIFF
--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -383,6 +383,7 @@ implements TemplateVariable, Searchable {
               $n .= " - ".__("(disabled)");
           $requested_names[$id] = $n;
           $topicsClean[$id] = $info;
+          $topicsClean[$id]['topic'] = $n;
       }
 
       if ($allData)


### PR DESCRIPTION
The function Topic->getHelpTopics() don't return localized names when the parameter $allData is true.