### PR TITLE
issue: Missing Thread On Referral Check

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2625,7 +2625,7 @@ implements RestrictedAccess, Threadable, Searchable {
     }
 
     function hasReferral($object, $type) {
-        if (($referral=$this->thread->getReferral($object->getId(), $type)))
+        if (($referral=$this->getThread()->getReferral($object->getId(), $type)))
             return $referral;
 
         return false;


### PR DESCRIPTION
This addresses an issue where attempting to Assign a Child Ticket throws a fatal error of `Call to a member function getReferral() on null`. This is due to the `thread` relation not being available for Child Tickets; instead `child_thread` is available. This updates the code to use `getThread()` which first checks if `thread` relation exists, if not it returns the `child_thread` relation.