### PR TITLE
issue: Improved Validation for Variable Names

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -871,7 +871,7 @@ class DynamicFormField extends VerySimpleModel {
                 /* `variable` is used for automation. Internally it's called `name` */
                 ), "name");
         }
-        if (preg_match('/[.{}\'"`; ]/u', $this->get('name')))
+        if ($this->get('name') && !preg_match('/^(?!\d)([[:alnum:]]|_|-)+$/u', $this->get('name')))
             $this->addError(__(
                 'Invalid character in variable name. Please use letters and numbers only.'
             ), 'name');


### PR DESCRIPTION
This addresses an issue where a variable name with `/` for example throws databases errors when reindexing cdata tables. This improves the regex validation for variable names to ensure alphanumeric characters only.