### PR TITLE
fetcher: Mail Fetch Order

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -981,6 +981,16 @@ class MailBoxAccount extends EmailAccount {
             ->filter(['type' => 'mailbox']);
     }
 
+    //TODO: Morhp MailBoxAccount to ImapMailBoxAccount
+    public function isImap() {
+        return (strcasecmp($this->getProtocol(), 'IMAP') === 0);
+    }
+
+     //TODO: Morhp MailBoxAccount to PopMailBoxAccount
+    public function isPop() {
+        return (strcasecmp($this->getProtocol(), 'POP') === 0);
+    }
+
     public function getProtocol() {
         return $this->protocol;
     }
@@ -989,9 +999,13 @@ class MailBoxAccount extends EmailAccount {
         return $this->folder;
     }
 
+    public function getFetchFolder() {
+        return $this->getFolder();
+    }
+
     public function getArchiveFolder() {
-        if ((strcasecmp($this->getProtocol(), 'imap') == 0) && $this->archivefolder)
-            return $this->archivefolder;
+        return ($this->isImap() && $this->archivefolder)
+            ? $this->archivefolder : null;
     }
 
     public function canDeleteEmails() {
@@ -1112,7 +1126,7 @@ class MailBoxAccount extends EmailAccount {
                                 !$mb->hasFolder($this->folder))
                             $errors['mailbox_folder'] = __('Unknown Folder');
                         if ($this->archivefolder
-                                && $this->protocol == 'IMAP'
+                                && $this->isImap()
                                 && !$mb->hasFolder($this->archivefolder)
                                 && !$mb->createFolder($this->archivefolder))
                             $errors['mailbox_archivefolder'] =

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -493,7 +493,8 @@ namespace osTicket\Mail {
          */
         public function moveMessage($id, $folder) {
             try {
-                return parent::moveMessage($id, $folder);
+                parent::moveMessage($id, $folder);
+                return true;
             } catch (\Throwable $t) {
                 // noop
             }

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -100,19 +100,22 @@ class Fetcher {
         if (!($messageCount = $this->mbox->countMessages()))
             return 0;
 
-        // Create a range of message sequence numbers (msgno) to fetch
-        // taking max fetch into account
-        // TODO: Use message UIDs instead of numbers
-        $messages = range(1, min($max, $messageCount));
         // If the number of emails in the folder are more than Max Fetch
-        // then fetch in Reverse Order - this is necessary when fetched
-        // emails are not getting archived or deleted, which might lead to
-        // fetcher being stuck 4ever on processing old emails already
+        // then process the latest $max emails - this is necessary when
+        // fetched emails are not getting archived or deleted, which might
+        // lead to fetcher being stuck 4ever processing old emails already
         // fetched
-        if ($messageCount > $max)
-            rsort($messages, SORT_NUMERIC);
+        if ($messageCount > $max) {
+            // Latest $max messages
+            $messages = range($messageCount-$max, $messageCount);
+        } else {
+            // Create a range of message sequence numbers (msgno) to fetch
+            // starting from the oldest taking max fetch into account
+            $messages = range(1, min($max, $messageCount));
+        }
 
         $msgs = $errors = 0;
+        // TODO: Use message UIDs instead of ids
         foreach ($messages as $i) {
             try {
                 // Okay, let's try to create a ticket

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -93,21 +93,36 @@ class Fetcher {
 
         // Get basic fetch settings
         $archiveFolder = $this->getArchiveFolder();
-        $delete = $this->canDeleteEmails();
-        $max = $this->getMaxFetch();
-        // Get full message count
-        $messageCount = $this->mbox->countMessages();
+        $deleteFetched =  $this->canDeleteEmails();
+        $max = $this->getMaxFetch() ?: 30; // default to 30 if not set
+
+        // Get message count in the Fetch Folder
+        if (!($messageCount = $this->mbox->countMessages()))
+            return 0;
+
+        // Create a range of message sequence numbers (msgno) to fetch
+        // taking max fetch into account
+        // TODO: Use message UIDs instead of numbers
+        $messages = range(1, min($max, $messageCount));
+        // If the number of emails in the folder are more than Max Fetch
+        // then fetch in Reverse Order - this is necessary when fetched
+        // emails are not getting archived or deleted, which might lead to
+        // fetcher being stuck 4ever on processing old emails already
+        // fetched
+        if ($messageCount > $max)
+            rsort($messages, SORT_NUMERIC);
+
         $msgs = $errors = 0;
-        for ($i = $messageCount; $i > 0; $i--) { // Process messages in reverse.
+        foreach ($messages as $i) {
             try {
                 // Okay, let's try to create a ticket
-                if ($this->createTicket($i)) {
+                if (($result=$this->createTicket($i))) {
                     // Mark the message as "Seen" (IMAP only)
                     $this->mbox->markAsSeen($i);
                     // Attempt to move the message if archive folder is set or
                     if ($archiveFolder)
                         $this->mbox->moveMessage($i, $archiveFolder);
-                    elseif ($delete)  // else delete if deletion is desired
+                    elseif ($deleteFetched)  // else delete if deletion is desired
                         $this->mbox->removeMessage($i);
                     $msgs++;
                     $errors = 0; // We are only interested in consecutive errors.
@@ -115,16 +130,17 @@ class Fetcher {
                     $errors++;
                 }
             } catch (\Throwable $t) {
-                // Generic Exceptions - log the message
-                $errors++;
+                // If we have result then exception happened after email
+                // processing and shouldn't count as an error
+                if (!$result)
+                    $errors++;
+                // log the exception as a debug message
                 $this->logDebug($t->getMessage());
             }
-
-            if ($max && ($msgs >= $max || $errors > ($max*0.8)))
-                break;
         }
+        // Expunge the mailbox
 		$this->mbox->expunge();
-        // Warn on excessive errors
+        // Warn on excessive errors (errors more than tickets created)
         if ($errors > $msgs) {
             $warn = sprintf(_S('Excessive errors processing emails for %1$s (%2$s). Please manually check the inbox.'),
                     $this->mbox->getHostInfo(), $this->getEmail());

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -24,7 +24,7 @@ class Fetcher {
     function __construct(\MailboxAccount $account, $charset='UTF-8') {
         $this->account = $account;
         $this->mbox = $account->getMailBox();
-        if ($folder = $this->getFolder())
+        if (($folder = $this->getFetchFolder()))
             $this->mbox->selectFolder($folder);
     }
 
@@ -44,8 +44,8 @@ class Fetcher {
         return $this->account->getMaxFetch();
     }
 
-    function getFolder() {
-        return $this->account->getFolder();
+    function getFetchFolder() {
+        return $this->account->getFetchFolder();
     }
 
     function getArchiveFolder() {
@@ -91,7 +91,7 @@ class Fetcher {
 
     function processEmails() {
         // We need a connection
-        if(!$this->mbox)
+        if (!$this->mbox)
             return false;
 
         // Get basic fetch settings

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -77,13 +77,10 @@ class Fetcher {
             return true;
         } catch (\EmailParseError $ex) {
             // Log the parse error + headers as a warning
+            // TODO: Create a ticket anyhow and attached raw email as an
+            // attachment (.eml) if we can parse the header
             $this->logWarning(sprintf("%s\n\n%s",
                         $ex->getMessage(),
-                        $this->mbox->getRawHeader($i)));
-        } catch (\Throwable $t) {
-            // Log the ex + headers as a debug error
-            $this->logDebug(sprintf("%s\n\n%s",
-                        $t->getMessage(),
                         $this->mbox->getRawHeader($i)));
         }
         return false;


### PR DESCRIPTION
osTicket currently fetches messages in LIFO order meaning the most recent messages get fetched first. This was intentional to avoid possible stalemate when fetched messages are left in the inbox (Do Nothing Option - which is not recommened). However, this can create out of order threading issues since subsequest replies can be fetched first.

This PR (last commit) addresses the issue by changing the logic so we can fetch older messages first (FIFO order) as long as the numbers of the emails in the folder being fetched are less than maximum messages to process at a time.