### PR TITLE
issue: Schedules stops_on

### DIFF
--- a/include/class.schedule.php
+++ b/include/class.schedule.php
@@ -955,7 +955,7 @@ class ScheduleEntry extends VerySimpleModel {
                 // range at the moment - assuming ends on the same day.
                 $source['ends_at'] = $ends->format('h:i a');
                 if (($stops=$this->getStopsDatetime()))
-                    $source['stops_on'] = $stops->setTimestamp();
+                    $source['stops_on'] = $stops->getTimestamp();
 
                 // See if time spans all day.
                 if ($this->isFullDay())


### PR DESCRIPTION
This addresses a small issue where we were calling `setTimestamp()` instead of `getTimestamp()` which causes a Fatal Error. We didn't notice this in previous versions due to pre-PHP 8 it was only a Warning not a Fatal Error. This updates the line to call the correct method which avoids any fatal errors.