### PR TITLE
Show "-Empty-" value for empty due dates in ticket view

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -585,10 +585,16 @@ if($ticket->isOverdue())
                          if ($role->hasPerm(Ticket::PERM_EDIT)) {
                              $duedate = $ticket->getField('duedate'); ?>
                            <td>
-                      <a class="inline-edit" data-placement="bottom"
+                      <a class="inline-edit" data-placement="bottom" data-toggle="tooltip" title="<?php echo __('Update'); ?>"
                           href="#tickets/<?php echo $ticket->getId();
                            ?>/field/duedate/edit">
-                           <span id="field_duedate"><?php echo Format::datetime($ticket->getEstDueDate()); ?></span>
+                           <?php
+                           $dueDateString = Format::datetime($ticket->getEstDueDate());
+                           if ($dueDateString)
+                               echo '<span id="field_duedate">'.$dueDateString.'</span>';
+                           else
+                               echo '<span id="field_duedate" class="faded">&mdash; '.__('Empty').' &mdash;</span>';
+                           ?>
                       </a>
                     <td>
                       <?php } else { ?>


### PR DESCRIPTION
When you don't use a *SLA Plan* the *Due Date* can be empty. The staff ticket view use now a `—Empty—` display value that the update popup link works:

![image](https://user-images.githubusercontent.com/497880/132018661-8213273a-2d89-47f9-bb73-22cc22385838.png)