### PR TITLE
Do not autocomplete new access fields of the (another) user

### DIFF
--- a/include/staff/templates/user-account.tmpl.php
+++ b/include/staff/templates/user-account.tmpl.php
@@ -90,7 +90,7 @@ if ($info['error']) {
                     <?php echo __('Username'); ?>:
                 </td>
                 <td>
-                    <input type="text" size="35" name="username" value="<?php echo $info['username']; ?>">
+                    <input type="text" size="35" name="username" value="<?php echo $info['username']; ?>" autocomplete="new-password">
                     <i class="help-tip icon-question-sign" data-title="<?php
                         echo __("Login via email"); ?>"
                     data-content="<?php echo sprintf('%s: %s',
@@ -104,7 +104,7 @@ if ($info['error']) {
                     <?php echo __('New Password'); ?>:
                 </td>
                 <td>
-                    <input type="password" size="35" name="passwd1" value="<?php echo $info['passwd1']; ?>">
+                    <input type="password" size="35" name="passwd1" value="<?php echo $info['passwd1']; ?>" autocomplete="new-password">
                     &nbsp;<span class="error">&nbsp;<?php echo
                     $errors['passwd1']; ?></span>
                 </td>
@@ -114,7 +114,7 @@ if ($info['error']) {
                    <?php echo __('Confirm Password'); ?>:
                 </td>
                 <td>
-                    <input type="password" size="35" name="passwd2" value="<?php echo $info['passwd2']; ?>">
+                    <input type="password" size="35" name="passwd2" value="<?php echo $info['passwd2']; ?>" autocomplete="new-password">
                     &nbsp;<span class="error">&nbsp;<?php echo $errors['passwd2']; ?></span>
                 </td>
             </tr>


### PR DESCRIPTION
Otherwise these fields get autocompleted by browser and need to be emptied to save the form (for example I want only to block the account and save).