### PR TITLE
installer: Checking Existing Install

### DIFF
--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -101,15 +101,17 @@ class Installer extends SetupWizard {
             } elseif(!db_select_database($vars['dbname'])) {
                 $this->errors['dbname']=__('Unable to select the database');
             } else {
-                //Abort if we have another installation (or table) with same prefix.
-                $sql = 'SELECT * FROM `'.$vars['prefix'].'config` LIMIT 1';
-                if(db_query($sql, false)) {
-                    $this->errors['err'] = __('We have a problem - another installation with same table prefix exists!');
-                    $this->errors['prefix'] = __('Prefix already in-use');
-                } else {
-                    //Try changing charset and collation of the DB - no bigie if we fail.
-                    db_query('ALTER DATABASE '.$vars['dbname'].' DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci', false);
-                }
+               try {
+                   //Abort if we have another installation (or table) with same prefix.
+                   $sql = 'SELECT * FROM `'.$vars['prefix'].'config` LIMIT 1';
+                   if(db_query($sql, false)) {
+                       $this->errors['err'] = __('We have a problem - another installation with same table prefix exists!');
+                       $this->errors['prefix'] = __('Prefix already in-use');
+                   } else {
+                       //Try changing charset and collation of the DB - no bigie if we fail.
+                       db_query('ALTER DATABASE '.$vars['dbname'].' DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci', false);
+                   }
+               } catch (Exception $ex) {} // If an error is thrown, don't worry, (be happy) it's okay!
             }
         }
 


### PR DESCRIPTION
This addresses an issue with PHP 8.1 where on install we run a query to see if we can select data from the `%TABLE_PREFIX%config` table to see if there is already an instance installed to avoid overwriting data. In PHP 8.1 this will throw a fatal error which kills the installer. This adds a `try {} catch() {}` statement around the call so that if it does throw an error it continues without issues. This is what we want anyways, if the query returns false or an error then we want to continue.