### PR TITLE
issue: Fix Upgrader Session Issues

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -55,16 +55,17 @@ class osTicket {
 
         require_once(INCLUDE_DIR.'class.config.php'); //Config helper
         require_once(INCLUDE_DIR.'class.company.php');
-
-        if (!defined('DISABLE_SESSION') || !DISABLE_SESSION)
-            $this->session = osTicketSession::start(SESSION_TTL); // start DB based session
-
+        // Load the config
         $this->config = new OsticketConfig();
-
+        // Start session  (if not disabled)
+        if (!defined('DISABLE_SESSION') || !DISABLE_SESSION)
+            $this->session = osTicketSession::start(SESSION_TTL,
+                    $this->isUpgradePending());
+        // CSRF Token
         $this->csrf = new CSRF('__CSRFToken__');
-
+        // Company information
         $this->company = new Company();
-
+        // Load Plugin Manager
         $this->plugins = new PluginManager();
     }
 

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -27,7 +27,7 @@ class osTicketSession {
     var $id = '';
     var $backend;
 
-    function __construct($ttl=0){
+    function __construct($ttl=0, $checkdbversion=false){
         $this->ttl = $ttl ?: ini_get('session.gc_maxlifetime') ?: SESSION_TTL;
 
         // Set osTicket specific session name.
@@ -40,7 +40,8 @@ class osTicketSession {
         ini_set('session.gc_maxlifetime', $ttl);
 
         // Skip db version check if version is later than 1.7
-        if (!defined('MAJOR_VERSION') && OsticketConfig::getDBVersion())
+        if ((!defined('MAJOR_VERSION') || $checkdbversion)
+                && OsticketConfig::getDBVersion())
             return session_start();
 
         # Cookies
@@ -71,7 +72,7 @@ class osTicketSession {
             $this->backend = new self::$backends['db']($this->ttl);
         }
 
-        if (!empty($this->id) && ($this->backend instanceof SessionBackend)) {
+        if ($this->backend instanceof SessionBackend) {
             // Set handlers.
             session_set_save_handler(
                 array($this->backend, 'open'),
@@ -127,8 +128,8 @@ class osTicketSession {
     }
 
     /* ---------- static function ---------- */
-    static function start($ttl=0) {
-        return new static($ttl);
+    static function start($ttl=0, $checkdbversion=false) {
+        return new static($ttl, $checkdbversion);
     }
 }
 

--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -217,6 +217,10 @@ class PluginManager {
     }
 
     static function auditPlugin() {
+        global $ost;
+        if (!$ost || $ost->isUpgradePending())
+            return false;
+
         return self::getPluginByName('Help Desk Audit', true);
     }
 

--- a/include/class.sequence.php
+++ b/include/class.sequence.php
@@ -204,7 +204,7 @@ class Sequence extends VerySimpleModel {
         return parent::__get($what);
     }
 
-    public static function __create($data) {
+    static function __create($data) {
         $instance = new self($data);
         $instance->save();
         return $instance;


### PR DESCRIPTION
This addresses session issues when upgrading from versions pre-1.7. This bypasses the DBSessionBackend if `MAJOR_VERSION` is not defined or an upgrade is pending and the `getDBVersion()` method returns `true` to default to using the local session storage.