### PR TITLE
issue: MaxLength Attribute

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4348,6 +4348,8 @@ class TextboxWidget extends Widget {
                     if ($v)
                         $attrs['data-translate-tag'] =  '"'.$v.'"';
                     break;
+                case 'length':
+                    $k = 'maxlength';
                 case 'size':
                 case 'maxlength':
                     if ($v && is_numeric($v))


### PR DESCRIPTION
This addresses an issue reported on the Forum where Fields are not honoring the Length value. This is due to the label being set to `length` while the HTML attribute is named `maxlength`. This adds a case for `length` that sets the attribute name to `maxlength`.