### PR TITLE
mailparse: thread_entry_recipients to

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -691,7 +691,9 @@ class EmailDataParser {
                 }
             }
         }
-        $data['thread_entry_recipients']['to'] = array_unique($data['thread_entry_recipients']['to']);
+        $data['thread_entry_recipients']['to'] = isset($data['thread_entry_recipients']['to'])
+                ? array_unique($data['thread_entry_recipients']['to'])
+                : [];
 
         /*
          * In the event that the mail was delivered to the system although none of the system


### PR DESCRIPTION
This addresses an issue where some emails don't have a To header which causes a fatal error when parsing mail. This is due to assuming To is set and passing it to array_unique which expects the value to be an array. This adds a check to see if To is set and if so we call array_unique otherwise we default to an empty array.