### PR TITLE
issue: List Item Properties On Mouseover

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -797,14 +797,13 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
     }
 
     function display() {
-
-        return $this->getValue();
         //TODO: Allow for display mode (edit, preview or both)
-        return sprintf('<a class="preview" href="#"
-                data-preview="#list/%d/items/%d/preview">%s</a>',
+        return sprintf('%s &nbsp;<a class="preview" href="#"
+                data-preview="#list/%d/items/%d/preview">
+                <i class="icon-info-sign"></i></a>',
+                $this->getValue(),
                 $this->getListId(),
-                $this->getId(),
-                $this->getValue()
+                $this->getId()
                 );
     }
 


### PR DESCRIPTION
This addresses an issue where when Inline Edit was introduced it removed the functionality for the List Item Properties popup on mouseover. This restructures the `display()` method for DynamicListItem to display the value with an info icon that on mouseover will display the associated List Item Properties.