### PR TITLE
xss: Stored XSS/Domain Whitelist Bypass

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -341,7 +341,7 @@ class Format {
             $config['elements'] = '*+iframe';
             $config['spec'] = 'iframe=-*,height,width,type,style,src(match="`^(https?:)?//(www\.)?('
                 .implode('|', $whitelist)
-                .')/?`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : '').',allowfullscreen';
+                .')/?([^@]*)$`i"),frameborder'.($options['spec'] ? '; '.$options['spec'] : '').',allowfullscreen';
         }
 
         return Format::html($html, $config);


### PR DESCRIPTION
This mitigates a vulnerability reported by haxatron on [huntr.dev](https://huntr.dev/) where one can bypass the Domain Whitelist and potentially store XSS via iFrame tags. This adds a new section to the iFrame REGEX that checks for `@` and denies the iFrame if exists.