### PR TITLE
session: Verify UserAgent String

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -201,6 +201,12 @@ extends SessionBackend {
         catch (OrmException $e) {
             return false;
         }
+        // Verify the User Agent string
+        if (isset($this->data->user_agent)
+                && (strcmp($_SERVER['HTTP_USER_AGENT'], $this->data->user_agent) !== 0)) {
+            $this->destroy($id);
+            return false;
+        }
         return $this->data->session_data;
     }
 


### PR DESCRIPTION
This adds an extra layer of security to Sessions where we will verify the UserAgent string. We will check to see if the UserAgent string saved in the database matches the current UserAgent string from the request. If the two do not match we will destroy the session and force the affected User/Agent to login again.