### PR TITLE
files: Catch possible Storage Backend Errors

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -477,9 +477,11 @@ class AttachmentFile extends VerySimpleModel {
                 elseif ($bk->write($file['data']) && $bk->flush()) {
                     $succeeded = true; break;
                 }
-            }
-            catch (Exception $e) {
+            } catch (Throwable $t) {
                 // Try next backend
+                // Backends can throw an exception or error.
+                // TODO: Log any exceptions and errors for debugging
+                // purposes.
             }
             // Fallthrough to default backend if different?
         }


### PR DESCRIPTION
Catch possible throwables from file storage backends. This is necessary so we don't crash while trying to save a file when storage backend is having issues or bugs. 

osTicket uses database as fallback storage...

- [ ] We beed to log the errors for debugging purposes.