### PR TITLE
issue: Assignee Item Property

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3526,10 +3526,10 @@ class AssigneeField extends ChoiceField {
                 $name = $value->getName();
             }
 
-            return array(JsonDataEncoder::encode(array($key => $name)));
+            return JsonDataEncoder::encode(array($key => $name));
         }
         if (is_array($value)) {
-            return array(JsonDataEncoder::encode($value[0]));
+            return JsonDataEncoder::encode($value[0]);
         }
         return $value;
     }
@@ -3562,7 +3562,7 @@ class AssigneeField extends ChoiceField {
         // Compare old and new
         return ($old == $new)
             ? false
-            : array($old[0], $new[0]);
+            : array($old, $new);
     }
 
     function whatChanged($before, $after) {

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -722,7 +722,7 @@ class DynamicListItem extends VerySimpleModel implements CustomListItem {
     function setConfiguration($vars, &$errors=array()) {
         $config = array();
         foreach ($this->getConfigurationForm($vars)->getFields() as $field) {
-            $config[$field->get('id')] = $field->to_php($field->getClean());
+            $config[$field->get('id')] = $field->to_database($field->getClean());
             $errors = array_merge($errors, $field->errors());
         }
 


### PR DESCRIPTION
This addresses an issue where you cannot save a value for an Assignee field that’s in the Item Properties of a List Item. This is due to the method used to prepare the data for the backend as well as the format of the data when returned from `to_database()`. This updates `to_php()` to `to_database()` to get the appropriate data for the backend. This also updates `to_database()` to return the JSON encoded data itself instead of in an array. Lastly, this updates the `getChanges()` method to remove the need to account for an array.