### PR TITLE
installer: Help Topic Disabled Fields

### DIFF
--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -551,11 +551,11 @@ implements TemplateVariable, Searchable {
 
     function updateForms($vars, &$errors) {
         $find_disabled = function($form) use ($vars) {
-            $fields = $vars['fields'] ?: array();
+            $fields = $vars['fields'] ?: null;
             $disabled = array();
             foreach ($form->fields->values_flat('id') as $row) {
                 list($id) = $row;
-                if (false === ($idx = array_search($id, $fields))) {
+                if (is_array($fields) && (false === ($idx = array_search($id, $fields)))) {
                     $disabled[] = $id;
                 }
             }


### PR DESCRIPTION
This addresses an issue where installing `1.16.x` has the Ticket Details Form Fields disabled for every Help Topic. This is due to checking if the Field IDs are in an empty array which obviously will return false. This updates the declaration of `$fields` from `array()` to `null` if the array index doesn’t exist. This also updates the `if` statement for the Field ID checking to ensure the `$fields` variable is an array. This ensures that the check is skipped if `$fields` is `null` avoiding erroneous disabled fields.