### PR TITLE
Fix: plugin config with multiple plugins

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -374,6 +374,7 @@ abstract class Plugin {
      * that inherits from PluginConfig. This is abstract and must be defined
      * by the plugin subclass.
      */
+    var $config = null;
     var $config_class = null;
     var $id;
     var $info;
@@ -480,11 +481,10 @@ abstract class Plugin {
     }
 
     function getConfig() {
-        static $config = null;
-        if ($config === null && $this->config_class)
-            $config = new $this->config_class($this->getId());
+        if ($this->config === null && $this->config_class)
+            $this->config = new $this->config_class($this->getId());
 
-        return $config;
+        return $this->config;
     }
 
     function source($what) {


### PR DESCRIPTION
Due to the current static way of storing the config for all plugins, the plugin config is stored statically for all plugins. This means it is impossible to use multiple plugins with configuration. 

This pull requests fix this while still preventing multiple database calls for the same config. 