### PR TITLE
plugins: Audit enable()

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -366,6 +366,8 @@ class PluginManager {
         ];
         $p = Plugin::create($vars);
         if ($p->save(true)) {
+            // TODO: Trigger enable() for the plugin (for now)
+            $p->getImpl()->enable();
             static::clearCache();
             return $p;
         }
@@ -774,6 +776,10 @@ class Plugin extends VerySimpleModel {
      * FALSE if the uninstall operation should be aborted.
      */
     function pre_uninstall(&$errors) {
+        return true;
+    }
+
+    function enable() {
         return true;
     }
 


### PR DESCRIPTION
This addresses an issue where the Audit Plugin relies on `enable()` being called in order to create the `_audit` table required for saving audit data to the database. This adds the method back temporarily until we can rewrite the plugin to fit the new standards. This also attempts to call `enable()` on install so that the table can be created. If the plugin doesn't have an `enable()` method it defaults to the parent class Plugin `enable()` which just returns `true`.