### PR TITLE
issue: Setup Admin Password Heltip Verbiage

### DIFF
--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -111,8 +111,8 @@ class Validator {
                     $this->errors[$k]=$field['error'];
                 break;
             case 'password':
-                if(strlen($this->input[$k])<5)
-                    $this->errors[$k]=$field['error'].' '.__('(Five characters min)');
+                if(strlen($this->input[$k])<6)
+                    $this->errors[$k]=$field['error'].' '.__('(Six characters min)');
                 break;
             case 'username':
                 $error = '';

--- a/include/i18n/en_US/help/tips/install.yaml
+++ b/include/i18n/en_US/help/tips/install.yaml
@@ -54,7 +54,7 @@ username:
 password:
     title: Password
     content: |
-        <p>Admin's password.  Must be five (5) characters or more.</p>
+        <p>Admin's password.  Must be six (6) characters or more.</p>
 
 password2:
     title: Confirm Password

--- a/setup/tips.php
+++ b/setup/tips.php
@@ -32,7 +32,7 @@ require_once('setup.inc.php');
 </div>
 <div id="t7">
 <b><?php echo __('Password');?></b>
-<p><?php echo __("Admin's password.  Must be five (5) characters or more.");?></p>
+<p><?php echo __("Admin's password.  Must be six (6) characters or more.");?></p>
 </div>
 <div id="t8">
 <b><?php echo __('Confirm Password');?></b>


### PR DESCRIPTION
This addresses #5930 where the Helptip for the Admin Password field on Install is incorrect. The Helptip states the password has to be a minimum of 5 characters where in reality it requires a minimum of 6. This updates the Helptip as well as the inline string from `Must be five (5) characters or more.` to `Must be six (6) characters or more.`. In addition, this updates the phrase `(Five characters min)` to `(Six characters min)` in `include/class.validator.php` as well as updates the check for less than 5 characters.