### PR TITLE
security: SSRF External Images

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -230,7 +230,7 @@ class OsticketConfig extends Config {
         'max_open_tickets' => 0,
         'files_req_auth' => 1,
         'force_https' => '',
-        'allow_external_images' => 1,
+        'allow_external_images' => 0,
     );
 
     function __construct($section=null) {

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -80,7 +80,7 @@ core:
     ticket_number_format: '######'
     ticket_sequence_id: 0
     queue_bucket_counts: 0
-    allow_external_images: 1
+    allow_external_images: 0
     task_number_format: '#'
     task_sequence_id: 2
     log_level: 2


### PR DESCRIPTION
This is an extension of `d98c2d0` and addresses an issue reported by haxatron. This ensures the `Allow External Images` setting is Disabled by default on new installs.