### PR TITLE
issue: Check User Status

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -612,6 +612,7 @@ abstract class StaffAuthenticationBackend  extends AuthenticationBackend {
         if (!($bk=static::getBackend($id)) //get the backend
                 || !($staff = $bk->validate($auth)) //Get AuthicatedUser
                 || !($staff instanceof Staff)
+                || !$staff->isActive()
                 || $staff->getId() != $_SESSION['_auth']['staff']['id'] // check ID
         )
             return null;
@@ -636,7 +637,9 @@ abstract class StaffAuthenticationBackend  extends AuthenticationBackend {
 
     protected function validate($authkey) {
 
-        if (($staff = StaffSession::lookup($authkey)) && $staff->getId())
+        if (($staff = StaffSession::lookup($authkey))
+            && $staff->getId()
+            && $staff->isActive())
             return $staff;
     }
 }
@@ -831,6 +834,9 @@ abstract class UserAuthenticationBackend  extends AuthenticationBackend {
                 )
             return null;
 
+        if (($account=$user->getAccount()) && !$account->isActive())
+            return null;
+
         $user->setAuthKey($_SESSION['_auth']['user']['key']);
 
         return $user;
@@ -839,7 +845,9 @@ abstract class UserAuthenticationBackend  extends AuthenticationBackend {
     protected function validate($userid) {
         if (!($user = User::lookup($userid)))
             return false;
-        elseif (!$user->getAccount())
+        elseif (!($account=$user->getAccount()))
+            return false;
+        elseif (!$account->isActive())
             return false;
 
         return new ClientSession(new EndUser($user));

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -1122,6 +1122,10 @@ class UserAccount extends VerySimpleModel {
         return $this->getStatus()->isLocked();
     }
 
+    function isActive() {
+        return (!$this->isLocked() && $this->isConfirmed());
+    }
+
     function forcePasswdReset() {
         $this->setStatus(UserAccountStatus::REQUIRE_PASSWD_RESET);
         return $this->save();


### PR DESCRIPTION
This is a rewrite of #6163 where we aren’t checking User/Agent status on login and on session validation. This adds checks to the UserAuthenticationBackend to ensure the User is active (ie. confirmed and not administratively locked). This also adds checks to the StaffAuthentciationBackend to ensure the Agent is active (ie. not locked). If a User/Agent is not active they will be redirected to the login screen.