### PR TITLE
fix staff login redirect loop when system is offline

### DIFF
--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -89,6 +89,8 @@ if(!$thisstaff->isAdmin()) {
 
     //Staff are not allowed to login in offline mode!!
     if(!$ost->isSystemOnline() || $ost->isUpgradePending()) {
+        //logout current user if system is offline
+        $thisstaff->logOut();
         staffLoginPage(__('System Offline'));
         exit;
     }


### PR DESCRIPTION
When the system is offline, it goes into an infinite loop when the staff tries to log in. 
With this fix, if the system is offline, authenticated user logs out before redirecting to the login page.