### PR TITLE
Password error message #5981

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -228,6 +228,10 @@ class UsersAjaxAPI extends AjaxController {
 
             if ($errors['err'])
                 $info['error'] = $errors['err'];
+            else if($errors['passwd1']){
+                    $info['error'] = __('Unable to update account.') //AQUI ERRO DO USERNAE
+                        .' '.__('Invalid password.');
+            }
             else
                 $info['error'] = __('Unable to update account.')
                     .' '.__('Correct any errors below and try again.');


### PR DESCRIPTION
Hi. I'm starting to help the Free Software and Open Source community. Could give feedback.

I fixed the error referring to the user screen, Button Manage Account, Tab Manege Access, to change the password. It did not show error messages regarding the password, it brings generic message.
In the code has password validation, I just sent the error message to the user interface
#5981 

thank you