### PR TITLE
upgrader: Email Account Status

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -947,7 +947,7 @@ class EmailAccount extends VerySimpleModel {
 
     static function create($ht=false) {
         $i = new static($ht);
-        $i->active = 0;
+        $i->active = isset($ht['active']) ? $ht['active'] : 0;
         $i->created = SqlFunction::NOW();
         return $i;
     }


### PR DESCRIPTION
This PR addresses an issue where we mistakenly disabled email account status when upgrading to 1.17.x from older versions.