### PR TITLE
issue: Redactor Freezing

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -1042,6 +1042,7 @@ if ($errors['err'] && isset($_POST['a'])) {
                         break;
                     } ?>
                     <input type="hidden" name="draft_id" value=""/>
+                    <br/>
                     <textarea name="response" id="response" cols="50"
                         data-signature-field="signature" data-dept-id="<?php echo $dept->getId(); ?>"
                         data-signature="<?php


### PR DESCRIPTION
This addresses an issue where removing all text in Redactor in the Post Reply box freezes the entire page (using 90% or more CPU). As a quick workaround user jarnott from the Forum found that adding a `br` tag between the `draft_id` input and the Post Reply `textarea` fixes the issue. This adds the `br` tag to temporarily address the issue until Redactor addresses the issue permanently.