### PR TITLE
issue: Filter Events

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4031,6 +4031,7 @@ implements RestrictedAccess, Threadable, Searchable {
                             $postCreate->logEvent($description['type'], $description['desc'], $username);
 
                     }
+                    if ($f->stopOnMatch()) break;
                 }
             }
         }


### PR DESCRIPTION
This addresses issue #6059 where Ticket Filter processing stops accurately but the Thread Events are blindly added for any Filters that match the criteria. This is due to not checking the current Filter in the iteration for `stopOnMatch()`. This adds a check for `stopOnMatch()` and if `true` we will break the loop.