### PR TITLE
xss: SVG Image

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -180,6 +180,7 @@ class AttachmentFile extends VerySimpleModel {
         }
         header('Content-Type: '.($this->getType()?$this->getType():'application/octet-stream'));
         header('Content-Length: '.$this->getSize());
+        header("Content-Security-Policy: default-src 'self'");
         $this->sendData();
         exit();
     }


### PR DESCRIPTION
This addresses a security vulnerability reported by Dawid Golda where uploading a malicious SVG, getting the direct file link, adding `s=1` to the end, and visiting the link directly will render the SVG in the browser and execute the malicious Javascript within the SVG. This adds a CSP (Content Security Policy) header with `default-src 'self'` to the display code. When this header is present it prevents all inline Javascript execution thus mitigating the XSS.