### PR TITLE
CDATA: DynamicFormField Update

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -80,10 +80,8 @@ class UsersAjaxAPI extends AjaxController {
                     'org__name__contains' => $q,
                     'account__username__contains' => $q,
                 ));
-                if (UserForm::getInstance()->getField('phone')) {
-                    UserForm::ensureDynamicDataView();
+                if (UserForm::getInstance()->getField('phone'))
                     $filter->add(array('cdata__phone__contains' => $q));
-                }
 
                 $users->filter($filter);
             }

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -283,6 +283,14 @@ class DynamicForm extends VerySimpleModel {
         return true;
     }
 
+    // ensure cdata tables exists
+    static function ensureDynamicDataViews($build=true) {
+        TicketForm::ensureDynamicDataView($build);
+        TaskForm::ensureDynamicDataView($build);
+        UserForm::ensureDynamicDataView($build);
+        OrganizationForm::ensureDynamicDataView($build);
+    }
+
     static function ensureDynamicDataView($build=false, $croak=true) {
 
         if (!($cdata=static::$cdata) || !$cdata['table'])

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -283,14 +283,22 @@ class DynamicForm extends VerySimpleModel {
         return true;
     }
 
-    static function ensureDynamicDataView() {
+    static function ensureDynamicDataView($build=false, $croak=true) {
 
         if (!($cdata=static::$cdata) || !$cdata['table'])
             return false;
 
         $sql = 'SHOW TABLES LIKE \''.$cdata['table'].'\'';
-        if (!db_num_rows(db_query($sql)))
-            return static::buildDynamicDataView($cdata);
+        // Return true if the cdata table exists
+        if (db_num_rows(db_query($sql)))
+            return true;
+
+        if (!$build && $croak)
+            die(sprintf('%s. %s.',
+                        __('Missing CDATA table'),
+                        __('Get technical support')));
+
+        return $build ? static::buildDynamicDataView($cdata) : false;
     }
 
     static function buildDynamicDataView($cdata) {
@@ -300,8 +308,16 @@ class DynamicForm extends VerySimpleModel {
         db_query($sql);
     }
 
-    static function dropDynamicDataView($table) {
-        db_query('DROP TABLE IF EXISTS `'.$table.'`');
+    static function dropDynamicDataView($cdata, $rebuild=true) {
+
+        if (!$cdata['table'])
+            return false;
+
+        $sql = 'DROP TABLE IF EXISTS `'.$cdata['table'].'`';
+        if (!db_query($sql))
+            return false;
+
+        return  static::ensureDynamicDataView($rebuild);
     }
 
     static function updateDynamicDataView($answer, $data) {
@@ -333,7 +349,7 @@ class DynamicForm extends VerySimpleModel {
                     db_input($answer->getEntry()->get('object_id')))
             .' ON DUPLICATE KEY UPDATE '.$fields;
         if (!db_query($sql))
-            return self::dropDynamicDataView($cdata['table']);
+            return self::dropDynamicDataView($cdata);
     }
 
     static function updateDynamicFormEntryAnswer($answer, $data) {
@@ -361,13 +377,13 @@ class DynamicForm extends VerySimpleModel {
 
         switch ($field->form->get('type')) {
         case 'T':
-            return TicketForm::dropDynamicDataView(TicketForm::$cdata['table']);
+            return TicketForm::dropDynamicDataView(TicketForm::$cdata);
         case 'A':
-            return TaskForm::dropDynamicDataView(TaskForm::$cdata['table']);
+            return TaskForm::dropDynamicDataView(TaskForm::$cdata);
         case 'U':
-            return UserForm::dropDynamicDataView(UserForm::$cdata['table']);
+            return UserForm::dropDynamicDataView(UserForm::$cdata);
         case 'O':
-            return OrganizationForm::dropDynamicDataView(OrganizationForm::$cdata['table']);
+            return OrganizationForm::dropDynamicDataView(OrganizationForm::$cdata);
         }
 
     }

--- a/include/staff/tasks.inc.php
+++ b/include/staff/tasks.inc.php
@@ -247,8 +247,6 @@ $pageNav=new Pagenate($count, $page, PAGE_LIMIT);
 $pageNav->setURL('tasks.php', $args);
 $tasks = $pageNav->paginate($tasks);
 
-TaskForm::ensureDynamicDataView();
-
 // Save the query to the session for exporting
 $_SESSION[':Q:tasks'] = $tasks;
 

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -318,8 +318,10 @@ class Installer extends SetupWizard {
             $user->setOrganization($org);
         }
 
-        //TODO: create another personalized ticket and assign to admin??
+        // Ensure cdata tables exists
+        DynamicForm::ensureDynamicDataViews();
 
+        //TODO: create another personalized ticket and assign to admin??
         //Log a message.
         $msg=__("Congratulations osTicket basic installation completed!\n\nThank you for choosing osTicket!");
         $sql='INSERT INTO '.TABLE_PREFIX.'syslog SET created=NOW(), updated=NOW(), log_type="Debug" '


### PR DESCRIPTION
This  PR addresses an issue where dynamic form field update can trigger multiple cdata rebuild queries, resulting in database DOS or even a cluster crash/lockup depending on the number of form entry entries.

The change makes it so CDATA tables rebuild is done on dynamic form field update, instead of relying on users/agents to trigger the rebuild process.