### PR TITLE
Issue: Saving Priority Field

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3037,19 +3037,19 @@ class PriorityField extends ChoiceField {
     function to_php($value, $id=false) {
         if ($value instanceof Priority)
             return $value;
+
         if (is_array($id)) {
             reset($id);
             $id = key($id);
-        }
-        elseif (is_array($value))
+        } elseif (is_array($value)) {
             list($value, $id) = $value;
-        elseif ($id === false && is_numeric($value)) {
+        } elseif ($id === false && is_numeric($value))
             $id = $value;
+
+        if (is_numeric($id))
             return $this->getPriority($id);
-        } elseif (is_numeric($id))
-            return $this->getPriority($id);
-        else
-            return $value;
+
+        return $value;
     }
 
     function to_database($value) {


### PR DESCRIPTION
This commit fixes an issue introducted by PR #5880 where we needed to split up the string of if statements checking the value and ids passed into to_php so that if we end up getting the id in one of the ifs above, we still do the priority lookup.