### PR TITLE
Use events for "Mark as (un)answered"

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1640,8 +1640,7 @@ class TicketsAjaxAPI extends AjaxController {
 
                 // Add success messages and log activity
                 $_SESSION['::sysmsgs']['msg'] = sprintf(__('Ticket marked as %s successfully'), $action);
-                $msg = sprintf(__('Ticket flagged as %s by %s'), $action, $thisstaff->getName());
-                $ticket->logActivity(sprintf(__('Ticket Marked %s'), ucfirst($action)), $msg);
+                $ticket->logEvent('mark-' . $action);
                 Http::response(201, $ticket->getId());
             }
         }

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2026,6 +2026,8 @@ class ThreadEvent extends VerySimpleModel {
     const VIEWED    = 'viewed';
     const MERGED    = 'merged';
     const UNLINKED    = 'unlinked';
+    const MARK_ANSWERED   = 'mark-answered';
+    const MARK_UNANSWERED = 'mark-unanswered';
 
     const MODE_STAFF = 1;
     const MODE_CLIENT = 2;
@@ -2063,6 +2065,8 @@ class ThreadEvent extends VerySimpleModel {
             'merged'      => 'code-fork',
             'linked'      => 'link',
             'unlinked'    => 'unlink',
+            'mark-answered'   => 'circle-arrow-right',
+            'mark-unanswered' => 'circle-arrow-left',
         );
         return @$icons[$this->state] ?: 'chevron-sign-right';
     }
@@ -2677,6 +2681,24 @@ class UnlinkEvent extends ThreadEvent {
     function getDescription($mode=self::MODE_STAFF) {
         return sprintf($this->template(__('<b>{somebody}</b> unlinked this ticket from %s{data.id}%s<b>{data.ticket}</b>%s {timestamp}'), $mode),
                 '<a href="tickets.php?id=', '">', '</a>');
+    }
+}
+
+class MarkAnsweredEvent extends ThreadEvent {
+    static $icon = 'circle-arrow-right';
+    static $state = 'mark-answered';
+
+    function getDescription($mode=self::MODE_STAFF) {
+        return $this->template(sprintf(__('Ticket flagged as %s by %s'), 'answered', '<b>{somebody}</b> {timestamp}'), $mode);
+    }
+}
+
+class MarkUnansweredEvent extends ThreadEvent {
+    static $icon = 'circle-arrow-left';
+    static $state = 'mark-unanswered';
+
+    function getDescription($mode=self::MODE_STAFF) {
+        return $this->template(sprintf(__('Ticket flagged as %s by %s'), 'unanswered', '<b>{somebody}</b> {timestamp}'), $mode);
     }
 }
 


### PR DESCRIPTION
This switch the *Mark as (un)answered* thread entries from activity to event:

![image](https://user-images.githubusercontent.com/497880/132698640-b2aade57-dd50-4f1c-b97a-9965a98450b6.png)

Unfortanlty I don't know how I get the new `mark-answered` and `mark-unanswered` names in the `event` table!?

I think it will be done by a SQL file in the `include\upgrader\streams\core` path:

```
/**
* @signature XXX
* @version v1.15.4
* @title Mark as (un)answered events
*
* This patch adds new events to the database to allow "mark as (un)answered" events
*
*/
-- Insert new events
INSERT INTO `%TABLE_PREFIX%event` (`id`, `name`, `description`)
VALUES
    ('','mark-answered',''),
    ('','mark-unanswered','');

-- Finished with patch
UPDATE `%TABLE_PREFIX%config`
   SET `value` = 'XXX', `updated` = NOW()
   WHERE `key` = 'schema_signature' AND `namespace` = 'core';
```

But how I know the signature ID? I hope you can help me! 😊