### PR TITLE
Issue: Delete Referrals

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -637,6 +637,12 @@ implements Searchable {
             ->delete();
     }
 
+    function deleteReferrals() {
+        return ThreadReferral::objects()
+            ->filter(array('thread_id'=>$this->getId()))
+            ->delete();
+    }
+
     function setExtra($mergedThread, $info='') {
 
         if ($info && $info['extra']) {
@@ -748,6 +754,7 @@ implements Searchable {
         // Mass delete entries
         $this->deleteAttachments();
         $this->removeCollaborators();
+        $this->deleteReferrals();
 
         $this->entries->delete();
 


### PR DESCRIPTION
This commit fixes an issue where we were not deleting referrals when a Ticket was deleted. Now we will delete any referrals related to a thread when the thread is deleted.