### PR TITLE
issue: def_assn_role

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1175,7 +1175,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             }
             $this->updateAccess($access, $errors);
             $this->setExtraAttr('def_assn_role',
-                isset($vars['assign_use_pri_role']), false);
+                isset($vars['assign_use_pri_role']), true);
 
             // Format team membership as [array(team_id, alerts?)]
             $teams = array();


### PR DESCRIPTION
This addresses an issue reported on the Forum where disabling `Fall back to primary role on assignments` doesn't actually save. This is due to the third parameter passed being `false`. The third parameter is `$commit` that determines wether or not to save it after changing. Since this was `false` it was never committed/saved in the database. This updates the parameter to `true` so that it gets committed/saved.