### PR TITLE
Fix truncation of messages containing encoded HTML entities which will decode in invalid HTML tags (e.g. <)

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -358,7 +358,7 @@ class Format {
     static function sanitize($text, $striptags=false, $spec=false) {
 
         //balance and neutralize unsafe tags.
-        $text = Format::safe_html($text, array('spec' => $spec));
+        $text = Format::safe_html($text, array('spec' => $spec, 'decode' => false));
 
         $text = self::localizeInlineImages($text);
 


### PR DESCRIPTION
This commit will disable the decoding of HTML entities (e.g. `&lt;` and `&gt;`) when come along from Format::sanitize function. This will fix the problem with < and > symbols truncating the remaining message within the html_balance/strip function.

Maybe, there is a good reason for this, but I can't figure it out, so please help me :-)