### PR TITLE
issue: preg_match Pass By Reference

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -55,7 +55,8 @@ class TicketsAjaxAPI extends AjaxController {
         global $ost;
         $hits = $ost->searcher->find($q, $hits, false);
 
-        if (preg_match('/\d{2,}[^*]/', $q, $T = array())) {
+        $T = array();
+        if (preg_match('/\d{2,}[^*]/', $q, $T)) {
             $hits = $this->lookupByNumber($limit, $visibility, $hits);
         }
         elseif (!count($hits) && preg_match('`\w$`u', $q)) {


### PR DESCRIPTION
This addresses an issue where in PHP 8 you can no longer pass variables by reference to preg_match. This moves the definition of the variable outside the preg_match so it no longer complains.