### PR TITLE
Prevent session fixation

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -101,6 +101,7 @@ class osTicketSession {
     }
 
     static function renewCookie($baseTime=false, $window=false) {
+        session_regenerate_id(); // Prevent Session Fixation
         setcookie(session_name(), session_id(),
             ($baseTime ?: time()) + ($window ?: SESSION_TTL),
             ini_get('session.cookie_path'),


### PR DESCRIPTION
Hi,
When authenticating a user, it doesn’t assign a new session ID, making it possible to use an existent session ID. The attack consists of obtaining a valid session ID (e.g. by connecting to the application), inducing a user to authenticate himself with that session ID, and then hijacking the user-validated session by the knowledge of the used session ID.