### PR TITLE
FeatureRequest: #action-dropdown-stats  ( #opened / #total )

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -397,9 +397,9 @@ if($ticket->isOverdue())
                         if ($user) { ?>
                             <a href="tickets.php?<?php echo Http::build_query(array(
                                 'status'=>'open', 'a'=>'search', 'uid'=> $user->getId()
-                            )); ?>" title="<?php echo __('Related Tickets'); ?>"
-                            data-dropdown="#action-dropdown-stats">
-                            (<b><?php echo $user->getNumOpenTickets(), " / ", $user->getNumTickets(); ?></b>)
+                            )); ?>" title="<?php echo __('Related Tickets');?>" 
+                            data-dropdown="#action-dropdown-stats" style="<?php if ($user->getNumOpenTickets() > 0) {echo "background-color: yellow; color: red;";}; ?>">
+							(<b><?php if ($user->getNumOpenTickets() > 0){echo $user->getNumOpenTickets(), " / ";}; echo $user->getNumTickets(); ?></b>)
                             </a>
                             <div id="action-dropdown-stats" class="action-dropdown anchor-right">
                                 <ul>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -454,7 +454,7 @@ if($ticket->isOverdue())
                         <a href="tickets.php?<?php echo Http::build_query(array(
                             'status'=>'open', 'a'=>'search', 'orgid'=> $user->getOrgId()
                         )); ?>" title="<?php echo __('Related Tickets'); ?>"
-                        data-dropdown="#action-dropdown-stats" style="<?php if ($user->getNumOpenOrganizationTickets() > 0) {echo "background-color: yellow; color: red;";}; ?>">
+                        data-dropdown="#action-dropdown-org-stats" style="<?php if ($user->getNumOpenOrganizationTickets() > 0) {echo "background-color: yellow; color: red;";}; ?>">
 						(<b><?php if ($user->getNumOpenOrganizationTickets() > 0){echo $user->getNumOpenOrganizationTickets(), " / ";}; echo $user->getNumOrganizationTickets(); ?></b>)
                         </a>
                             <div id="action-dropdown-org-stats" class="action-dropdown anchor-right">

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -454,8 +454,8 @@ if($ticket->isOverdue())
                         <a href="tickets.php?<?php echo Http::build_query(array(
                             'status'=>'open', 'a'=>'search', 'orgid'=> $user->getOrgId()
                         )); ?>" title="<?php echo __('Related Tickets'); ?>"
-                        data-dropdown="#action-dropdown-org-stats">
-                        (<b><?php echo $user->getNumOrganizationTickets(); ?></b>)
+                        data-dropdown="#action-dropdown-stats" style="<?php if ($user->getNumOpenOrganizationTickets() > 0) {echo "background-color: yellow; color: red;";}; ?>">
+						(<b><?php if ($user->getNumOpenOrganizationTickets() > 0){echo $user->getNumOpenOrganizationTickets(), " / ";}; echo $user->getNumOrganizationTickets(); ?></b>)
                         </a>
                             <div id="action-dropdown-org-stats" class="action-dropdown anchor-right">
                                 <ul>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -399,7 +399,7 @@ if($ticket->isOverdue())
                                 'status'=>'open', 'a'=>'search', 'uid'=> $user->getId()
                             )); ?>" title="<?php echo __('Related Tickets'); ?>"
                             data-dropdown="#action-dropdown-stats">
-                            (<b><?php echo $user->getNumTickets(); ?></b>)
+                            (<b><?php echo $user->getNumOpenTickets(), " / ", $user->getNumTickets(); ?></b>)
                             </a>
                             <div id="action-dropdown-stats" class="action-dropdown anchor-right">
                                 <ul>


### PR DESCRIPTION
For description take a look here.
https://forum.osticket.com/d/99995-related-number-of-tickets

![image](https://user-images.githubusercontent.com/11089482/135483387-8c28278e-8903-4c2d-ad29-3f13ea9fc936.png)

This information after using this patch, shows
number of (#opened / #all) tickets

Previously it was:
number of (#all) tickets

I plan to do the same with the number of tickets for the organization.
Moreover, I will add a color change if the number of open tickets is> 0

**Summary:**
The point is that the visible information "1 Open Ticket" was currently visible only after clicking on the number (4)
, and now it is immediately displayed as (1/4) so without clicking you can see how many tickets a given user has opened.
It helps agents to solve other tickets opened by the same user/client because when agents do the job for current ticket, then he already know (without additional click) that the user/client mentioned above, has also other opened tickets.
