### PR TITLE
Fix HTML syntax in thread view

### DIFF
--- a/include/client/templates/thread-entry.tmpl.php
+++ b/include/client/templates/thread-entry.tmpl.php
@@ -38,7 +38,7 @@ if ($cfg->isAvatarsEnabled() && $user)
                 )
             ); ?>
             <span style="max-width:500px" class="faded title truncate"><?php
-                echo $entry->title; ?></span>
+                echo $entry->title; ?>
             </span>
     </div>
     <div class="thread-body" id="thread-id-<?php echo $entry->getId(); ?>">

--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -82,7 +82,7 @@ if ($user && $cfg->isAvatarsEnabled())
             )
         ); ?>
         <span style="max-width:400px" class="faded title truncate"><?php
-            echo $entry->title; ?></span>
+            echo $entry->title; ?>
         </span>
     </div>
     <div class="thread-body no-pjax">


### PR DESCRIPTION
```
This fixes "span" element being closed twice.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```