### PR TITLE
issue: PEAR Mail parseAddressList()

### DIFF
--- a/include/pear/Mail.php
+++ b/include/pear/Mail.php
@@ -241,7 +241,6 @@ class Mail
     function parseRecipients($recipients)
     {
         include_once 'Mail/RFC822.php';
-        include_once INCLUDE_DIR.'class.mailparse.php';
 
         // if we're passed an array, assume addresses are valid and
         // implode them before parsing.
@@ -252,7 +251,8 @@ class Mail
         // Parse recipients, leaving out all personal info. This is
         // for smtp recipients, etc. All relevant personal information
         // should already be in the headers.
-        $addresses = Mail_Parse::parseAddressList($recipients, 'localhost', false);
+        $parser = new Mail_RFC822();
+        $addresses = $parser->parseAddressList($recipients, 'localhost', false);
 
         // If parseAddressList() returned a PEAR_Error object, just return it.
         if (is_a($addresses, 'PEAR_Error')) {


### PR DESCRIPTION
This addresses an issue reported on the Forum where when `Mail::parseRecipients()` is called it throws a fatal error of `Uncaught ValueError: mb_convert_encoding(): Argument #2 ($to_encoding) must be a valid encoding, "localhost" given`. This is due to an erroneous change when adding PHP 8.0 support. We changed the called class from `Mail_RFC822` to `Mail_Parse` but left the same arguments. This is obviously an issue as both classes' methods take different arguments. This changes the called class back to `Mail_RFC822` to stick to original functionality and updates it for PHP 8.0 standards.