### PR TITLE
issue: urldecode Dispatcher

### DIFF
--- a/include/class.dispatcher.php
+++ b/include/class.dispatcher.php
@@ -33,6 +33,8 @@ class Dispatcher {
             $_SERVER['REQUEST_METHOD'] = strtoupper($_GET['_method']);
             unset($_GET['_method']);
         }
+        // Decode URL for accurate matching
+        $url = urldecode($url);
         foreach ($this->urls as $matcher) {
             if ($matcher->matches($url)) {
                 return $matcher->dispatch($url, $args);


### PR DESCRIPTION
This addresses an issue where if using a webserver that encodes URLs by default (like NGINX) some of the AJAX URLs will not resolve. This ensures the URL is decoded with `urldecode()` before matching and dispatching.