### PR TITLE
security: open.php Refresh

### DIFF
--- a/open.php
+++ b/open.php
@@ -51,7 +51,8 @@ if ($_POST) {
             session_write_close();
             session_regenerate_id();
             @header('Location: tickets.php?id='.$ticket->getId());
-        }
+        } else
+            $ost->getCSRF()->rotate();
     }else{
         $errors['err'] = $errors['err'] ?: sprintf('%s %s',
             __('Unable to create a ticket.'),


### PR DESCRIPTION
This addresses an issue reported by Vladislav Alyohin where Users can create a Ticket in the Client Portal and click Refresh over and over again on success. The result is a duplicate Ticket being created (with a different Ticket Number) for each refresh. This adds an else statement so if there is no client or if they are no longer valid we will rotate the CSRF token. This will create the initial Ticket and on refresh will force the User back to the Landing Page.