### PR TITLE
issue: Plain-Text Canned Responses

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -231,7 +231,7 @@ var scp_prep = function() {
                 success: function(canned){
                     //Canned response.
                     var box = $('#response', fObj),
-                        redactor = $R('#response');
+                        redactor = $R('#response.richtext');
                     if (canned.response) {
                         if (redactor) {
                             redactor.api('selection.restore');


### PR DESCRIPTION
Rebase of #6015.

**Problem:**

In a non-rich-text setting, osTicket includes HTML elements if canned responses are added to a response. [This problem has been discussed, for instance, in a thread on the osTicket forum.](https://forum.osticket.com/d/96411-agent-responses-show-html-markup)

**Background:**

The problem came in with commit a1116036afff42b41d057f38b8c1ac3f50ddbf7b, probably during an upgrade of the Redactor library. Since this commit, a canned response loaded from the server always turns the response into a rich-text response on the client side. However, the server (rightly) expects non-rich-text content so that the response is malformatted later in this process.

**Solution:**

The solution to fix this is quite easy. The response HTML element is annotated the `.richtext` if it is meant to contain rich text. Hence, the selector for Redactor can be extended with this class. Consequently, rich text is only used if that is intended, i.e., no more malformatting with unwanted HTML elements.