### PR TITLE
issue: Status List getSortModes()

### DIFF
--- a/include/class.list.php
+++ b/include/class.list.php
@@ -45,7 +45,7 @@ interface CustomList {
     function getConfigurationForm();
     function getSummaryFields();
 
-    static function getSortModes();
+    function getSortModes();
     function getSortMode();
     function getListOrderBy();
 
@@ -181,12 +181,16 @@ class DynamicList extends VerySimpleModel implements CustomList {
         return ($this->getForm() && $this->getForm()->getFields());
     }
 
-    static function getSortModes() {
+    static function sortModes() {
         return array(
             'Alpha'     => __('Alphabetical'),
             '-Alpha'    => __('Alphabetical (Reversed)'),
             'SortCol'   => __('Manually Sorted')
         );
+    }
+
+    function getSortModes() {
+        return self::sortModes();
     }
 
     function getSortMode() {

--- a/include/staff/dynamic-list.inc.php
+++ b/include/staff/dynamic-list.inc.php
@@ -86,7 +86,7 @@ $info=Format::htmlchars(($errors && $_POST) ? array_merge($info,$_POST) : $info,
             <td width="180"><?php echo __('Sort Order'); ?>:</td>
             <td><select name="sort_mode">
                 <?php
-                $sortModes = $list ? $list::getSortModes() : DynamicList::getSortModes();
+                $sortModes = $list ? $list->getSortModes() : DynamicList::sortModes();
                 foreach ($sortModes as $key=>$desc) { ?>
                 <option value="<?php echo $key; ?>" <?php
                     if ($key == $info['sort_mode']) echo 'selected="selected"';


### PR DESCRIPTION
This addresses issue #6063 where TicketStatusList does not have a `getSortModes()` method and fatal fails when loading the status list. This was done by `__call()` via `CustomListHandler` previously but we changed `getSortModes()` to a static method to match PHP 8 standards. We didn't account for the fact that `__call()` cannot call a static method as it uses `$this` context. This renames the `getSortModes()` method for `DynamicList` to `sortModes()`, creates a new method called `getSortModes()` which returns the self `sortModes()`, updates `dynamic-list.inc.php` to call the method non-statically and for `DynamicList` calls `sortModes()` statically, and removes `static` keyword from `getSortModes()` on `CustomList` interface.