### PR TITLE
issue: Plugin Config Item Exists

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -77,7 +77,12 @@ class Config {
     }
 
     function exists($key) {
-        return $this->get($key, null) ? true : false;
+        if ((isset($this->session) && array_key_exists($key, $this->session))
+                || array_key_exists($key, $this->config)
+                || array_key_exists($key, $this->defaults))
+            return true;
+
+        return false;
     }
 
     function set($key, $value) {


### PR DESCRIPTION
This addresses an issue where the Audit Log plugin shows Ticket Views in the Audit Logs and shows the setting as enabled even when you disable and save via plugin config. This is due to the current `Config::exists()` method using the config `->get()` method and checking the return value to determine `true` or `false`. This is problematic, especially when values can be `NULL` or `0`. This updates the `Config::exists()` method to check if the key exists in the session or config array. If the key does exist then we return `true` otherwise we return `false`.