### PR TITLE
issue: Task Export

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -680,7 +680,7 @@ class ResultSetExporter {
                 }
             }
             // Evalutate :: function call on target current
-            if ($func && (method_exists($current, $func) || method_exists($current, '__call'))) {
+            if (($current && $func) && (method_exists($current, $func) || method_exists($current, '__call'))) {
                 $current = $current->{$func}();
             }
 


### PR DESCRIPTION
This addresses an issue reported on the Forum where exporting Tasks gives you a fatal error. This is due to not checking if `$current` is set before using it in `method_exists()`. This checks to make sure we have `$current` set before using it.