### PR TITLE
issue: mPDF Table Print

### DIFF
--- a/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
+++ b/include/mpdf/vendor/mpdf/mpdf/src/Config/ConfigVariables.php
@@ -261,7 +261,7 @@ class ConfigVariables
 			'packTableData' => false,
 
 			'ignore_table_percents' => false,
-			'ignore_table_widths' => false,
+			'ignore_table_widths' => true,
 			// If table width set > page width, force resizing but keep relative sizes
 			// Also forces respect of cell widths set by %
 			'keep_table_proportions' => true,


### PR DESCRIPTION
This addresses issue #6159 where tables are not appearing correctly in PDFs. This is due to mPDF config revert when upgrading mPDF. This updates the config `ignore_table_widths` to `true` so tables appear correctly.