### PR TITLE
issue: Remaining Deprecated each()

### DIFF
--- a/include/cli/modules/i18n.php
+++ b/include/cli/modules/i18n.php
@@ -393,7 +393,7 @@ class i18n_Compiler extends Module {
     function __read_next_string($tokens) {
         $string = array();
 
-        while (list(,$T) = each($tokens)) {
+        foreach ($tokens as $x=>$T) {
             switch ($T[0]) {
                 case T_CONSTANT_ENCAPSED_STRING:
                     // Strip leading and trailing ' and " chars
@@ -468,7 +468,7 @@ class i18n_Compiler extends Module {
     }
 
     function __get_func_args($tokens, $args) {
-        while (list(,$T) = each($tokens)) {
+        foreach ($tokens as $x=>$T) {
             switch ($T[0]) {
             case T_WHITESPACE:
                 continue 2;
@@ -483,7 +483,7 @@ class i18n_Compiler extends Module {
     function __find_strings($tokens, $funcs, $parens=0) {
         $T_funcs = array();
         $funcdef = false;
-        while (list(,$T) = each($tokens)) {
+        foreach ($tokens as $x=>$T) {
             switch ($T[0]) {
             case T_STRING:
             case T_VARIABLE:

--- a/include/pear/Mail/mime.php
+++ b/include/pear/Mail/mime.php
@@ -181,7 +181,7 @@ class Mail_mime
 
         // Update build parameters
         if (!empty($params) && is_array($params)) {
-            while (list($key, $value) = each($params)) {
+            foreach ($params as $key=>$value) {
                 $this->build_params[$key] = $value;
             }
         }

--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -276,7 +276,7 @@ class Mail_mimeDecode extends PEAR
                     $content_disposition = $this->_parseHeaderValue($headers[$key]['value']);
                     $return->disposition   = $content_disposition['value'];
                     if (isset($content_disposition['other'])) {
-                        while (list($p_name, $p_value) = each($content_disposition['other'])) {
+                        foreach ($content_disposition['other'] as $p_name=>$p_value) {
                             $return->d_parameters[$p_name] = $p_value;
                         }
                     }

--- a/include/pear/Mail/mimePart.php
+++ b/include/pear/Mail/mimePart.php
@@ -622,7 +622,7 @@ class Mail_mimePart
         $escape = '=';
         $output = '';
 
-        while (list($idx, $line) = each($lines)) {
+        foreach ($lines as $idx=>$line) {
             $newline = '';
             $i = 0;
 

--- a/include/pear/Net/DNS2.php
+++ b/include/pear/Net/DNS2.php
@@ -858,7 +858,8 @@ class Net_DNS2
             //
             if ($tcp_fallback == false) {
 
-                $ns = each($this->nameservers);
+                $ns = (empty($this->nameservers) || !is_array($this->nameservers))
+                        ? false : [key($this->nameservers), current($this->nameservers)];
                 if ($ns === false) {
 
                     throw new Net_DNS2_Exception(

--- a/include/staff/faq.inc.php
+++ b/include/staff/faq.inc.php
@@ -82,7 +82,7 @@ if ($topics = $thisstaff->getTopicNames()) {
     <select multiple="multiple" name="topics[]" class="multiselect"
         data-placeholder="<?php echo __('Help Topics'); ?>"
         id="help-topic-selection" style="width:350px;">
-    <?php while (list($topicId,$topic) = each($topics)) { ?>
+    <?php foreach ($topics as $topicId => $topic) { ?>
         <option value="<?php echo $topicId; ?>" <?php
             if (in_array($topicId, $info['topics'])) echo 'selected="selected"';
         ?>><?php echo $topic; ?></option>


### PR DESCRIPTION
This addresses an issue reported on the Forum where a couple of `each()` methods slipped through the cracks. This updates all the `each()` (minus the php_analyzer file for now) to the new PHP 8 standards.