### PR TITLE
Make Max-Age consistent across backends

### DIFF
--- a/logo.php
+++ b/logo.php
@@ -22,11 +22,12 @@ session_set_save_handler('noop','noop','noop','noop','noop','noop');
 define('DISABLE_SESSION', true);
 
 require('client.inc.php');
-
+$ttl = 86400; // max-age
 if (($logo = $ost->getConfig()->getClientLogo())) {
-    $logo->display();
-} else {
-    header('Location: '.ASSETS_PATH.'images/logo.png');
+    $logo->display(false, $ttl);
 }
 
+header("Cache-Control: private, max-age=$ttl");
+header('Pragma: private');
+header('Location: '.ASSETS_PATH.'images/logo.png');
 ?>

--- a/scp/logo.php
+++ b/scp/logo.php
@@ -23,20 +23,21 @@ define('DISABLE_SESSION', true);
 
 require_once('../main.inc.php');
 
+$ttl = 86400; // max-age
 if (isset($_GET['backdrop'])) {
     if (($backdrop = $ost->getConfig()->getStaffLoginBackdrop())) {
-        $backdrop->display();
+        $backdrop->display(false, $ttl);
         // ::display() will not return
     }
-    header("Cache-Control: private, max-age=86400");
+    header("Cache-Control: private, max-age=$ttl");
     header('Pragma: private');
     Http::redirect('images/login-headquarters.jpg');
 }
 elseif (($logo = $ost->getConfig()->getStaffLogo())) {
-    $logo->display();
+    $logo->display(false, $ttl);
 }
 
-header("Cache-Control: private, max-age=86400");
+header("Cache-Control: private, max-age=$ttl");
 header('Pragma: private');
 Http::redirect('images/ost-logo.png');
 


### PR DESCRIPTION
This commits makes max-age (ttl) for logos and backgrounds consistent regardless of the storage backend.