### PR TITLE
mailer: Improvements & Enhancements

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -201,11 +201,19 @@ namespace osTicket\Mail {
             }
         }
 
-        public function setFrom($emailOrAddressList, $name=null) {
+        public function setFrom($email, $name=null) {
             // We're resetting the body here when FROM address changes - e.g
             // after failed send attempt while trying multiple SMTP accounts
             unset($this->body);
-            return parent::setFrom($emailOrAddressList, $name);
+            return parent::setFrom($email, $name);
+        }
+
+        // This is used to set FROM & and clear Sender to a new Email Address
+        public function setOriginator($email, $name=null) {
+            // Set the FROM  Header
+            $this->setFrom($email, $name);
+            // Remove Sender Header
+            $this->getHeaders()->removeHeader('sender');
         }
 
         public function setContentType($contentType) {

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -604,7 +604,7 @@ class Mailer {
                 // Attempt to send the Message.
                 if (($smtp=$smtpAccount->getSmtpConnection())
                         && $smtp->sendMessage($message))
-                     return $messageId;
+                     return $message->getId();
             } catch (\Exception $ex) {
                 // Log the SMTP error
                 $this->logError(sprintf("%1\$s: %2\$s (%3\$s)\n\n%4\$s\n",
@@ -635,7 +635,7 @@ class Mailer {
             $args = [];
             $sendmail =  new  Sendmail($args);
             if ($sendmail->sendMessage($message))
-                return $messageId;
+                return $message->getId();
         } catch (\Exception $ex) {
             $this->logError(sprintf("%1\$s\n\n%2\$s\n",
                         _S("Unable to email via Sendmail"),

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -615,7 +615,7 @@ class Mailer {
                     ));
             }
             // Attempt  Failed:  Reset FROM to original email and clear Sender
-            $message->setOrignator($this->getFromEmail(), $this->getFromName());
+            $message->setOriginator($this->getFromEmail(), $this->getFromName());
         }
 
         // No SMTP or it FAILED....use Sendmail transport (PHP mail())

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -20,7 +20,7 @@ namespace osTicket\Mail;
 class Mailer {
     private $from = null;
     var $email = null;
-    var $accounts = [];
+    var $smtpAccounts = [];
 
     var $ht = array();
     var $attachments = array();
@@ -34,19 +34,19 @@ class Mailer {
         if (($email instanceof \Email)
                 && ($smtp=$email->getSmtpAccount(false))
                 && $smtp->isActive()) {
-            $this->accounts[$smtp->getId()] = $smtp;
+            $this->smtpAccounts[$smtp->getId()] = $smtp;
         }
         if ($cfg)  {
             // Get Default MTA  (SMTP)
             if (($smtp=$cfg->getDefaultMTA()) && $smtp->isActive()) {
-                $this->accounts[$smtp->getId()] = $smtp;
+                $this->smtpAccounts[$smtp->getId()] = $smtp;
                 // If email is not set then use Default MTA
                 if (!$email)
                     $email = $smtp->getEmail();
             } elseif (!$email && $cfg && ($email=$cfg->getDefaultEmail())) {
                 // as last resort we will send  via Default Email
                 if (($smtp=$email->getSmtpAccount(false)) && $smtp->isActive())
-                    $this->accounts[$smtp->getId()] = $smtp;
+                    $this->smtpAccounts[$smtp->getId()] = $smtp;
             }
         }
 
@@ -64,7 +64,7 @@ class Mailer {
     }
 
     function getSmtpAccounts() {
-        return $this->accounts;
+        return $this->smtpAccounts;
     }
 
     function getEmail() {
@@ -585,46 +585,60 @@ class Mailer {
 
         // Try possible SMTP Accounts - connections are cached per request
         // at the account level.
-        foreach ($this->getSmtpAccounts() ?: [] as $account) {
+        foreach ($this->getSmtpAccounts() ?: [] as $smtpAccount) {
             try {
-                // Overwrite FROM Address if the account doesn't allow spoofing
-                if (!$account->allowSpoofing())
-                    $message->setFrom(
+                //  Check if SPOOFING is allowed.
+                if (!$smtpAccount->allowSpoofing()
+                        && strcasecmp($smtpAccount->getEmail()->getEmail(),
+                            $this->getFromEmail())) {
+                    // If the Account DOES NOT allow spoofing then set the
+                    // Sender as the smtp account sending out the email
+                    // TODO: Allow Aliases to Spoof parent account by
+                    // default.
+                    $message->setSender(
                             // get Account Email
-                            (string) $account->getEmail()->getEmail(),
+                            (string) $smtpAccount->getEmail()->getEmail(),
                             // Try to keep the name if available
-                            $this->getFromName() ?: $account->getName());
-                if (($smtp=$account->getSmtpConnection())
+                            $this->getFromName() ?: $smtpAccount->getName());
+                }
+                // Attempt to send the Message.
+                if (($smtp=$smtpAccount->getSmtpConnection())
                         && $smtp->sendMessage($message))
                      return $messageId;
             } catch (\Exception $ex) {
                 // Log the SMTP error
                 $this->logError(sprintf("%1\$s: %2\$s (%3\$s)\n\n%4\$s\n",
                         _S("Unable to email via SMTP"),
-                        $account->getEmail()->getEmail(),
-                        $account->getHostInfo(),
+                        $smtpAccount->getEmail()->getEmail(),
+                        $smtpAccount->getHostInfo(),
                         $ex->getMessage()
                     ));
             }
-            // Reset FROM address
-            $message->setFrom($this->getFromEmail(), $this->getFromName());
+            // Attempt  Failed:  Reset FROM to original email and clear Sender
+            $message->setOrignator($this->getFromEmail(), $this->getFromName());
         }
 
-        //No SMTP or it failed....use Sendmail transport (PHP mail())
-        $args =  [];
-        if (isset($options['from_address']))
+        // No SMTP or it FAILED....use Sendmail transport (PHP mail())
+        // Set Sender / Originator
+        if (isset($options['from_address'])) {
+            // This is often set via Mailer::sendmail()
             $message->setSender($options['from_address']);
-        elseif (($from=$this->getFromAddress()))
-            $message->setSender($from->getEmail(), $from->getName());
+        } elseif (($from=$this->getFromAddress())) {
+            // This should be already set but we're making doubly sure
+            $message->setOriginator($from->getEmail(), $from->getName());
+        }
 
         try {
-            // ostTicket/Mail/Sendmail transport
+            // ostTicket/Mail/Sendmail transport (mail())
+            // Set extra params as needed
+            // NOTE: Laminas Mail doesn't respect -f param set Sender (above)
+            $args = [];
             $sendmail =  new  Sendmail($args);
             if ($sendmail->sendMessage($message))
                 return $messageId;
         } catch (\Exception $ex) {
             $this->logError(sprintf("%1\$s\n\n%2\$s\n",
-                        _S("Unable to email via php mail function"),
+                        _S("Unable to email via Sendmail"),
                         $ex->getMessage()
                 ));
         }


### PR DESCRIPTION
**Spoofing**: When an SMTP Account **DOES NOT** allow spoofing then set the Sender (Envelope FROM) to the account's email address and leave the Header FROM as set.

**Originator**: When an SMTP account send fails - we now reset the Originator / Sender to the original From Address, incase spoofing setting changed the Sender.