### PR TITLE
issue: getDBVersion() SQL Errors

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -39,7 +39,8 @@ class osTicketSession {
         // Set session cleanup time to match TTL
         ini_set('session.gc_maxlifetime', $ttl);
 
-        if (OsticketConfig::getDBVersion())
+        // Skip db version check if version is later than 1.7
+        if (!defined('MAJOR_VERSION') && OsticketConfig::getDBVersion())
             return session_start();
 
         # Cookies


### PR DESCRIPTION
This addresses an issue where when `OsticketConfig::getDBVersion()` is ran, a `column not found` SQL Error is generated. This is due to the config table structure being completely different from 1.7 onwards. This adds a check to see if the `MAJOR_VERSION` constant is defined, if so, it will skip the `OsticketConfig::getDBVersion()` call in `include/class.ostsession.php` (thus skipping the query execution). If the constant is not defined it will continue on and call `OsticketConfig::getDBVersion()`.