### PR TITLE
issue: QueueSort

### DIFF
--- a/include/ajax.admin.php
+++ b/include/ajax.admin.php
@@ -225,10 +225,12 @@ class AdminAjaxAPI extends AjaxController {
             Http::response(403, 'Access denied');
 
         $sort = new QueueSort();
+        $errors = array();
         if ($_POST) {
+            $_POST['root'] = $root;
             $data_form = $sort->getDataConfigForm($_POST);
             if ($data_form->isValid()) {
-                $sort->update($data_form->getClean() + $_POST, $root);
+                $sort->update($data_form->getClean() + $_POST, $errors);
                 if ($sort->save())
                     Http::response(201, $this->encode(array(
                         'id' => $sort->getId(),


### PR DESCRIPTION
This addresses an issue reported on the Forum where when adding a new Queue Sort an error of `Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given` is thrown. This is due to passing the wrong arguments to the `QueueSort::update()` method. This corrects the arguments to `$vars, $errors` to resolve the error.