### PR TITLE
issue: Staff Ticket Open Session

### DIFF
--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -432,6 +432,8 @@ if($_POST && !$errors):
                         $response_form->setSource(array());
                         $response_form->getField('attachments')->reset();
                         $_SESSION[':form-data'] = null;
+                        // Regenerate Session ID
+                        $thisstaff->regenerateSession();
                     } elseif(!$errors['err']) {
                         // ensure that we retain the tid if ticket is created from thread
                         if ($_SESSION[':form-data']['ticketId'] || $_SESSION[':form-data']['taskId'])


### PR DESCRIPTION
This addresses an issue where we are not regenerating the session for Staff members after they've opened a Ticket. This adds `$thisstaff->regenerateSession()` after creating a Ticket so that the session is regenerated.