### PR TITLE
i18n: Default Ticket Queue

### DIFF
--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -57,6 +57,13 @@ default_sla:
       - title: Create more SLA Plans
         href: /scp/slas.php
 
+default_ticket_queue:
+    title: Default Ticket Queue
+    content: >
+        Setting to determine the default queue for Agents upon log-in.
+        Agents can also set their default queue in their Profile tab to
+        override this setting.
+
 default_priority:
     title: Default Priority
     content: >


### PR DESCRIPTION
This adds the Help Tip for Default Ticket Queue setting in Admin Panel > Settings > Tickets > Settings.