### PR TITLE
xss: Advanced Search

### DIFF
--- a/include/staff/templates/advanced-search.tmpl.php
+++ b/include/staff/templates/advanced-search.tmpl.php
@@ -1,7 +1,9 @@
 <?php
 global $thisstaff;
 
-$parent_id = $_REQUEST['parent_id'] ?: $search->parent_id;
+$parent_id = (isset($_REQUEST['parent_id']) && is_numeric($_REQUEST['parent_id']))
+        ? $_REQUEST['parent_id']
+        : $search->parent_id;
 if ($parent_id
     && is_numeric($parent_id)
     && (!($parent = SavedQueue::lookup($parent_id)))


### PR DESCRIPTION
This mitigates a vulnerability reported by Iwan where XSS is possible via Advanced Search AJAX. This ensures the `parent_id` from the request `is_numeric` to avoid possible XSS.