### PR TITLE
email: Set Default Email Message Encoding to UTF-8

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -27,8 +27,11 @@ namespace osTicket\Mail {
         private $mimeMessage = null;
         // MimeMessage Content
         private $mimeContent = null;
-        // Charset
-        private $charset = 'utf-8';
+        // Default Charset
+        protected $charset = 'utf-8';
+        // Default Encoding (upstream is ASCII)
+        protected $encoding = 'utf-8';
+
         // Internal flags used to set Content-Type
         private $hasHtml = false;
         private $hasAttachments = false;

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -428,38 +428,36 @@ class Mailer {
                 $recipient = $recipient->getSessionUser();
             switch (true) {
                 case $recipient instanceof \EmailRecipient:
-                    $addr = sprintf('"%s" <%s>',
-                            $recipient->getName(),
-                            $recipient->getEmail());
+                    $email = $recipient->getEmail()->getEmail();
+                    $name =  (string) $recipient->getName();
                     switch ($recipient->getType()) {
                         case 'to':
-                            $message->addTo($addr);
+                            $message->addTo($email, $name);
                             break;
                         case 'cc':
-                            $message->addCc($addr);
+                            $message->addCc($email, $name);
                             break;
                         case 'bcc':
-                            $message->addBcc($addr);
+                            $message->addBcc($email, $name);
                             break;
                     }
                     break;
                 case $recipient instanceof \TicketOwner:
                 case $recipient instanceof \Staff:
-                    $message->addTo(sprintf('"%s" <%s>',
-                                $recipient->getName(),
-                                $recipient->getEmail()));
+                    $message->addTo($recipient->getEmail()->getEmail(),
+                            (string) $recipient->getName());
                     break;
                 case $recipient instanceof \Collaborator:
-                    $message->addCc(sprintf('"%s" <%s>',
-                                $recipient->getName(),
-                                $recipient->getEmail()));
+                    $message->addCc($recipient->getEmail()->getEmail(),
+                             (string) $recipient->getName());
                     break;
                 case $recipient instanceof \EmailAddress:
                     $message->addTo($recipient->getAddress());
                     break;
                 default:
                     // Assuming email address.
-                    $message->addTo($recipient);
+                    if (is_string($recipient))
+                        $message->addTo($recipient);
             }
         }
 


### PR DESCRIPTION
This PR sets UTF-8 as the default email encoding. By default Laminas Mail uses ASCII encoding - which can cause `invalid header value` exception when an email address name of the sender or one of the recipients has an accented character.

Please note that individual Mime Parts set thier own encoding as needed - by default osTicket uses base64 to encode `text/{plain/html}` parts to reduce the overrall size of the Message - configuratable option to make `quoted-printable` encoding an option is planned.