### PR TITLE
issue: Manually Sorted Topics

### DIFF
--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -65,7 +65,7 @@ if($_POST){
 
                 $activeTopics = Topic::getHelpTopics(false, false);
                 $allTopics = count(Topic::getAllHelpTopics());
-                $diff = array_intersect($_POST['ids'], array_keys($activeTopics));
+                $diff = is_array($_POST['ids']) ? array_intersect($_POST['ids'], array_keys($activeTopics)) : [];
 
                 switch(strtolower($_POST['a'])) {
                     case 'enable':


### PR DESCRIPTION
This addresses issue #6197 where setting Help Topics sort to Manually throws a fatal error. This is due to not checking if `$_POST['ids']` is an array before passing it to `array_intersect()`. This adds a check to see if the ids are an array and if not then `$diff` will be set to an empty array (which is what `array_intersect()` returns if the arrays have no common values).