### PR TITLE
date(): Argument #2 must be of type ?int

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -3130,7 +3130,7 @@ extends QueueColumnFilter {
     function filter($text, $row) {
         return sprintf(
             '<time class="relative" datetime="%s" title="%s">%s</time>',
-            date(DateTime::W3C, Misc::db2gmtime($text->value) ?: 0),
+            date(DateTime::W3C, strtotime(Misc::db2gmtime($text->value)) ?: 0),
             Format::daydatetime($text->value),
             Format::relativeTime(Misc::db2gmtime($text->value))
         );


### PR DESCRIPTION
Patch to correct the php8.0.20 error :

2022/07/21 11:49:43 [error] 11135#0: *263185 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: date(): Argument #2 ($timestamp) must be of type ?int, string given in ##/upload/include/class.queue.php:3133
Stack trace:
#0 ##/upload/include/class.queue.php(3133): date()
#1 ##/upload/include/class.queue.php(2336): HumanizedDateFilter->filter()
#2 ##/upload/include/staff/templates/queue-tickets.tmpl.php(270): QueueColumn->render()
#3 ##/upload/scp/tickets.php(565): require_once('...')
#4 ##/upload/scp/index.php(17): require('...')
#5 {main}

php installed from Aapanel with nginx

php -v
PHP 8.0.20 (cli) (built: Jul 21 2022 10:20:43) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.20, Copyright (c) Zend Technologies