### PR TITLE
Revert "Prevent session fixation"

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -101,7 +101,6 @@ class osTicketSession {
     }
 
     static function renewCookie($baseTime=false, $window=false) {
-        session_regenerate_id(); // Prevent Session Fixation
         setcookie(session_name(), session_id(),
             ($baseTime ?: time()) + ($window ?: SESSION_TTL),
             ini_get('session.cookie_path'),


### PR DESCRIPTION
This PR reverts osTicket/osTicket#5897 due attachments issues related to session regeneration. 

We will revisit the session fixation issue in the near future.

