### PR TITLE
forms: Add getNotice func. to DynamicFormEntry

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1034,6 +1034,10 @@ class DynamicFormEntry extends VerySimpleModel {
         return $this->form->getInstructions();
     }
 
+    function getNotice() {
+        return  $this->form->getNotice();
+    }
+
     function getDynamicForm() {
         return $this->form;
     }


### PR DESCRIPTION
This PR fixes a bug where getNotice was undefined when rendering a dynamic form entry. It now delegates getting a notice, if any, from the form impl.