### PR TITLE
php: 8.1 Support

### DIFF
--- a/include/class.import.php
+++ b/include/class.import.php
@@ -31,8 +31,6 @@ class CsvImporter {
     function __construct($stream) {
         // File upload
         if (is_array($stream) && !$stream['error']) {
-            // Properly detect Macintosh style line endings
-            ini_set('auto_detect_line_endings', true);
             $this->stream = fopen($stream['tmp_name'], 'r');
             // Skip Byte Order Mark (BOM) if present
             if (!self::isBOM(fgets($this->stream, 4)))

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -596,8 +596,6 @@ class DynamicList extends VerySimpleModel implements CustomList {
 
     function importFromPost($stuff, $extra=array()) {
         if (is_array($stuff) && !$stuff['error']) {
-            // Properly detect Macintosh style line endings
-            ini_set('auto_detect_line_endings', true);
             $stream = fopen($stuff['tmp_name'], 'r');
         }
         elseif ($stuff) {

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -1667,7 +1667,17 @@ EOF;
         return $classname;
     }
 
+    // Fix PHP 8.1.x Deprecation Warnings
+    // Serializable interface will be removed in PHP 9.x
     function serialize() {
+        return serialize($this->__serialize());
+    }
+
+    function unserialize($data) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    function __serialize() {
         $info = get_object_vars($this);
         unset($info['query']);
         unset($info['limit']);
@@ -1675,11 +1685,10 @@ EOF;
         unset($info['_iterator']);
         unset($info['count']);
         unset($info['total']);
-        return serialize($info);
+        return $info;
     }
 
-    function unserialize($data) {
-        $data = unserialize($data);
+    function __unserialize($data) {
         foreach ($data as $name => $val) {
             $this->{$name} = $val;
         }
@@ -3621,12 +3630,22 @@ class Q implements Serializable {
         return $result;
     }
 
+    // Fix PHP 8.1.x Deprecation Warnings
+    // Serializable interface will be removed in PHP 9.x
     function serialize() {
-        return serialize(array($this->negated, $this->ored, $this->constraints));
+        return serialize($this->__serialize());
     }
 
     function unserialize($data) {
-        list($this->negated, $this->ored, $this->constraints) = unserialize($data);
+        $this->__unserialize(unserialize($data));
+    }
+
+    function __serialize() {
+        return array($this->negated, $this->ored, $this->constraints);
+    }
+
+    function __unserialize($data) {
+        list($this->negated, $this->ored, $this->constraints) = $data;
     }
 }
 ?>

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2960,7 +2960,12 @@ class MySqlCompiler extends SqlCompiler {
         $q->annotations = false;
         $exec = $q->getQuery(array('nosort' => true));
         $exec->sql = 'SELECT COUNT(*) FROM ('.$exec->sql.') __';
-        $row = $exec->getRow();
+        try {
+            $row = $exec->getRow();
+        } catch (mysqli_sql_exception $e) {
+            throw new InconsistentModelException(
+                'Unable to prepare query: '.db_error().' '.$sql);
+        }
         return is_array($row) ? (int) $row[0] : null;
     }
 

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -71,7 +71,7 @@ class osTicketSession {
             $this->backend = new self::$backends['db']($this->ttl);
         }
 
-        if ($this->backend instanceof SessionBackend) {
+        if (!empty($this->id) && ($this->backend instanceof SessionBackend)) {
             // Set handlers.
             session_set_save_handler(
                 array($this->backend, 'open'),

--- a/include/class.page.php
+++ b/include/class.page.php
@@ -234,10 +234,7 @@ class Page extends VerySimpleModel {
         try {
             return self::objects()->filter(array('type'=>$type))->one();
         }
-        catch (DoesNotExist $ex) {
-            return null;
-        }
-        catch (InconsistentModelException $ex) {
+        catch (DoesNotExist | InconsistentModelException $ex) {
             return null;
         }
     }

--- a/include/class.sequence.php
+++ b/include/class.sequence.php
@@ -204,7 +204,7 @@ class Sequence extends VerySimpleModel {
         return parent::__get($what);
     }
 
-    function __create($data) {
+    public static function __create($data) {
         $instance = new self($data);
         $instance->save();
         return $instance;

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -667,12 +667,20 @@ class Translation extends gettext_reader implements Serializable {
     }
 
 
+    // Fix PHP 8.1.x Deprecation Warnings
+    // Serializable interface will be removed in PHP 9.x
     function serialize() {
-        return serialize(array($this->charset, $this->encode, $this->cache_translations));
+        return serialize($this->__serialize());
     }
     function unserialize($what) {
-        list($this->charset, $this->encode, $this->cache_translations)
-            = unserialize($what);
+        $this->__unserialize(unserialize($what));
+    }
+
+    function __serialize() {
+        return array($this->charset, $this->encode, $this->cache_translations);
+    }
+    function __unserialize($what) {
+        list($this->charset, $this->encode, $this->cache_translations) = $what;
         $this->short_circuit = ! $this->enable_cache
             = 0 < $this->cache_translations ? count($this->cache_translations) : 1;
     }

--- a/include/class.util.php
+++ b/include/class.util.php
@@ -215,12 +215,22 @@ implements ArrayAccess, Serializable {
         unset($this->storage[$offset]);
     }
 
-    // Serializable
+    // Fix PHP 8.1.x Deprecation Warnings
+    // Serializable interface will be removed in PHP 9.x
     function serialize() {
-        return serialize($this->storage);
+        return serialize($this->__serialize());
     }
+
     function unserialize($what) {
-        $this->storage = unserialize($what);
+        $this->__unserialize(unserialize($what));
+    }
+
+    // Serializable
+    function __serialize() {
+        return $this->storage;
+    }
+    function __unserialize($what) {
+        $this->storage = $what;
     }
 }
 

--- a/include/cli/modules/agent.php
+++ b/include/cli/modules/agent.php
@@ -51,9 +51,6 @@ class AgentManager extends Module {
 
         switch ($args['action']) {
         case 'import':
-            // Properly detect Macintosh style line endings
-            ini_set('auto_detect_line_endings', true);
-
             if (!$options['file'] || $options['file'] == '-')
                 $options['file'] = 'php://stdin';
             if (!($this->stream = fopen($options['file'], 'rb')))

--- a/include/cli/modules/list.php
+++ b/include/cli/modules/list.php
@@ -38,8 +38,6 @@ class ListManager extends Module {
                 if (!$list)
                     $this->fail("List ID required for items import");
 
-                // Properly detect Macintosh style line endings
-                ini_set('auto_detect_line_endings', true);
                 if (!$options['file'])
                     $this->fail('CSV file to import list items from is required!');
                 elseif (!($this->stream = fopen($options['file'], 'rb')))

--- a/include/cli/modules/user.php
+++ b/include/cli/modules/user.php
@@ -53,9 +53,6 @@ class UserManager extends Module {
 
         switch ($args['action']) {
         case 'import':
-            // Properly detect Macintosh style line endings
-            ini_set('auto_detect_line_endings', true);
-
             if (!$options['file'] || $options['file'] == '-')
                 $options['file'] = 'php://stdin';
             if (!($this->stream = fopen($options['file'], 'rb')))

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -185,8 +185,10 @@ function db_query($query, $logError=true, $buffered=true) {
 
     $tries = 3;
     do {
-        $res = $__db->query($query,
-            $buffered ? MYSQLI_STORE_RESULT : MYSQLI_USE_RESULT);
+        try {
+            $res = $__db->query($query,
+                $buffered ? MYSQLI_STORE_RESULT : MYSQLI_USE_RESULT);
+        } catch (mysqli_sql_exception $e) {}
         // Retry the query due to deadlock error (#1213)
         // TODO: Consider retry on #1205 (lock wait timeout exceeded)
         // TODO: Log warning

--- a/include/upgrader/streams/core/15b30765-dd0022fb.task.php
+++ b/include/upgrader/streams/core/15b30765-dd0022fb.task.php
@@ -82,7 +82,7 @@ class AttachmentMigrater extends MigrationTask {
         return $this->queue;
     }
 
-    function getQueueLength() { return count($this->queue); }
+    function getQueueLength() { return count($this->queue ?: []); }
     /**
      * Processes the next item on the work queue. Emits a JSON messages to
      * indicate current progress.

--- a/include/upgrader/streams/core/26fd79dc-00c949a6.task.php
+++ b/include/upgrader/streams/core/26fd79dc-00c949a6.task.php
@@ -112,7 +112,7 @@ class EventEnumRemoval extends MigrationTask {
     }
 
     function getQueueLength() {
-        return count($this->queue);
+        return count($this->queue ?: []);
     }
 
     function next() {


### PR DESCRIPTION
This addresses Warnings and Fatal Errors with PHP 8.1.x. This includes:
- Fix Deprecation Warnings (Serializable)
- Fix Deprecation Warnings (line_endings)
- Fix Upgrader Issues