### PR TITLE
issue: Information and SectionBreak Fields On Edit

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2701,6 +2701,14 @@ class SectionBreakField extends FormField {
     function isBlockLevel() {
         return true;
     }
+
+    function isEditableToStaff() {
+        return $this->isVisibleToStaff();
+    }
+
+    function isEditableToUsers() {
+        return $this->isVisibleToUsers();
+    }
 }
 
 class ThreadEntryField extends FormField {
@@ -5336,6 +5344,14 @@ class FreeTextField extends FormField {
 
     function isBlockLevel() {
         return true;
+    }
+
+    function isEditableToStaff() {
+        return $this->isVisibleToStaff();
+    }
+
+    function isEditableToUsers() {
+        return $this->isVisibleToUsers();
     }
 
     /* utils */


### PR DESCRIPTION
This addresses an issue where Information and SectionBreak Fields do not display on Ticket edit for Users and Agents. This is due to no visibility option for Editable for these field types. Since these field types don't have Editable visibility when we check for `isEditableTo[Staff|Users]()` it returns false. This overwrites the two methods for both field types so that they are visible on Edit if the field is visible to the respective user-type (User/Agent).