### PR TITLE
email: use correct e-mail formatting

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -67,7 +67,7 @@ class Email extends VerySimpleModel {
         if ($this->mail_encryption == 'SSL')
             $this->mail_proto .= "/".$this->mail_encryption;
 
-        $this->address=$this->name?($this->name.'<'.$this->email.'>'):$this->email;
+        $this->address=$this->name?($this->name.' <'.$this->email.'>'):$this->email;
     }
 
     function getEmail() {


### PR DESCRIPTION
```
Add missing space between name and actual e-mail.
Before: foo<foo@bar.com>
After: foo <foo@bar.com>

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```
This fixes #6006

## Before
![before](https://user-images.githubusercontent.com/452972/138599924-dd1d4764-766a-4a3c-a7ba-62cba24e208b.png)

## After
![after](https://user-images.githubusercontent.com/452972/138599954-5852d647-c4e6-4884-b22d-34e0a85d5185.png)