### PR TITLE
typo: Default Sorting

### DIFF
--- a/include/staff/queue.inc.php
+++ b/include/staff/queue.inc.php
@@ -124,7 +124,7 @@ else {
             echo Format::htmlchars($errors['filter']); ?></div>
         <br/>
 
-        <div><strong><?php echo __("Defaut Sorting"); ?></strong></div>
+        <div><strong><?php echo __("Default Sorting"); ?></strong></div>
         <hr/>
         <select name="sort_id">
           <option value="" <?php if ($queue->filter == "")

--- a/include/staff/templates/savedqueue-settings.tmpl.php
+++ b/include/staff/templates/savedqueue-settings.tmpl.php
@@ -42,7 +42,7 @@
             echo Format::htmlchars($errors['filter']); ?></div>
  </div>
  <div>
-    <div class="faded"><strong><?php echo __("Defaut Sorting"); ?></strong></div>
+    <div class="faded"><strong><?php echo __("Default Sorting"); ?></strong></div>
     <div>
         <select name="sort_id">
          <option value="" <?php if ($queue->sort_id == 0)


### PR DESCRIPTION
This uses #5835 and rebases it for `1.14.x`. This updates the typos of `Defaut Sorting` to the correct spelling of `Default Sorting`.