### PR TITLE
Issue: Deleted Forms on Help Topics

### DIFF
--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -29,8 +29,9 @@ class DynamicFormsAjaxAPI extends AjaxController {
         }
 
         foreach ($topic->getForms() as $form) {
-            if (!$form->hasAnyVisibleFields())
+            if ($form->isDeleted() || !$form->hasAnyVisibleFields())
                 continue;
+
             ob_start();
             $form->getForm($_SESSION[':form-data'])->render(array(
                 'staff' => !$client,

--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -128,8 +128,16 @@ class DynamicForm extends VerySimpleModel {
         return $form;
     }
 
+    function hasFlag($flag) {
+        return (isset($this->flags) && ($this->flags & $flag) != 0);
+    }
+
+    function isDeleted() {
+        return $this->hasFlag(self::FLAG_DELETED);
+    }
+
     function isDeletable() {
-        return $this->flags & self::FLAG_DELETABLE;
+        return $this->hasFlag(self::FLAG_DELETABLE);
     }
 
     function setFlag($flag) {


### PR DESCRIPTION
This commit fixes an issue we had with forms that have been deleted that were attached to a Help Topic. If a custom form is attached to a help topic and then the form is deleted, we put a flag on the form so that existing tickets still show the fields. However, if you are creating new tickets with those help topics, the deleted form is still showing up even though it should be hidden.

A check has now been added in the getFormsForHelpTopic method to skip deleted forms when creating new Tickets.