### PR TITLE
issue: imagesx Boolean

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -160,8 +160,8 @@ class AttachmentFile extends VerySimpleModel {
     function display($scale=false, $ttl=86400) {
         $this->makeCacheable($ttl);
 
-        if ($scale && extension_loaded('gd')) {
-            $image = imagecreatefromstring($this->getData());
+        if ($scale && extension_loaded('gd')
+                && ($image = imagecreatefromstring($this->getData()))) {
             $width = imagesx($image);
             if ($scale <= $width) {
                 $height = imagesy($image);


### PR DESCRIPTION
This addresses an issue where if `imagecreatefromstring()` fails it returns false (boolean) and we then pass that to `imagesx()`. This method only accepts Gdimage (since PHP 8) so this adds a check for `$image` and if false we will default to `1` otherwise the image will be passed to `imagesx()` as normal.