### PR TITLE
Performance fix: join cdata table earlier

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2626,6 +2626,12 @@ class SqlCompiler {
 
     function getJoins($queryset) {
         $sql = '';
+        //fix:move cdata table on top in the joins. 10x faster db with 250000+ tickets
+        if (array_key_exists("cdata", $this->joins)) {
+            $temp = ['cdata' => $this->joins['cdata']];
+            unset($this->joins['cdata']);
+            $this->joins = $temp + $this->joins;
+        }
         foreach ($this->joins as $path => $j) {
             if (!$j['sql'])
                 continue;


### PR DESCRIPTION
Hi,
we have about 250k tickets and if we load the list of open tickets, it takes more than 30s to load the page.
The culprit is the big SQL query, which joins the cdata table (containing two custom ticket fields) too late. 

In this fix/hack we just change the order of joins, so the cdata table gets joined earlier, which makes the query 10 times faster on our system.

The may be a more elegant way to ensure the table is joined earlier, so feel free to suggest another path. Without this patch, OsTicket is not usable for us with this high number of tickets.