### PR TITLE
issue: Deprecated Required Parameter

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -187,7 +187,7 @@ extends VerySimpleModel {
             ))->delete();
     }
 
-    static function getConfigsByNamespace($namespace=false, $key, $value=false) {
+    static function getConfigsByNamespace(?string $namespace=null, $key, $value=false) {
         $filter = array();
 
          $filter['key'] = $key;

--- a/include/class.email.php
+++ b/include/class.email.php
@@ -467,7 +467,7 @@ class Email extends VerySimpleModel {
         return false;
     }
 
-    static function validateCredentials($username=null, $password=null, $id=null, &$errors, $smtp=false) {
+    static function validateCredentials(?string $username=null, ?string $password=null, ?int $id=null, &$errors, $smtp=false) {
         if (!$username)
             $errors[$smtp ? 'smtp_userid' : 'userid'] = __('Username missing');
 

--- a/include/class.export.php
+++ b/include/class.export.php
@@ -322,7 +322,7 @@ static function departmentMembers($dept, $agents, $filename='', $how='csv') {
     exit;
   }
 
-  static function audits($type, $filename='', $tableInfo='', $object='', $how='csv', $show_viewed=true, $data=array(), CsvExporter $exporter) {
+  static function audits($type, ?string $filename=null, ?string $tableInfo=null, ?string $object=null, ?string $how='csv', ?bool $show_viewed=true, ?array $data=array(), CsvExporter $exporter) {
       $headings = array('Description', 'Timestamp', 'IP');
       switch ($type) {
           case 'audit':

--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -89,7 +89,7 @@ class FilterAction extends VerySimpleModel {
         return $this->_impl;
     }
 
-    static function setFilterFlags($actions=false, $flag, $bool) {
+    static function setFilterFlags(?object $actions=null, $flag, $bool) {
         $flag = constant($flag);
         if ($actions) {
             foreach ($actions as $action)

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2935,12 +2935,12 @@ implements RestrictedAccess, Threadable, Searchable {
         return true;
     }
 
-    function release($info=array(), &$errors) {
-        if ($info['sid'] && $info['tid'])
+    function release(?array $info=array(), &$errors) {
+        if (isset($info['sid']) && isset($info['tid']))
             return $this->unassign();
-        elseif ($info['sid'] && $this->setStaffId(0))
+        elseif (isset($info['sid']) && $this->setStaffId(0))
             return true;
-        elseif ($info['tid'] && $this->setTeamId(0))
+        elseif (isset($info['tid']) && $this->setTeamId(0))
             return true;
 
         return false;


### PR DESCRIPTION
This addresses a few issues reported on the Forum where some methods are throwing `Deprecated: required parameter follows optional parameter` errors. This updates the erroneous methods to match the PHP 8 standards using explicit nullable types with defaults.