### PR TITLE
Issue: Filter Email Variables

### DIFF
--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -532,6 +532,7 @@ class FA_SendEmail extends TriggerAction {
         $vars = array(
             'url' => $ost->getConfig()->getBaseUrl(),
             'ticket' => $ticket['ticket'],
+            'recipient' => $ticket['ticket']->getOwner(),
         );
         $info = $ost->replaceTemplateVariables(array(
             'subject' => $config['subject'],

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4359,9 +4359,6 @@ implements RestrictedAccess, Threadable, Searchable {
             return null;
 
         /* -------------------- POST CREATE ------------------------ */
-        $vars['ticket'] = $ticket;
-        self::filterTicketData($origin, $vars,
-            array_merge(array($form), $topic_forms), $user, true);
 
         // Save the (common) dynamic form
         // Ensure we have a subject
@@ -4418,6 +4415,10 @@ implements RestrictedAccess, Threadable, Searchable {
         $vars['title'] = $vars['subject']; //Use the initial subject as title of the post.
         $vars['userId'] = $ticket->getUserId();
         $message = $ticket->postMessage($vars , $origin, false);
+
+        $vars['ticket'] = $ticket;
+        self::filterTicketData($origin, $vars,
+            array_merge(array($form), $topic_forms), $user, true);
 
         // If a message was posted, flag it as the orignal message. This
         // needs to be done on new ticket, so as to otherwise separate the


### PR DESCRIPTION
This commit fixes an issue where some template variables could not be used when using a Filter to send an email. The filter should run after the appropriate variables have been created in the ticket, and we need to set the recipient as the ticket owner within the filter action as well.