### PR TITLE
issue: Email Templates Static

### DIFF
--- a/include/class.banlist.php
+++ b/include/class.banlist.php
@@ -17,11 +17,11 @@
 require_once "class.filter.php";
 class Banlist {
 
-    function add($email,$submitter='') {
+    static function add($email,$submitter='') {
         return self::getSystemBanList()->addRule('email','equal',$email);
     }
 
-    function remove($email) {
+    static function remove($email) {
         return self::getSystemBanList()->removeRule('email','equal',$email);
     }
 

--- a/include/class.template.php
+++ b/include/class.template.php
@@ -424,7 +424,7 @@ class EmailTemplateGroup {
         return $group->save(0,$vars,$errors);
     }
 
-    function add($vars, &$errors) {
+    static function add($vars, &$errors) {
         return self::lookup(self::create($vars, $errors));
     }
 
@@ -682,7 +682,7 @@ class EmailTemplate {
         return $template->save(0, $vars, $errors);
     }
 
-    function add($vars, &$errors) {
+    static function add($vars, &$errors) {
         $inst = self::lookup(self::create($vars, $errors));
 
         // Inline images (attached to the draft)

--- a/include/pear/Auth/SASL.php
+++ b/include/pear/Auth/SASL.php
@@ -58,7 +58,7 @@ class Auth_SASL
     *                             SCRAM-* (any mechanism of the SCRAM family)
     *                     Types are not case sensitive
     */
-    function &factory($type)
+    static function &factory($type)
     {
         switch (strtolower($type)) {
             case 'anonymous':


### PR DESCRIPTION
This addresses an issue reported on the Forum where cloning a Template Set gives you a fatal error of `Non-static method EmailTemplateGroup::add() cannot be called statically`. This updates the `add()` method to static for `EmailTemplateGroup` and `EmailTemplate` classes.