### PR TITLE
POP3 Configration can not be saved

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -331,7 +331,7 @@ namespace osTicket\Mail {
                 parent::login($user, $password, $tryApop);
                 return true;
              } catch (\Throwable $e) {
-                 throw new Exception(__('cannot login, user or password wrong'));
+                 throw new Exception(__('login failed').': '.$e->getMessage());
              }
          }
     }

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -235,7 +235,7 @@ namespace osTicket\Mail {
         }
 
         abstract public function __construct($accountSetting);
-        abstract private function oauth2Auth(AccessToken $token);
+        abstract protected function oauth2Auth(AccessToken $token);
     }
 
     class ImapMailboxProtocol extends ImapProtocol {
@@ -326,6 +326,14 @@ namespace osTicket\Mail {
              return trim($result);
          }
 
+         public function login($user, $password, $tryApop = true) {
+             try {
+                parent::login($user, $password, $tryApop);
+                return true;
+             } catch (\Throwable $e) {
+                 throw new Exception(__('cannot login, user or password wrong'));
+             }
+         }
     }
 
     // MailBoxStorageTrait


### PR DESCRIPTION
First error: abstract functions can not be private. It have to be protected or public...

Second error: the pop3 login function doesn't respond anything on successful login. This will be return false in MailBoxProtocolTrait::basicAuth()
So the settings can't be saved although the data is correct.