### PR TITLE
Fix malforming *text* thread entries by looking for unclosed HTML tags

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2840,7 +2840,7 @@ class TextThreadEntryBody extends ThreadEntryBody {
     }
 
     function getClean() {
-        return Format::htmlchars(Format::html_balance(Format::stripEmptyLines(parent::getClean())));
+        return Format::htmlchars(Format::stripEmptyLines(parent::getClean()));
     }
 
     function prepend($what) {


### PR DESCRIPTION
```
When dealing with *text* entries there is no point in checking them for
invalid HTML code (unclosed HTML tags) using Format::html_balance().
That could result in treating pure text as HTML and malforming parts
looking similar to HTML syntax.

This change *prevents* replacing fragments like:
"foo <bar@qux> ..."
with:
"foo <bar> ...</bar>"

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```