### PR TITLE
Issue: Queue Columns Custom Fields

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3043,10 +3043,13 @@ class PriorityField extends ChoiceField {
         }
         elseif (is_array($value))
             list($value, $id) = $value;
-        elseif ($id === false)
+        elseif ($id === false && is_numeric($value)) {
             $id = $value;
-
-        return $this->getPriority($id);
+            return $this->getPriority($id);
+        } elseif (is_numeric($id))
+            return $this->getPriority($id);
+        else
+            return $value;
     }
 
     function to_database($value) {
@@ -3243,6 +3246,15 @@ class DepartmentField extends ChoiceField {
          }
 
         return $choices;
+    }
+
+    function display($dept, &$styles=null) {
+        if (!is_numeric($dept) && is_string($dept))
+            return Format::htmlchars($dept);
+        elseif ($dept instanceof Dept)
+            return Format::htmlchars($dept->getName());
+
+        return parent::display($dept);
     }
 
     function parse($id) {


### PR DESCRIPTION
This commit fixes an issue where a DepartmentField or PriorityField added to a Custom Form would not show up in a
 Queue Column.

PriorityField:
In to_php, if the $value passed in is actually the priority_id or the $id passed in is actually the priority_id, we should use the id to get the Priority value that should be displayed, however, if the $value passed in is already the Priority value as a string, we should return that value.

DepartmentField:
A display function needed to be added for this field. If the $dept passed in is the Department name, we should return that, otherwise if the $dept isn't a Dept object, we should use the parent display function as it was doing before. Finally, if the $dept is a Dept object, we should get the Department name from that.