### PR TITLE
session: Add Noop Session Backend

### DIFF
--- a/logo.php
+++ b/logo.php
@@ -15,12 +15,9 @@
 
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
-
-// Don't update the session for inline image fetches
-if (!function_exists('noop')) { function noop() {} }
-session_set_save_handler('noop','noop','noop','noop','noop','noop');
-define('DISABLE_SESSION', true);
-
+// Disable updating session data - false still starts the session but data
+// write is ignored.
+define('DISABLE_SESSION', false);
 require('client.inc.php');
 $ttl = 86400; // max-age
 if (($logo = $ost->getConfig()->getClientLogo())) {

--- a/manage.php
+++ b/manage.php
@@ -23,10 +23,6 @@ if (PHP_SAPI != "cli")
 
 require_once 'bootstrap.php';
 require_once CLI_DIR . 'cli.inc.php';
-
-if (!function_exists('noop')) { function noop() {} }
-session_set_save_handler('noop','noop','noop','noop','noop','noop');
-
 class Manager extends Module {
     var $prologue =
         "Manage one or more osTicket installations";

--- a/scp/logo.php
+++ b/scp/logo.php
@@ -15,14 +15,10 @@
 
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
-
-// Don't update the session for inline image fetches
-if (!function_exists('noop')) { function noop() {} }
-session_set_save_handler('noop','noop','noop','noop','noop','noop');
-define('DISABLE_SESSION', true);
-
+// Disable updating session data - false still starts the session but data
+// write is ignored.
+define('DISABLE_SESSION', false);
 require_once('../main.inc.php');
-
 $ttl = 86400; // max-age
 if (isset($_GET['backdrop'])) {
     if (($backdrop = $ost->getConfig()->getStaffLoginBackdrop())) {


### PR DESCRIPTION
osTicket support uploading your own logos as well as login backgrounds and calls logo.php (on both panels) to fetch the image in question. Previously we didn't care about session data so session handler was set to an inline noop function as a way to bypass starting a "real" session. The problem with the approach is; if osTicket is hosted behind a proxy with multiple web severs in the backend, the proxy needs to send all requests to the same server for specific user session. To do so session name (OSTSESSID) is used to route requests from the same session to the same backend server.

This PR adds a noop session backend allowing for ability to start a session while still ignoring data writes. Noop backend is used when DISABLE_SESSION is defined and set to false.