### PR TITLE
Mailer: Skip Invalid Email Recipients

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -151,6 +151,19 @@ implements EmailContact, ITicketUser, TemplateVariable {
         return $this->user->getId();
     }
 
+    function getEmailAddress() {
+        $emailaddr =  (string) $this->getEmail();
+        if (($name=$this->getName()))
+            $emailaddr = sprintf('"%s" <%s>',
+                    (string) $name,
+                    $emailaddr);
+        return $emailaddr;
+    }
+
+    function __toString() {
+        return $this->getEmailAddress();
+    }
+
     abstract function getTicketId();
     abstract function getTicket();
 }

--- a/include/class.collaborator.php
+++ b/include/class.collaborator.php
@@ -39,12 +39,6 @@ implements EmailContact, ITicketUser {
 
     var $active;
 
-    function __toString() {
-        return Format::htmlchars($this->toString());
-    }
-    function toString() {
-        return sprintf('"%s" <%s>', $this->getName(), $this->getEmail());
-    }
 
     function getId() {
         return $this->id;
@@ -81,6 +75,16 @@ implements EmailContact, ITicketUser {
     function getEmail() {
         return $this->user->getEmail();
     }
+
+    function getEmailAddress() {
+        $emailaddr =  (string) $this->getEmail();
+        if (($name=$this->getName()))
+            $emailaddr = sprintf('"%s" <%s>',
+                    (string) $name,
+                    $emailaddr);
+        return $emailaddr;
+    }
+
     function getName() {
         return $this->user->getName();
     }
@@ -133,6 +137,10 @@ implements EmailContact, ITicketUser {
     }
     function getUserId() {
         return $this->user_id;
+    }
+
+    function __toString() {
+        return Format::htmlchars($this->getEmailAddress());
     }
 
     function hasFlag($flag) {

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -445,15 +445,16 @@ class Mailer {
                         break;
                     case $recipient instanceof \TicketOwner:
                     case $recipient instanceof \Staff:
-                        $message->addTo($recipient->getEmail()->getEmail(),
+                        $message->addTo((string) $recipient->getEmail(),
                                 (string) $recipient->getName());
                         break;
                     case $recipient instanceof \Collaborator:
-                        $message->addCc($recipient->getEmail()->getEmail(),
+                        $message->addCc((string) $recipient->getEmail(),
                                  (string) $recipient->getName());
                         break;
                     case $recipient instanceof \EmailAddress:
-                        $message->addTo($recipient->getAddress());
+                        $message->addTo((string) $recipient->getEmail(),
+                                (string) $recipient->getName());
                         break;
                     default:
                         // Assuming email address.

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -18,6 +18,7 @@
 namespace osTicket\Mail;
 
 class Mailer {
+    private $from = null;
     var $email = null;
     var $accounts = [];
 
@@ -35,18 +36,18 @@ class Mailer {
                 && $smtp->isActive()) {
             $this->accounts[$smtp->getId()] = $smtp;
         }
-
-        if ($cfg
-                && ($smtp=$cfg->getDefaultMTA())
-                && $smtp->isActive()) {
-            $this->accounts[$smtp->getId()] = $smtp;
-            if ($smtp->allowSpoofing() || !$email)
-                $email = $smtp->getEmail();
-        }
-
-        if (!$email && $cfg && ($email=$cfg->getDefaultEmail())) {
-            if (($smtp=$email->getSmtpAccount(false)) && $smtp->isActive())
+        if ($cfg)  {
+            // Get Default MTA  (SMTP)
+            if (($smtp=$cfg->getDefaultMTA()) && $smtp->isActive()) {
                 $this->accounts[$smtp->getId()] = $smtp;
+                // If email is not set then use Default MTA
+                if (!$email)
+                    $email = $smtp->getEmail();
+            } elseif (!$email && $cfg && ($email=$cfg->getDefaultEmail())) {
+                // as last resort we will send  via Default Email
+                if (($smtp=$email->getSmtpAccount(false)) && $smtp->isActive())
+                    $this->accounts[$smtp->getId()] = $smtp;
+            }
         }
 
         $this->email = $email;
@@ -71,20 +72,36 @@ class Mailer {
     }
 
     /* FROM Address */
-    function setFromAddress($from) {
-        $this->ht['from'] = $from;
+    function setFromAddress($from=null, $name=null) {
+        if ($from instanceof \EmailAddress)
+            $this->from = $from;
+        elseif (\Validator::is_email($from)) {
+            $this->from = new \EmailAddress(
+                    sprintf('"%s" <%s>', $name ?: '', $from));
+        } elseif (is_string($from))
+            $this->from = new \EmailAddress($from);
+        elseif (($email=$this->getEmail())) {
+            // we're assuming from was null or unexpected monster
+            $address = sprintf('"%s" <%s>',
+                    $name ?: $email->getName(),
+                    $email->getEmail());
+            $this->from = new \EmailAddress($address);
+        }
     }
 
     function getFromAddress($options=array()) {
+        if (!isset($this->from))
+            $this->setFromAddress(null, $options['from_name'] ?: null);
 
-        if (!$this->ht['from'] && ($email=$this->getEmail())) {
-            if (($name = $options['from_name'] ?: $email->getName()))
-                $this->ht['from'] =sprintf('"%s" <%s>', $name, $email->getEmail());
-            else
-                $this->ht['from'] =sprintf('<%s>', $email->getEmail());
-        }
+        return $this->from;
+    }
 
-        return $this->ht['from'];
+    function getFromName() {
+        return $this->getFromAddress()->getName();
+    }
+
+    function getFromEmail() {
+        return $this->getFromAddress()->getEmail();
     }
 
     /* attachments */
@@ -323,8 +340,10 @@ class Mailer {
 
          // Create new ostTicket/Mail/Message object
         $message = new Message();
-        // Set basic headers
-        $message->addFrom($this->getFromAddress($options));
+        // Set From Address
+        $from = $this->getFromAddress($options);
+        $message->setFrom($from->getEmail(), $from->getName());
+        // Set Subject
         $message->setSubject($subject);
 
         $headers = array (
@@ -507,7 +526,7 @@ class Mailer {
         if ($isHtml && $cfg && $cfg->isRichTextEnabled()) {
             // Pick a domain compatible with pear Mail_Mime
             $matches = array();
-            if (preg_match('#(@[0-9a-zA-Z\-\.]+)#', $this->getFromAddress(), $matches)) {
+            if (preg_match('#(@[0-9a-zA-Z\-\.]+)#', (string) $this->getFromAddress(), $matches)) {
                 $domain = $matches[1];
             } else {
                 $domain = '@localhost';
@@ -556,13 +575,17 @@ class Mailer {
             }
         }
 
-        // set Body & Content Type
-        $message->prepare();
-
         // Try possible SMTP Accounts - connections are cached per request
         // at the account level.
         foreach ($this->getSmtpAccounts() ?: [] as $account) {
             try {
+                // Overwrite FROM Address if the account doesn't allow spoofing
+                if (!$account->allowSpoofing())
+                    $message->setFrom(
+                            // get Account Email
+                            (string) $account->getEmail()->getEmail(),
+                            // Try to keep the name if available
+                            $this->getFromName() ?: $account->getName());
                 if (($smtp=$account->getSmtpConnection())
                         && $smtp->sendMessage($message))
                      return $messageId;
@@ -583,8 +606,8 @@ class Mailer {
         $args =  [];
         if (isset($options['from_address']))
             $args[] = '-f '.$options['from_address'];
-        elseif ($this->getEmail())
-            $args = ['-f '.$this->getEmail()->getEmail()];
+        elseif (($from=$this->getFromAddress()))
+            $args = ['-f '.$from->getEmail()];
 
         try {
             // ostTicket/Mail/Sendmail transport
@@ -628,9 +651,9 @@ class Mailer {
 
     //Emails using native php mail function - if DB connection doesn't exist.
     //Don't use this function if you can help it.
-    static function sendmail($to, $subject, $message, $from, $options=null) {
+    static function sendmail($to, $subject, $message, $from=null, $options=null) {
         $mailer = new Mailer(null, array('notice'=>true, 'nobounce'=>true));
-        $mailer->setFromAddress($from);
+        $mailer->setFromAddress($from, $options['from_name'] ?: null);
         return $mailer->send($to, $subject, $message, $options);
     }
 }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -330,6 +330,15 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         return $this->email;
     }
 
+    function getEmailAddress() {
+        $emailaddr =  (string) $this->getEmail();
+        if (($name=$this->getName()))
+            $emailaddr = sprintf('"%s" <%s>',
+                    (string) $name,
+                    $emailaddr);
+        return $emailaddr;
+    }
+
     function getAvatar($size=null) {
         global $cfg;
         $source = $cfg->getStaffAvatarSource();

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -737,6 +737,8 @@ implements TemplateVariable {
             $this->address = sprintf('"%s" <%s>',
                     $this->getName(),
                     $this->email);
+        else
+             $this->address =  $this->email;
     }
 
     function __toString() {
@@ -745,7 +747,7 @@ implements TemplateVariable {
 
     function getVar($what) {
 
-        if (!$this->_info)
+        if (!isset($this->_info))
             return '';
 
         switch ($what) {

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -742,7 +742,7 @@ implements TemplateVariable {
     }
 
     function __toString() {
-        return (string) $this->getAddress();
+        return (string) $this->email;
     }
 
     function getVar($what) {

--- a/include/class.util.php
+++ b/include/class.util.php
@@ -8,6 +8,7 @@ interface EmailContact {
     function getUserId();
     function getName();
     function getEmail();
+    function getEmailAddress();
 }
 
 
@@ -15,6 +16,7 @@ class EmailRecipient
 implements EmailContact {
     protected $contact;
     protected $type;
+    protected $address;
 
     function __construct(EmailContact $contact, $type='to') {
         $this->contact = $contact;
@@ -37,6 +39,16 @@ implements EmailContact {
         return $this->contact->getEmail();
     }
 
+    function getEmailAddress() {
+        if (!isset($this->address)) {
+            $this->address =  (string) $this->getEmail();
+            if (($name=$this->getName()))
+                $this->address = sprintf('"%s" <%s>',
+                        (string) $name, $this->address);
+        }
+        return $this->address;
+    }
+
     function getName() {
         return $this->contact->getName();
     }
@@ -44,6 +56,11 @@ implements EmailContact {
     function getType() {
         return $this->type;
     }
+
+    function __toString() {
+        return (string) $this->getEmailAddress();
+    }
+
 }
 
 abstract class BaseList


### PR DESCRIPTION
This PR adds ability for `osTicket\Mailer` to skip invalid email recipients when sending out an email. A Mailer warning with the recipient info (name & email address) is logged.

For uniformity sake, `EmailContact` interface now requires getEmailAddress() to be defined downstream. This was necessary because some of the objects implementing the interface (e.g Staff) return a name when casted to string via magic function `__toString` and changing it will affect variables used in email templates and possibly leak the agent's email.