### PR TITLE
fix database timezone issues

### DIFF
--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -116,7 +116,11 @@ function db_version() {
 }
 
 function db_timezone() {
-    return db_get_variable('time_zone', 'global');
+    $tz = db_get_variable('time_zone', 'global');
+    if ($tz == 'SYSTEM') {
+        $tz = db_get_variable('system_time_zone', 'global');
+    }
+    return $tz;
 }
 
 function db_get_variable($variable, $type='session') {

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -116,7 +116,7 @@ function db_version() {
 }
 
 function db_timezone() {
-    return db_get_variable('system_time_zone', 'global');
+    return db_get_variable('time_zone', 'global');
 }
 
 function db_get_variable($variable, $type='session') {


### PR DESCRIPTION
switch from using `system_time_zone` which is automatically set when the database starts for the first time, to using `time_zone` which is the timezone that the database is actually using.

the `system_time_zone` variable is only used if the `time_zone` variable is set to `SYSTEM`

the `time_zone` variable is what the database is actually using.

if the `time_zone` variable is set to `SYSTEM`; use the `system_time_zone` variable