### PR TITLE
Revert "issue: List Item Properties On Mouseover"

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -797,13 +797,14 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
     }
 
     function display() {
+
+        return $this->getValue();
         //TODO: Allow for display mode (edit, preview or both)
-        return sprintf('%s &nbsp;<a class="preview" href="#"
-                data-preview="#list/%d/items/%d/preview">
-                <i class="icon-info-sign"></i></a>',
-                $this->getValue(),
+        return sprintf('<a class="preview" href="#"
+                data-preview="#list/%d/items/%d/preview">%s</a>',
                 $this->getListId(),
-                $this->getId()
+                $this->getId(),
+                $this->getValue()
                 );
     }
 


### PR DESCRIPTION
This reverts commit a6a719239b1513683daa63f7b630a1aa43fefd8d as putting the preview in the display messes up exports and multi-selection.