### PR TITLE
xss: Client-Side i18n

### DIFF
--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -77,11 +77,11 @@ if (osTicket::is_ie())
         parse_str($_SERVER['QUERY_STRING'], $qs);
         foreach ($langs as $L) {
             $qs['lang'] = $L; ?>
-        <link rel="alternate" href="//<?php echo $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']; ?>?<?php
+        <link rel="alternate" href="//<?php echo $_SERVER['HTTP_HOST'] . htmlspecialchars($_SERVER['REQUEST_URI']); ?>?<?php
             echo http_build_query($qs); ?>" hreflang="<?php echo $L; ?>" />
 <?php
         } ?>
-        <link rel="alternate" href="//<?php echo $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']; ?>"
+        <link rel="alternate" href="//<?php echo $_SERVER['HTTP_HOST'] . htmlspecialchars($_SERVER['REQUEST_URI']); ?>"
             hreflang="x-default" />
 <?php
     }


### PR DESCRIPTION
This mitigates a vulnerability reported by @tieupham267 where XSS is possible via the `REQUEST_URI` parameter on the Client Portal. This is due to the parameter not being converted to HTML entities before attaching to `<link>` tags. This adds `htmlspecialchars()` around the `REQUEST_URI` to ensure the content is properly converted.