### PR TITLE
mailer: Reset FROM Address when SMTP fails

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -124,6 +124,13 @@ namespace osTicket\Mail {
             $this->hasAttachments = true;
         }
 
+        public function setFrom($emailOrAddressList, $name=null) {
+            // We're resetting the body here when FROM address changes - e.g
+            // after failed send attempt while trying multiple SMTP accounts
+            unset($this->body);
+            return parent::setFrom($emailOrAddressList, $name);
+        }
+
         public function setContentType($contentType) {
             // We can only set content type for multipart message
             if (isset($this->body)
@@ -761,7 +768,7 @@ namespace osTicket\Mail {
         }
 
         public function describe() {
-            return sprintf('%s//%s:%s/%s',
+            return sprintf('%s://%s:%s/%s',
                     $this->getSsl() ?: 'none',
                     $this->getHost(),
                     $this->getPort(),

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -597,9 +597,9 @@ class Mailer {
                         $account->getHostInfo(),
                         $ex->getMessage()
                     ));
-                // Try the next SMTP account
-                continue;
             }
+            // Reset FROM address
+            $message->setFrom($this->getFromEmail(), $this->getFromName());
         }
 
         //No SMTP or it failed....use php's native mail function.


### PR DESCRIPTION
This PR adds ability to reset FROM address when SMTP attempt fails. This is important becacause of Spoofing Allowed setting on SMTP accounts might differ.