### PR TITLE
Auth: Service Name on Client Portal

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -847,19 +847,24 @@ abstract class ExternalUserAuthenticationBackend
     static $sign_in_image_url = false;
     static $service_name = "External";
 
-    function renderExternalLink() { ?>
-        <a class="external-sign-in" title="<?php echo sprintf(__('Sign in with %s'), __(static::$service_name)); ?>"
+    function renderExternalLink() {
+        $service = sprintf('%s %s',
+                __('Sign in with'),
+                $this->getServiceName());
+
+        ?>
+        <a class="external-sign-in" title="<?php echo $service; ?>"
                 href="login.php?do=ext&amp;bk=<?php echo urlencode(static::$id); ?>">
 <?php if (static::$sign_in_image_url) { ?>
         <img class="sign-in-image" src="<?php echo static::$sign_in_image_url;
-            ?>" alt="<?php echo sprintf(__('Sign in with %s'), __(static::$service_name)); ?>"/>
+            ?>" alt="<?php $service; ?>"/>
 <?php } else { ?>
             <div class="external-auth-box">
             <span class="external-auth-icon">
                 <i class="icon-<?php echo static::$fa_icon; ?> icon-large icon-fixed-with"></i>
             </span>
             <span class="external-auth-name">
-                <?php echo sprintf(__('Sign in with %s'), __(static::$service_name)); ?>
+                <?php echo $service; ?>
             </span>
             </div>
 <?php } ?>


### PR DESCRIPTION
Use configurable service name when supported by the auth backend.