### PR TITLE
plugin: Make Plugin Base Class Play Nice

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -171,11 +171,12 @@ class Form {
      * Transform form data to database ready clean data.
      *
      */
-    function to_db($validate=true) {
-        if (!$this->isValid())
+    function to_db($clean=null, $validate=true) {
+        if (!$clean
+                && !$this->isValid()
+                && !($clean=$this->getClean($validate)))
             return false;
         $data = [];
-        $clean = $this->getClean($validate);
         foreach ($clean as $name => $val) {
             if (!($f = $this->getField($name)))
                 continue;

--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -118,15 +118,20 @@ abstract class PluginConfig extends Config {
      */
     function store(SimpleForm $form = null, &$errors=array()) {
 
-        if ($this->hasCustomConfig())
-            return $this->saveConfig($form, $errors);
+        try {
+            if ($this->hasCustomConfig())
+                return $this->saveConfig($form, $errors);
 
-        $form = $form ?: $this->getForm();
-        if (($data=$form->to_db())
-                && $this->pre_save($data, $errors)
-                && count($errors) === 0)
-            return $this->updateAll($data);
-
+            $form = $form ?: $this->getForm();
+            if (($clean=$form->getClean())
+                    && $this->pre_save($clean, $errors)
+                    && count($errors) === 0
+                    && ($data=$form->to_db($clean)))
+                return $this->updateAll($data);
+        } catch (Throwable $t) {
+            if  (!isset($errors['err']))
+                $errors['err'] = $t->getMessage();
+        }
         return false;
     }
 

--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -641,6 +641,17 @@ class Plugin extends VerySimpleModel {
         return true;
     }
 
+   /*
+    * Get Namespace of the instance otherwise return plugin's namespace
+    *
+    */
+    function getNamespace() {
+        if (($c=$this->getConfig()) && ($i=$c->getInstance()))
+            return $i->getNamespace();
+
+        return sprintf('plugin.%d', $this->getId());
+    }
+
     /*
      *
      * isMultiInstance

--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -607,8 +607,13 @@ class Plugin extends VerySimpleModel {
      *
      */
     function canAddInstance() {
-        if (!$this->isMultiInstance()
-                && $this->getNumInstances())
+
+        // No instances yet
+        if (!$this->getNumInstances())
+            return true;
+
+        // We have at least one instance already.
+        if (!$this->isMultiInstance())
             return false;
 
         // Some Plugins DO Not or SHOULDN'T support multiple instances due


### PR DESCRIPTION
This commit addresses backward compatibility issue related to the data sent to pre_save hook. Older plugins expected clean data whereas the new interface provided to_db data which might be json formatted for example depending on the config field database format. Now we will send the clean data to pre_save then transform the results for database storage via the form / fields.