### PR TITLE
tests: Validation Checks

### DIFF
--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -164,9 +164,10 @@ class Validator {
     /*** Functions below can be called directly without class instance.
          Validator::func(var..);  (nolint) ***/
     static function is_email($email, $list=false, $verify=false) {
+        require_once PEAR_DIR . 'Mail/RFC822.php';
         require_once PEAR_DIR . 'PEAR.php';
-        require_once INCLUDE_DIR . 'class.mailparse.php';
-        if (!($mails = @Mail_Parse::parseAddressList($email)) || PEAR::isError($mails))
+        $rfc822 = new Mail_RFC822();
+        if (!($mails = @$rfc822->parseAddressList($email)) || PEAR::isError($mails))
             return false;
 
         if (!$list && count($mails) > 1)


### PR DESCRIPTION
This addresses an issue where when running cli tests a validation check for `jared@` failed. This is due to switching the calling class of `parseAddressList()` from `Mail_RFC822` to `Mail_Parse`. This reverts the calling class to `Mail_RFC822` to fix the issue.