### PR TITLE
oops: Banlist Created

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -238,6 +238,7 @@ extends VerySimpleModel {
             $extra['notes'] = Format::sanitize($extra['notes']);
         $rule = array_merge($extra,array('what'=>$what, 'how'=>$how, 'val'=>$val));
         $rule = new FilterRule($rule);
+        $rule->created = SqlFunction::NOW();
         $this->rules->add($rule);
         if ($rule->save())
             return true;


### PR DESCRIPTION
This addresses an issue where the created date for banlist items show an old, incorrect date. This is due to not setting a created date before saving to the database.