### PR TITLE
issue: Dispatcher include_once

### DIFF
--- a/include/class.dispatcher.php
+++ b/include/class.dispatcher.php
@@ -166,7 +166,7 @@ class UrlMatcher {
 
         if (strpos($class, ":")) {
             list($file, $class) = explode(":", $class, 2);
-            include $file;
+            include_once $file;
         }
         return array($class, $func);
     }


### PR DESCRIPTION
This addresses issue #6218 where using `include` for things like `api.tickets.php` fails with fatal error of `Cannot declare class xxx, becuase the name is already in use`. This changes `include` to `include_once` so that we avoid fatal errors and the files still get included.