### PR TITLE
Issue: Audit Closed Ticket Events

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1526,8 +1526,6 @@ implements RestrictedAccess, Threadable, Searchable {
 
                 $ecb = function($t) use ($status) {
                     $t->logEvent('closed', array('status' => array($status->getId(), $status->getName())), null, 'closed');
-                    $type = array('type' => 'closed');
-                    Signal::send('object.edited', $t, $type);
                     $t->deleteDrafts();
                 };
                 break;


### PR DESCRIPTION
This commit fixes an issue where we were double auditing the Closed event for Tickets. This should have been removed in PR #5051 in the 'Code Optimization' commit where we started automatically logging some of the audits in class.orm.php