### PR TITLE
tests: UninitializedVars

### DIFF
--- a/include/class.draft.php
+++ b/include/class.draft.php
@@ -73,8 +73,6 @@ class Draft extends VerySimpleModel {
 
     static function getAttachmentIds($body=false) {
         $attachments = array();
-        if (!$body)
-            $body = $this->getBody();
         $body = Format::localizeInlineImages($body);
         $matches = array();
         if (preg_match_all('/"cid:([\\w.-]{32})"/', $body, $matches)) {

--- a/include/class.filter_action.php
+++ b/include/class.filter_action.php
@@ -91,11 +91,9 @@ class FilterAction extends VerySimpleModel {
 
     static function setFilterFlags($actions=false, $flag, $bool) {
         $flag = constant($flag);
-        if ($actions) {
+        if ($actions)
             foreach ($actions as $action)
                 $action->setFilterFlag($flag, $bool);
-        } else
-            $this->setFilterFlag($flag, $bool);
     }
 
     function setFilterFlag($flag, $bool) {

--- a/scp/canned.php
+++ b/scp/canned.php
@@ -73,7 +73,7 @@ if ($_POST) {
                 // Attach inline attachments from the editor
                 if (isset($_POST['draft_id'])
                         && ($draft = Draft::lookup($_POST['draft_id']))) {
-                    $images = $draft->getAttachmentIds($_POST['response']);
+                    $images = Draft::getAttachmentIds($_POST['response']);
                     $canned->attachments->keepOnlyFileIds($images, true);
                 }
 
@@ -107,7 +107,7 @@ if ($_POST) {
                 if (isset($_POST['draft_id'])
                         && ($draft = Draft::lookup($_POST['draft_id'])))
                     $premade->attachments->upload(
-                        $draft->getAttachmentIds($_POST['response']), true);
+                        Draft::getAttachmentIds($_POST['response']), true);
 
                 // Delete this user's drafts for new canned-responses
                 Draft::deleteForNamespace('canned', $thisstaff->getId());


### PR DESCRIPTION
This addresses an issue found when running cli tests where two static methods are using `$this`. This updates the methods to remove the use of `$this` and updates remaining non-static calls to static.