### PR TITLE
Set timeout on smtp connections to avoid an RuntimeException

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -1199,6 +1199,10 @@ class SmtpAccount extends EmailAccount {
             $setting = $this->getAccountSetting();
             $setting->setCredentials($this->cred);
             $smtpOptions = new osTicket\Mail\SmtpOptions($setting);
+            // set timeout to 5 minutes to prevent quitting connection from mail server before we will do it
+            // this would raise an RuntimeException from laminas-mail
+            // see: https://docs.laminas.dev/laminas-mail/transport/smtp-authentication/#smtp-transport-usage-for-servers-with-reuse-time-limit
+            $smtpOptions->setConnectionTimeLimit(300);
             $smtp = new osTicket\Mail\Smtp($smtpOptions);
             // Attempt to connect if Credentials are sent
             if ($cred) $smtp->connect();


### PR DESCRIPTION
Some mail server close the connection before laminas-mail can quit the connection after osTicket sent an email. This will raise an RuntimeException.
To avoid this behavior, we can set an timeout to keep the connection alive. Laminas-mail will quit the connection by itself, if the job is done and send a QUIT command.

For more details see:
https://docs.laminas.dev/laminas-mail/transport/smtp-authentication/#smtp-transport-usage-for-servers-with-reuse-time-limit and
https://github.com/laminas/laminas-mail/issues/158