### PR TITLE
Add option to assign forms to tickets which are created by mail

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -233,6 +233,7 @@ class OsticketConfig extends Config {
         'default_storage_bk' => 'D',
         'message_autoresponder_collabs' => true,
         'add_email_collabs' => true,
+        'add_email_forms' => false,
         'clients_only' => false,
         'client_registration' => 'closed',
         'accept_unregistered_email' => true,
@@ -861,6 +862,10 @@ class OsticketConfig extends Config {
 
     function addCollabsViaEmail() {
         return ($this->get('add_email_collabs'));
+    }
+
+    function addFormsViaEmail() {
+        return ($this->get('add_email_forms'));
     }
 
     function getAdminEmail() {
@@ -1565,6 +1570,7 @@ class OsticketConfig extends Config {
             'use_email_priority'=>isset($vars['use_email_priority'])?1:0,
             'accept_unregistered_email'=>isset($vars['accept_unregistered_email'])?1:0,
             'add_email_collabs'=>isset($vars['add_email_collabs'])?1:0,
+            'add_email_forms'=>isset($vars['add_email_forms'])?1:0,
             'reply_separator'=>$vars['reply_separator'],
             'email_attachments'=>isset($vars['email_attachments'])?1:0,
          ));

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3963,6 +3963,53 @@ implements RestrictedAccess, Threadable, Searchable {
         return db_fetch_array(db_query($sql));
     }
 
+    /**
+     * Handle the forms associate with the help topics.
+     * Instanciate the entries, disable and track the requested disabled fields.
+     * 
+     * @param TicketForm $form Ticket form
+     * @param int $topicId ID from the help topic.
+     * @param array $vars Variables array
+     * @return array Associated forms
+     */
+    protected static function handleFormsAssociation(&$form, $topicId, $vars) {
+        global $cfg;
+        
+        $topic_forms = array();
+        if ($topicId) {
+            if ($__topic=Topic::lookup($topicId)) {
+                foreach ($__topic->getForms() as $idx=>$__F) {
+                    $disabled = array();
+                    foreach ($__F->getFields() as $field) {
+                        if (!$field->isEnabled() && $field->hasFlag(DynamicFormField::FLAG_ENABLED))
+                            $disabled[] = $field->get('id');
+                    }
+                    // Special handling for the ticket form — disable fields
+                    // requested to be disabled as per the help topic.
+                    if ($__F->get('type') == 'T') {
+                        foreach ($form->getFields() as $field) {
+                            if (false !== array_search($field->get('id'), $disabled))
+                                $field->disable();
+                        }
+                        $form->sort = $idx;
+                        $__F = $form;
+                    }
+                    else {
+                        $__F = $__F->instanciate($idx);
+                        $__F->setSource($vars);
+                        $topic_forms[] = $__F;
+                    }
+                    // Track fields currently disabled
+                    $__F->extra = JsonDataEncoder::encode(array(
+                        'disable' => $disabled
+                    ));
+                }
+            }
+        }
+
+        return $topic_forms;
+    }
+
     protected static function filterTicketData($origin, $vars, $forms, $user=false, $postCreate=false) {
         global $cfg;
 
@@ -4141,38 +4188,7 @@ implements RestrictedAccess, Threadable, Searchable {
         $topic_forms = array();
         if (!$errors) {
 
-            // Handle the forms associate with the help topics. Instanciate the
-            // entries, disable and track the requested disabled fields.
-            if ($vars['topicId']) {
-                if ($__topic=Topic::lookup($vars['topicId'])) {
-                    foreach ($__topic->getForms() as $idx=>$__F) {
-                        $disabled = array();
-                        foreach ($__F->getFields() as $field) {
-                            if (!$field->isEnabled() && $field->hasFlag(DynamicFormField::FLAG_ENABLED))
-                                $disabled[] = $field->get('id');
-                        }
-                        // Special handling for the ticket form — disable fields
-                        // requested to be disabled as per the help topic.
-                        if ($__F->get('type') == 'T') {
-                            foreach ($form->getFields() as $field) {
-                                if (false !== array_search($field->get('id'), $disabled))
-                                    $field->disable();
-                            }
-                            $form->sort = $idx;
-                            $__F = $form;
-                        }
-                        else {
-                            $__F = $__F->instanciate($idx);
-                            $__F->setSource($vars);
-                            $topic_forms[] = $__F;
-                        }
-                        // Track fields currently disabled
-                        $__F->extra = JsonDataEncoder::encode(array(
-                            'disable' => $disabled
-                        ));
-                    }
-                }
-            }
+            $topic_forms = self::handleFormsAssociation($form, $vars['topicId'], $vars);
 
             try {
                 $vars = self::filterTicketData($origin, $vars,
@@ -4295,6 +4311,8 @@ implements RestrictedAccess, Threadable, Searchable {
                     && ($T = $email->getTopic())
                     && ($T->isActive())) {
                 $topic = $T;
+                if ($cfg->addFormsViaEmail())
+                    $topic_forms = self::handleFormsAssociation($form, $T->getId(), $vars);
             }
             $email = null;
             $source = 'Email';

--- a/include/i18n/en_US/help/tips/settings.email.yaml
+++ b/include/i18n/en_US/help/tips/settings.email.yaml
@@ -118,6 +118,12 @@ accept_email_collaborators:
         <em>Collaborators can always be added manually by Agents when
         viewing a ticket.</em>
 
+add_email_forms:
+    title: Add Forms
+    content: >
+        Forms associated with the Help Topic will be added to the ticket,
+        <strong>but will not have any data</strong>.
+
 default_mta:
     title: Default MTA
     content: >

--- a/include/staff/settings-emails.inc.php
+++ b/include/staff/settings-emails.inc.php
@@ -141,6 +141,13 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config)
             <?php echo __('Automatically add collaborators from email fields'); ?>&nbsp;
             <i class="help-tip icon-question-sign" href="#accept_email_collaborators"></i>
         </tr>
+        <tr>
+            <td width="180"><?php echo __('Add Forms'); ?>:</td>
+            <td><input type="checkbox" name="add_email_forms" <?php
+            echo $config['add_email_forms'] ? 'checked="checked"' : ''; ?>/>
+            <?php echo __('Add forms associated with the Help Topic to the ticket'); ?>&nbsp;
+            <i class="help-tip icon-question-sign" href="#add_email_forms"></i>
+        </tr>
         <tr><th colspan=2><em><strong><?php echo __('Outgoing Email');?></strong>: <?php echo __('Default email only applies to outgoing emails without SMTP setting.');?></em></th></tr>
         <tr><td width="180"><?php echo __('Default MTA'); ?>:</td>
             <td>


### PR DESCRIPTION
This is a new version from my PR #5906 to fix one problem of the bug #5846. I know that you [don't want to allow this by default](https://forum.osticket.com/d/99863-custom-form-not-added-for-tickets-received-via-email/11). So i create a new mail option, which is off by default.