### PR TITLE
Issue: Agent Permission to Assign Tickets

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -1134,6 +1134,7 @@ class TicketsAjaxAPI extends AjaxController {
 
                         $depts = $tickets->values_flat('dept_id');
                     }
+                    //agents in depts $thisstaff can access
                     $members = $thisstaff->getDeptAgents(array('available' => true));
 
                     if ($depts) {
@@ -1211,6 +1212,9 @@ class TicketsAjaxAPI extends AjaxController {
                 $f->configure('prompt', $prompt);
 
             if ($_POST && $form->isValid()) {
+                // we need to clear this relation so we can create a fresh
+                // query that will get roles for all depts this agent can access
+                unset($thisstaff->ht['dept_access']);
                 foreach ($_POST['tids'] as $tid) {
                     if (($t=Ticket::lookup($tid))
                             // Make sure the agent is allowed to


### PR DESCRIPTION
When we do $thisstaff->getDeptAgents, we are trying to get active agents $thisstaff can assign tickets to. The query done for this groups records in the staff_dept_access table by staff_id, so when we try to do getRoles() for $thisstaff, the only role we can get from staff_dept_access is the first record for $thisstaff.

This commit unsets the dept_access relation so that it can be requeried to get all staff_dept_access records for $thisstaff.