### PR TITLE
issue: File Upload Size

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3965,7 +3965,11 @@ class FileUploadField extends FormField {
     }
 
     function getConfiguration() {
+        global $cfg;
+
         $config = parent::getConfiguration();
+        // If no size present default to system setting
+        $config['size'] ??= $cfg->getMaxFileSize();
         $_types = self::getFileTypes();
         $mimetypes = array();
         $extensions = array();


### PR DESCRIPTION
This addresses an issue where if the Issue Details field or any custom FileUpload field don't have `configuration` set any file upload to such fields will fail with `File too large` error. This is due to the `configuration` not being set so when we check the uploaded file size to the allowed file `size` from the field's config via `$config['size']` it fails. This adds a check for the `size` option in the `$config` array and if not set or set to NULL then we will default to 1MB. PHP's default `upload_max_filesize` is 2MB so this shouldn't be an issue (unless you set it lower - why tho??).