### PR TITLE
issue: Auto-Assign Comments Var

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2077,7 +2077,7 @@ implements RestrictedAccess, Threadable, Searchable {
             && ($msg=$tpl->getAssignedAlertMsgTemplate())
         ) {
             $msg = $this->replaceVars($msg->asArray(),
-                array('comments' => $comments,
+                array('comments' => $comments ?: '',
                       'assignee' => $assignee,
                       'assigner' => $assigner
                 )


### PR DESCRIPTION
This addresses #5978 where when a Filter auto-assigns an Agent, the New Assignment Alert they receive shows the `%{comments}` variable. This is due to `$comments` being `false` therefore it skips the variable. This adds a check for `$comments` and if empty/false uses `''` so the variable is replaced/removed from the final alert.