### PR TITLE
Issue: AJAX use wrong "Due Date"

### DIFF
--- a/include/ajax.tasks.php
+++ b/include/ajax.tasks.php
@@ -245,6 +245,9 @@ class TasksAjaxAPI extends AjaxController {
                       );
 
                 switch (true) {
+                    case ($fid == 'duedate'):
+                        $clean = Format::datetime($task->duedate);
+                        break;
                     case $field instanceof DateTime:
                     case $field instanceof DatetimeField:
                         $clean = Format::datetime((string) $field->getClean());

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -665,6 +665,9 @@ class TicketsAjaxAPI extends AjaxController {
                       );
 
                 switch (true) {
+                    case ($fid == 'duedate'):
+                        $clean = Format::datetime($ticket->getEstDueDate());
+                        break;
                     case $field instanceof DateTime:
                     case $field instanceof DatetimeField:
                         $clean = Format::datetime((string) $field->getClean());


### PR DESCRIPTION
Because the *Due Date* are converted to  DB timezone the AJAX must use this value directly. If not it update the page with a wrong time.