### PR TITLE
Replace hacky way with ReflectionClass

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -193,20 +193,14 @@ class PluginManager {
                     = new $class($ht['id']);
             }
             else {
-                // Get instance without calling the constructor. Thanks
-                // http://stackoverflow.com/a/2556089
-                $a = unserialize(
-                    sprintf(
-                        'O:%d:"%s":0:{}',
-                        strlen($class), $class
-                    )
-                );
+                $reflection = new ReflectionClass($class);
+                $a = $reflection->newInstanceWithoutConstructor();
                 // Simulate __construct() and load()
                 $a->id = $ht['id'];
                 $a->ht = $ht;
                 $a->info = $info;
                 static::$plugin_list[$ht['install_path']] = &$a;
-                unset($a);
+                unset($a,$reflection);
             }
         }
         return static::$plugin_list;


### PR DESCRIPTION
The solution in [the mentioned stackoverflow](https://stackoverflow.com/questions/2555883/in-php-is-it-possible-to-create-an-instance-of-an-class-without-calling-classs/2556089#2556089) suggests that from PHP 5.4 on, one can create an instance without calling the constructor [this way](https://stackoverflow.com/questions/2555883/in-php-is-it-possible-to-create-an-instance-of-an-class-without-calling-classs/8457580#8457580).