### PR TITLE
issue: User/Agent Password Reset

### DIFF
--- a/pwreset.php
+++ b/pwreset.php
@@ -21,6 +21,9 @@ if($_POST) {
                 if (!$acct->isPasswdResetEnabled()) {
                     $banner = __('Password reset is not enabled for your account. Contact your administrator');
                 }
+                elseif (!$acct->hasPassword()
+                        || (($bk=$acct->backend) && ($bk !== 'local')))
+                    $banner = __('Unable to reset password. Contact your administrator');
                 elseif ($acct->sendResetEmail()) {
                     $inc = 'pwreset.sent.php';
                 }

--- a/scp/pwreset.php
+++ b/scp/pwreset.php
@@ -42,15 +42,11 @@ if($_POST) {
             $userid = (string) $_POST['userid'];
             if (Validator::is_userid($userid)
                     && ($staff=Staff::lookup($userid))) {
-                if (!$staff->hasPassword()) {
-                    if ($staff->sendResetEmail('registration-staff', false) !== false)
-                        $msg = __('Registration email sent successfully.');
-                    else
-                        $msg = __('Unable to reset password. Contact your administrator');
-                }
-                elseif (!$staff->sendResetEmail()) {
+                if (!$staff->hasPassword()
+                        || (($bk=$staff->getAuthBackend()) && !($bk instanceof osTicketStaffAuthentication)))
+                    $msg = __('Unable to reset password. Contact your administrator');
+                elseif (!$staff->sendResetEmail())
                     $tpl = 'pwreset.sent.php';
-                }
             }
             else
                 $tpl = 'pwreset.sent.php';


### PR DESCRIPTION
This addresses an issue where password reset is triggered even though the user/agent doesn’t have a password or the authentication backend is external.