### PR TITLE
Issue: isset(VerySimpleModel->field) return TRUE by NULL value

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -427,7 +427,7 @@ class VerySimpleModel {
     }
 
     function __isset($field) {
-        return ($this->ht && array_key_exists($field, $this->ht))
+        return ($this->ht && array_key_exists($field, $this->ht) && isset($this->ht[$field]))
             || isset(static::$meta['joins'][$field]);
     }
 


### PR DESCRIPTION
While working on bug #5954 I noticed a problem with `isset()` function on `VerySimpleModel` objects.

In this case it was the the `getStaffId()` function from class `ThreadEntry` ([line 1078-1080](https://github.com/osTicket/osTicket/blob/develop/include/class.thread.php#L1078-L1080))

The `isset($this->staff_id)` returns `true` even when the value is `NULL`:

```
    function getStaffId() {
        var_dump($this->staff_id); //NULL
        var_dump(isset($this->staff_id)); //bool(true)
        return isset($this->staff_id) ? $this->staff_id : 0;
    }
```

Problem is that the class `VerySimpleModel` override the `__isset` methode but don't check for `NULL` values itself.