### PR TITLE
Show Topics including parents in dropdown list

### DIFF
--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -100,7 +100,7 @@ if ($_POST)
                       }
                         foreach($topics as $id =>$name) {
                             echo sprintf('<option value="%d" %s>%s</option>',
-                                    $id, ($info['topicId']==$id)?'selected="selected"':'',$name);
+                                    $id, ($info['topicId']==$id)?'selected="selected"':'',TOPIC::getTopicName($id));
                         }
                     }
                     ?>


### PR DESCRIPTION
Child topics with the same name can not be identified without parent topic info