### PR TITLE
mailer: Make Headers Valid Again

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -187,6 +187,20 @@ namespace osTicket\Mail {
             }
         }
 
+        // Set Message Sender is useful for SendMail transport, its basically -f
+        // parameter in the mail() interface
+        public function setSender($email, $name=null) {
+            try {
+                // Exception is thrown on invalid email address
+                $header = new Header\Sender();
+                $header->setAddress($email, $name); #nolint
+                $this->addHeader($header);
+            } catch (\Throwable $t) {
+                // Silently ignore invalid email sender defaults to FROM
+                // addresses
+            }
+        }
+
         public function setFrom($emailOrAddressList, $name=null) {
             // We're resetting the body here when FROM address changes - e.g
             // after failed send attempt while trying multiple SMTP accounts

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -21,6 +21,7 @@ namespace osTicket\Mail {
     use Laminas\Mime\Message as MimeMessage;
     use Laminas\Mime\Mime;
     use Laminas\Mime\Part as MimePart;
+    use Laminas\Mail\Header;
 
     class  Message extends MailMessage {
         // MimeMessage Parts
@@ -67,8 +68,11 @@ namespace osTicket\Mail {
             return $this->mimeContent;
         }
 
-        public function addHeader($key, $value) {
-            return $this->getHeaders()->addHeaderLine($key, $value);
+        public function addHeader($header, $value=null) {
+            if (isset($value))
+                $this->getHeaders()->addHeaderLine($header, $value);
+            else
+                $this->getHeaders()->addHeader($header);
         }
 
         public function addHeaders(array $headers)  {
@@ -122,6 +126,24 @@ namespace osTicket\Mail {
             $f->encoding = Mime::ENCODING_BASE64;
             $this->addMimePart($f);
             $this->hasAttachments = true;
+        }
+
+        // Expects a  valid date e.g date('r')
+        public function setDate(string $date) {
+            $d = new Header\Date($date);
+            // Laminas auto adds Date upstream when any header is added
+            // We're clearing it here to we back that-date up like it's
+            // 99 & 2000 ~ Juvenile
+            $this->clearHeaderByName('date');
+            $this->addHeader($d);
+        }
+
+        // Please use this method to set Message-Id otherwise it will be
+        // utf-8 endcoded and results is an invalid email & bounces
+        public function setMessageId(string $id) {
+            $mid = new Header\MessageId();
+            $mid->setId($id);
+            $this->addHeader($mid);
         }
 
         public function setFrom($emailOrAddressList, $name=null) {

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -135,7 +135,7 @@ namespace osTicket\Mail {
             // Laminas auto adds Date upstream when any header is added
             // We're clearing it here to we back that-date up like it's
             // 99 & 2000 ~ Juvenile
-            $this->getHeaders()->removeHeader($d::$type);
+            $this->getHeaders()->removeHeader('date');
             $this->addHeader($d);
         }
 

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -163,6 +163,19 @@ namespace osTicket\Mail {
             }
         }
 
+        public function addReferences($references) {
+            if (!is_array($references))
+                $references = explode(' ', $references);
+
+            try {
+                $header = new Header\References();
+                $header->setIds($references); #nolint
+                $this->addHeader($header);
+            } catch (\Throwable $t) {
+                // Mshenzi
+            }
+        }
+
         public function setFrom($emailOrAddressList, $name=null) {
             // We're resetting the body here when FROM address changes - e.g
             // after failed send attempt while trying multiple SMTP accounts

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -163,10 +163,21 @@ namespace osTicket\Mail {
             }
         }
 
+        public function addInReplyTo($inReplyTo) {
+             if (!is_array($inReplyTo))
+                $inReplyTo = explode(' ', $inReplyTo);
+            try {
+                $header = new Header\InReplyTo();
+                $header->setIds($inReplyTo); #nolint
+                $this->addHeader($header);
+            } catch (\Throwable $t) {
+                // Mshenzi
+            }
+        }
+
         public function addReferences($references) {
             if (!is_array($references))
                 $references = explode(' ', $references);
-
             try {
                 $header = new Header\References();
                 $header->setIds($references); #nolint

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -610,12 +610,12 @@ class Mailer {
             $message->setFrom($this->getFromEmail(), $this->getFromName());
         }
 
-        //No SMTP or it failed....use php's native mail function.
+        //No SMTP or it failed....use Sendmail transport (PHP mail())
         $args =  [];
         if (isset($options['from_address']))
-            $args[] = '-f '.$options['from_address'];
+            $message->setSender($options['from_address']);
         elseif (($from=$this->getFromAddress()))
-            $args = ['-f '.$from->getEmail()];
+            $message->setSender($from->getEmail(), $from->getName());
 
         try {
             // ostTicket/Mail/Sendmail transport

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -399,10 +399,9 @@ class Mailer {
 
         // Return-Path
         if (isset($options['nobounce']) && $options['nobounce'])
-            $headers['Return-Path'] = '<>';
+            $message->setReturnPath('<>');
         elseif ($this->getEmail() instanceof \Email)
-            $headers['Return-Path'] = sprintf('<%s>',
-                    $this->getEmail()->getEmail());
+            $message->setReturnPath($this->getEmail()->getEmail());
 
         // Bulk.
         if (isset($options['bulk']) && $options['bulk'])

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -337,20 +337,19 @@ class Mailer {
 
         $messageId = $this->getMessageId($recipients, $options);
         $subject = preg_replace("/(\r\n|\r|\n)/s",'', trim($subject));
+        $from = $this->getFromAddress($options);
 
          // Create new ostTicket/Mail/Message object
         $message = new Message();
+        // Set our custom Message-Id
+        $message->setMessageId($messageId);
         // Set From Address
-        $from = $this->getFromAddress($options);
         $message->setFrom($from->getEmail(), $from->getName());
         // Set Subject
         $message->setSubject($subject);
 
-        $headers = array (
-            'Date'=> date('D, d M Y H:i:s O'),
-            'Message-ID' => "<{$messageId}>",
-            'X-Mailer' =>'osTicket Mailer',
-        );
+        // Collect Generic Headers
+        $headers = ['X-Mailer' =>'osTicket Mailer'];
 
         // Add in the options passed to the constructor
         $options = ($options ?: array()) + $this->options;

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -423,7 +423,7 @@ class Mailer {
                     'Auto-Submitted' => 'auto-generated');
         // In-Reply-To
         if (isset($options['inreplyto']) && $options['inreplyto'])
-            $headers += array('In-Reply-To' => $options['inreplyto']);
+            $message->addInReplyTo($options['inreplyto']);
 
         // References
         if (isset($options['references']) && $options['references'])

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -426,13 +426,8 @@ class Mailer {
             $headers += array('In-Reply-To' => $options['inreplyto']);
 
         // References
-        if (isset($options['references']) && $options['references']) {
-            if (is_array($options['references']))
-                $headers += array('References' =>
-                    implode(' ', $options['references']));
-            else
-                $headers += array('References' => $options['references']);
-        }
+        if (isset($options['references']) && $options['references'])
+            $message->addReferences($options['references']);
 
         // Add Headers
         $message->addHeaders($headers);


### PR DESCRIPTION
**Message-Id**: osTicket uses encoded message Id to thread emails on reply. Laminas Mail, the new backend we're mangles up the Message-Id when set as a generic header. This commits corrects the issue by using MessageId object - making sure it is ASCII encoded.

**Date**: Date is auto-added upstream - so we're removing it from Mailer to avoid double header issues - but if need be, you can overwrite it by setting your own fake date!

**Return-Path**: Adds Return-Path Header interface to osTicket\Mail\Message

**References**: Use References Header interface to add references instead of using Generic Headers which might break due encoding.

**In-Reply-To**:  Add In-Reply-To Header interface

**Sender**: Add Sender Header interface 
