### PR TITLE
issue: User sendUnlockEmail

### DIFF
--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1212,11 +1212,11 @@ class UserAccount extends VerySimpleModel {
     }
 
     function sendResetEmail() {
-        return static::sendUnlockEmail('pwreset-client') === true;
+        return $this->sendUnlockEmail('pwreset-client') === true;
     }
 
     function sendConfirmEmail() {
-        return static::sendUnlockEmail('registration-client') === true;
+        return $this->sendUnlockEmail('registration-client') === true;
     }
 
     function setPassword($new) {
@@ -1225,7 +1225,7 @@ class UserAccount extends VerySimpleModel {
         Signal::send('auth.clean', $this->getUser());
     }
 
-    protected static function sendUnlockEmail($template) {
+    protected function sendUnlockEmail($template) {
         global $ost, $cfg;
 
         $token = Misc::randCode(48); // 290-bits


### PR DESCRIPTION
This addresses issue #6074 where `sendUnlockEmail()` is static but cannot be as it uses `$this`. This updates the method to non-static and updates all calls to non-static calls.