### PR TITLE
issue: Favicons Login Headers

### DIFF
--- a/include/staff/login.header.php
+++ b/include/staff/login.header.php
@@ -14,6 +14,8 @@ header("Content-Security-Policy: frame-ancestors ".$cfg->getAllowIframes().";");
     <meta http-equiv="cache-control" content="no-cache" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="<?php echo ROOT_PATH ?>images/oscar-favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="<?php echo ROOT_PATH ?>images/oscar-favicon-16x16.png" sizes="16x16" />
     <script type="text/javascript" src="<?php echo ROOT_PATH; ?>js/jquery-3.5.1.min.js"></script>
     <script type="text/javascript">
         $(document).ready(function() {


### PR DESCRIPTION
This addresses a small issue where Favicons weren't appearing on the Staff Login Page. This is due to the Staff Login Page using a different header than other pages. This adds the Favicons to the Staff Login Page Headers so that they appear correctly.