### PR TITLE
Fix: plugin management displays config edit form for different plugin

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -375,6 +375,7 @@ abstract class Plugin {
      * by the plugin subclass.
      */
     var $config_class = null;
+    var $config = null;
     var $id;
     var $info;
 
@@ -480,11 +481,10 @@ abstract class Plugin {
     }
 
     function getConfig() {
-        static $config = null;
-        if ($config === null && $this->config_class)
-            $config = new $this->config_class($this->getId());
+        if ($this->config === null && $this->config_class)
+            $this->config = new $this->config_class($this->getId());
 
-        return $config;
+        return $this->config;
     }
 
     function source($what) {


### PR DESCRIPTION
The getConfig method of the Plugin class incorrectly uses a static variable to cache the plugin config.
This means only the first edited plugin shows the correct edit form.

Switch to using a class member variable.