### PR TITLE
Issue: Installer YAML

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -502,36 +502,34 @@ extends VerySimpleModel {
 
             if (is_array($rule)) {
                 if($rule["w"] || $rule["h"]) {
-                // Check for REGEX compile errors
-                if (in_array($rule["h"], array('match','not_match'))) {
-                    $wrapped = "/".$rule["v"]."/iu";
-                    if (false === @preg_match($rule["v"], ' ')
-                            && (false !== @preg_match($wrapped, ' ')))
-                        $rule["v"] = $wrapped;
+                    // Check for REGEX compile errors
+                    if (in_array($rule["h"], array('match','not_match'))) {
+                        $wrapped = "/".$rule["v"]."/iu";
+                        if (false === @preg_match($rule["v"], ' ')
+                                && (false !== @preg_match($wrapped, ' ')))
+                            $rule["v"] = $wrapped;
+                    }
+
+                    if(!$rule["w"] || !in_array($rule["w"],$matches))
+                        $errors["rule_$i"]=__('Invalid match selection');
+                    elseif(!$rule["h"] || !in_array($rule["h"],$types))
+                        $errors["rule_$i"]=__('Invalid match type selection');
+                    elseif(!$rule["v"])
+                        $errors["rule_$i"]=__('Value required');
+                    elseif($rule["w"]=='email'
+                            && $rule["h"]=='equal'
+                            && !Validator::is_email($rule["v"]))
+                        $errors["rule_$i"]=__('Valid email required for the match type');
+                    elseif (in_array($rule["h"], array('match','not_match'))
+                            && (false === @preg_match($rule["v"], ' ')))
+                        $errors["rule_$i"] = sprintf(__('Regex compile error: (#%s)'),
+                            preg_last_error());
+                    else //for everything-else...we assume it's valid.
+                        $rules[]=array('what'=>$rule["w"],
+                            'how'=>$rule["h"],'val'=>trim($rule["v"]));
+                } elseif($rule["v"]) {
+                    $errors["rule_$i"]=__('Incomplete selection');
                 }
-
-                if(!$rule["w"] || !in_array($rule["w"],$matches))
-                    $errors["rule_$i"]=__('Invalid match selection');
-                elseif(!$rule["h"] || !in_array($rule["h"],$types))
-                    $errors["rule_$i"]=__('Invalid match type selection');
-                elseif(!$rule["v"])
-                    $errors["rule_$i"]=__('Value required');
-                elseif($rule["w"]=='email'
-                        && $rule["h"]=='equal'
-                        && !Validator::is_email($rule["v"]))
-                    $errors["rule_$i"]=__('Valid email required for the match type');
-                elseif (in_array($rule["h"], array('match','not_match'))
-                        && (false === @preg_match($rule["v"], ' ')))
-                    $errors["rule_$i"] = sprintf(__('Regex compile error: (#%s)'),
-                        preg_last_error());
-
-
-                else //for everything-else...we assume it's valid.
-                    $rules[]=array('what'=>$rule["w"],
-                        'how'=>$rule["h"],'val'=>trim($rule["v"]));
-            }elseif($rule["v"]) {
-                $errors["rule_$i"]=__('Incomplete selection');
-            }
             }
         }
 
@@ -564,6 +562,15 @@ extends VerySimpleModel {
         if ($this->dirty)
             $this->updated = SqlFunction::NOW();
         return parent::save($refetch || $this->dirty);
+    }
+
+    static function __create($vars,&$errors) {
+        $filter = new static($vars);
+        if ($filter->save()) {
+            $filter->save_rules($vars, $errors);
+            $filter->save_actions($filter->getId(), $vars, $errors);
+            return $filter;
+        }
     }
 
     static function create($vars,&$errors) {

--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -49,14 +49,14 @@ class Internationalization {
     function loadDefaultData() {
         # notrans -- do not translate the contents of this array
         $models = array(
-            'department.yaml' =>    'Dept::__create',
             'sla.yaml' =>           'SLA::__create',
+            'department.yaml' =>    'Dept::__create',
             'form.yaml' =>          'DynamicForm::create',
             'list.yaml' =>          'DynamicList::create',
             // Note that department, sla, and forms are required for
             // help_topic
             'help_topic.yaml' =>    'Topic::__create',
-            'filter.yaml' =>        'Filter::create',
+            'filter.yaml' =>        'Filter::__create',
             'team.yaml' =>          'Team::__create',
             // Organization
             'organization.yaml' =>  'Organization::__create',

--- a/include/i18n/en_US/filter.yaml
+++ b/include/i18n/en_US/filter.yaml
@@ -30,12 +30,11 @@
   name: SYSTEM BAN LIST #notrans
   notes: |
     Internal list for email banning. Do not remove
-
   rules:
     - isactive: 1
-      what: email #notrans
-      how: equal #notrans
-      val: test@example.com #notrans
+      w: email #notrans
+      h: equal #notrans
+      v: test@example.com #notrans
   actions:
     - sort: 1
       type: reject #notrans


### PR DESCRIPTION
This commit fixes an issue where some default data was not being inserted into the database for fresh installs:

1. Sales Department
	The Sales Department was not being created because we were trying to set an sla_id before the SLA table was created.

2. Banlist
	The default Filter Rule and Action for the System Banlist was not being created because the save function now calls the ORM save function, so it is no longer calling save_rules and save_actions for the installer. We also have to change the YAML to refer to the fields as w,h,v instead of what, how, value for them to be recognized correctly.

It also fixes some spacing issues in the Filter class.