### PR TITLE
search: Child Thread Relation

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -381,7 +381,8 @@ class CustomQueue extends VerySimpleModel {
             $exclude[$base] = 1;
             foreach ($base::getMeta('joins') as $path=>$j) {
                 $fc = $j['fkey'][0];
-                if (isset($exclude[$fc]) || $j['list'])
+                if (isset($exclude[$fc]) || $j['list']
+                        || (isset($j['searchable']) && !$j['searchable']))
                     continue;
                 foreach (static::getSearchableFields($fc, $recurse-1,
                     true, $exclude)

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -88,6 +88,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     'ticket_id'  => 'TicketThread.object_id',
                     "'C'" => 'TicketThread.object_type',
                 ),
+                'searchable' => false,
                 'null' => true,
             ),
             'cdata' => array(


### PR DESCRIPTION
This addresses issue #5959 where `TicketThread / Last Message` and `TicketThread / Last Response` appear twice in the Advanced Search available Fields. This is due to the joins/relationships automatically being added to searchable fields. In this case, searching TicketThread will search the Parent and Child Threads so there is no need for two separate options. This adds a new property called `searchable` (set to false) to the `child_thread` relation in the Ticket class. In addition, this adds a check when generating the searchable fields that skips the relation if the `searchable` property is `false`.