### PR TITLE
fetcher: Fail Safely on Email Parse Error

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -158,10 +158,14 @@ class TicketApiController extends ApiController {
 
     function processEmail($data=false) {
 
-        if (!$data)
-            $data = $this->getEmailRequest();
-        elseif (!is_array($data))
-            $data = $this->parseEmail($data);
+        try {
+            if (!$data)
+                $data = $this->getEmailRequest();
+            elseif (!is_array($data))
+                $data = $this->parseEmail($data);
+        } catch (Exception $ex)  {
+            throw new EmailParseError($ex->getMessage());
+        }
 
         $seen = false;
         if (($entry = ThreadEntry::lookupByEmailHeaders($data, $seen))
@@ -246,7 +250,7 @@ class PipeApiController extends TicketApiController {
     }
 }
 
-class TicketDenied extends Exception {
+class TicketDenied extends Exception {}
+class EmailParseError extends Exception {}
 
-}
 ?>

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -226,8 +226,10 @@ class ApiController extends Controller {
                 return $this->exerr(415, __('Unsupported data format'));
         }
 
-        if (!($data = $parser->parse($stream)))
+        if (!($data = $parser->parse($stream))) {
             $this->exerr(400, $parser->lastError());
+            throw new Exception($parser->lastError());
+        }
 
         //Validate structure of the request.
         if ($validate && $data)

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -71,9 +71,15 @@ class Fetcher {
             // If a ticket is denied we're going to report it as processed
             // so it can be moved out of the inbox or deleted.
             return true;
+        } catch (\EmailParseError $ex) {
+            // Log the parse error + headers as a warning
+            $this->log(sprintf("%s\n\n%s",
+                        $ex->getMessage(),
+                        $this->mbox->getRawHeader($i)));
         } catch (\Throwable $t) {
-            return false;
+            //noop
         }
+        return false;
     }
 
     function processEmails() {


### PR DESCRIPTION
This PR adds ability to log email parse errors. This can happen if the system fails to fetch complete raw email or when the email content is malformed somehow.