### PR TITLE
issue: AuthenticationBackend getBkId()

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -178,7 +178,7 @@ abstract class OAuth2Backend extends ServiceRegistry {
                 || !($bk instanceof OAuth2Backend))
             return false;
 
-        static::$registry[$bk->getId()] = $bk;
+        static::$registry[$bk->getBkId()] = $bk;
     }
 
     static function allRegistered() {
@@ -330,7 +330,7 @@ abstract class AuthenticationBackend extends ServiceRegistry {
         foreach (static::allRegistered() as $bk) {
             if ($backends //Allowed backends
                     && $bk->supportsInteractiveAuthentication()
-                    && !in_array($bk->getId(), $backends))
+                    && !in_array($bk->getBkId(), $backends))
                 // User cannot be authenticated against this backend
                 continue;
 
@@ -589,7 +589,7 @@ abstract class StaffAuthenticationBackend  extends AuthenticationBackend {
         if (!($backends=self::getAllowedBackends($staff->getId())))
             return true;  //No restrictions
 
-        return in_array($bk->getId(), array_map('strtolower', $backends));
+        return in_array($bk->getBkId(), array_map('strtolower', $backends));
     }
 
     function getPasswordPolicies($user=null) {

--- a/include/staff/staff.inc.php
+++ b/include/staff/staff.inc.php
@@ -150,7 +150,7 @@ if (($bks = StaffAuthenticationBackend::getInteractive())) {
                 ">
               <option value="">&mdash; <?php echo __('Use any available backend'); ?> &mdash;</option>
 <?php foreach ($bks as $ab) {
-                $id = $ab->getId(); ?>
+                $id = $ab->getBkId(); ?>
               <option value="<?php echo $id; ?>" <?php
                 if ($staff->backend == $id)
                   echo 'selected="selected"'; ?>><?php


### PR DESCRIPTION
This addresses an issue where we are calling `getId()` instead of `getBkId()` in some places when registering and listing plugin instances. This causes an issue if a User is auto-created via something like LDAP and the `backend` is set to something like `ldap.client.p[id]i[id]`. When we get available/registered backends we are not selecting the appropriate ID so the backend is considered "not in the list" and does not let the User authenticate. This changes all the calls to `getBkId()` to ensure we are selecting the appropriate ID.