### PR TITLE
issue: Undefined Constant GLOB_BRACE

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -251,7 +251,7 @@ class PluginManager {
      */
     static function allInfos() {
         foreach (glob(INCLUDE_DIR . 'plugins/*',
-                GLOB_NOSORT|GLOB_BRACE) as $p) {
+                GLOB_NOSORT) as $p) {
             $is_phar = false;
             if (substr($p, strlen($p) - 5) == '.phar'
                     && class_exists('Phar')


### PR DESCRIPTION
This addresses issue #6079 where using `1.16.x` and PHP 8.0 on certain GNU systems (eg. Alpine, Solaris, etc.) throws a fatal error of `Undefined constant: "GLOB_BRACE"` when loading Plugins. This is due to `GLOB_BRACE` not being available on said GNU systems. This removes `GLOB_BRACE` from `include/class.plugin.php` completely as it is not used anyways.