### PR TITLE
issue: Queue Export Headings

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1185,7 +1185,7 @@ class CustomQueue extends VerySimpleModel {
                 continue;
             }
 
-            $f->set('heading', $heading);
+            $f->set('heading', isset($fields[$key]['heading']) ? $fields[$key]['heading'] : $heading);
             $f->set('sort', array_search($key, $order)+1);
             unset($new[$key]);
         }


### PR DESCRIPTION
This addresses an issue where updating the Queue Export Column Headings doesn't actually save the changes. This is due to using the previous heading regardless of the headings being passed in. This adds a check for the column heading in `$fields` and if exists we use that otherwise we default back to the previous heading.