### PR TITLE
issue: Malformed From Headers

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -797,13 +797,14 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
     }
 
     function display() {
+
+        return $this->getValue();
         //TODO: Allow for display mode (edit, preview or both)
-        return sprintf('%s &nbsp;<a class="preview" href="#"
-                data-preview="#list/%d/items/%d/preview">
-                <i class="icon-info-sign"></i></a>',
-                $this->getValue(),
+        return sprintf('<a class="preview" href="#"
+                data-preview="#list/%d/items/%d/preview">%s</a>',
                 $this->getListId(),
-                $this->getId()
+                $this->getId(),
+                $this->getValue()
                 );
     }
 

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -208,6 +208,9 @@ class Mail_Parse {
         if (!($header = $this->struct->headers['from']))
             return null;
 
+        if ((strpos($header, '<') !== false) && (strpos($header, '>') === false))
+            $header = $header.'>';
+
         return Mail_Parse::parseAddressList($header, $this->charset);
     }
 


### PR DESCRIPTION
This addresses an issue where malformed From headers cause fatal errors in osTicket. We utilize PEAR's Mail_RFC822 class, specifically the `parseAddressList()` method, to parse the address list and give us an array of recipients in the From header. When a recipient in the From header is malformed this method returns an empty array. In most cases this causes a fatal error as the Ticket now has "no user". This commit attempts to fix the malformed recipient before it gets to the `parseAddressList()` method to better ensure we can retrieve a recipient.