### PR TITLE
mail: Add plain:// encryption scheme hint

### DIFF
--- a/include/i18n/en_US/help/tips/emails.email.yaml
+++ b/include/i18n/en_US/help/tips/emails.email.yaml
@@ -89,9 +89,13 @@ host_and_port:
         may be available in the documentation for your hosting account or
         from your email administrator.
         <br/><br/>
-        If using non standard <span class="doc-desc-title">port</span>
-        number with SSL enabled then prefix the hostname with ssl:// or tls://
-        scheme to hint to supported encryption.
+        If using non-standard <span class="doc-desc-title">port</span>
+        number with <span class="doc-desc-title">encryption</span> enabled
+        then prefix the hostname with ssl:// or tls:// scheme to hint to
+        supported encryption.
+        <br/><br/>
+        To  force a plain connection even when using a standard encryption <span
+        class="doc-desc-titl">port</span> then use plain:// scheme.
 
 mailbox_folder:
     title: Mail Folder

--- a/include/i18n/en_US/help/tips/emails.email.yaml
+++ b/include/i18n/en_US/help/tips/emails.email.yaml
@@ -94,8 +94,8 @@ host_and_port:
         then prefix the hostname with ssl:// or tls:// scheme to hint to
         supported encryption.
         <br/><br/>
-        To  force a plain connection even when using a standard encryption <span
-        class="doc-desc-titl">port</span> then use plain:// scheme.
+        To force a plain connection even when using a standard encryption <span
+        class="doc-desc-title">port</span> then use plain:// scheme.
 
 mailbox_folder:
     title: Mail Folder


### PR DESCRIPTION
When configuring an email, starting with osTicket v1.17, the adminstrator can hint to the desired encryption when using non-stantard ports by prefixing the `hostname` with an encryption scheme  e.g `tls://` or `ssl://`. Using hints is much better and less confusing than the old ways of presenting a user with `IMAP` and `IMAP + SSL` as protocol selections - when infact we could use the port number, in the backend, to determined the encryption.

This PR adds support for the exact opposite  - by allowing an admin to force unencrypted connection even when using standard encryption ports (god only knows why!!) by simply adding `plain://` as the scheme hint. 