### PR TITLE
cli: User Import

### DIFF
--- a/include/cli/modules/user.php
+++ b/include/cli/modules/user.php
@@ -168,7 +168,8 @@ class UserManager extends Module {
         default:
             $this->stderr->write('Unknown action!');
         }
-        @fclose($this->stream);
+        if (is_resource($this->stream))
+            @fclose($this->stream);
     }
 
     function getQuerySet($options, $requireOne=false) {


### PR DESCRIPTION
This addresses issue #6291 where importing users from CSV via command line causes a fatal error. This is due to attempting `fclose()` on a stream that has already been closed. The CsvImporter `__descontruct()` method already closes the stream so when we get to the end of the import and attempt to call `fclose()` in the CLI method, it causes a fatal error as the stream (resource) is no longer valid (as it's already been closed). This adds a check to see if the stream is a valid resource and if so then we close it, otherwise we skip and continue (as it's already closed).