### PR TITLE
issue: Undefined Variable ORM

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2964,7 +2964,7 @@ class MySqlCompiler extends SqlCompiler {
             $row = $exec->getRow();
         } catch (mysqli_sql_exception $e) {
             throw new InconsistentModelException(
-                'Unable to prepare query: '.db_error().' '.$sql);
+                'Unable to prepare query: '.db_error().' '.$exec->sql);
         }
         return is_array($row) ? (int) $row[0] : null;
     }


### PR DESCRIPTION
This addresses an issue where a wrong variable was used which caused undefined variable errors with the built-in tests. This corrects the variable from `$sql` to `$exec->sql`.