### PR TITLE
auth: Allow AuthBackends to auto-register Users

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -134,7 +134,7 @@ class ClientCreateRequest {
     function attemptAutoRegister() {
         global $cfg;
 
-        if (!$cfg || !$cfg->isClientRegistrationEnabled())
+        if (!$cfg || $cfg->isClientRegistrationMode(['disabled']))
             return false;
 
         // Attempt to automatically register


### PR DESCRIPTION
This PR allows AuthBackends like LDAP or SAML to auto-register End Users even when the registration is set to `private` - removing the need to make registration mode public for auto-register to work.

The rationale is - Users already in such backends are already approved/registered internally. 