### PR TITLE
security: Recipient Injection via User's Name

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -169,6 +169,10 @@ class UsersAjaxAPI extends AjaxController {
             Http::response(404, 'Unknown user');
 
         $errors = array();
+        $form = UserForm::getUserForm()->getForm($_POST);
+        if (!is_string($form->getField('name')->getValue()))
+            Http::response(404, 'Invalid Data');
+
         if ($user->updateInfo($_POST, $errors, true) && !$errors)
              Http::response(201, $user->to_json(),  'application/json');
 
@@ -298,6 +302,8 @@ class UsersAjaxAPI extends AjaxController {
 
             $info['title'] = __('Add New User');
             $form = UserForm::getUserForm()->getForm($_POST);
+            if (!is_string($form->getField('name')->getValue()))
+                Http::response(404, 'Invalid Data');
             if (($user = User::fromForm($form)))
                 Http::response(201, $user->to_json(), 'application/json');
 


### PR DESCRIPTION
This mitigates a vulnerability reported by Luca where email recipients can be injected via the User's Name when creating/updating a User. This adds a check to ensure the passed value is a string. If the value is not a string we will refuse the request.