### PR TITLE
SMTP: Dont send 'QUIT' on __destruct()

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -609,9 +609,10 @@ namespace osTicket\Mail {
             parent::__construct($this->buildOptions($setting));
         }
 
+        // Build out SmtpOptions options based on SmtpAccount Settings
         private function buildOptions(AccountSetting $setting) {
-            // Build out SmtpOptions options based on SmtpAccount Settings
-            $config = [];
+            // Dont send 'QUIT' on __destruct()
+            $config = ['use_complete_quit' => false];
             $connect = $setting->getConnectionConfig();
             $auth = $setting->getAuthCredentials();
             switch (true) {
@@ -623,7 +624,7 @@ namespace osTicket\Mail {
                     ];
                     break;
                 case $auth instanceof BasicAuthCredentials:
-                    $config = [
+                    $config += [
                         'username' => $auth->getUsername(),
                         'password' => $auth->getPasswd(),
                         'ssl' => $connect['ssl'],
@@ -633,7 +634,7 @@ namespace osTicket\Mail {
                     $token = $auth->getAccessToken();
                     if ($token->hasExpired())
                         throw new Exception('Access Token is Expired');
-                    $config = [
+                    $config += [
                         'xoauth2' => $token->getAuthRequest(),
                         'ssl' => $connect['ssl'],
                     ];
@@ -643,8 +644,9 @@ namespace osTicket\Mail {
             }
 
             return [
-                'host'      => $connect['host'],
-                'port'      => $connect['port'],
+                'host' => $connect['host'],
+                'port' => $connect['port'],
+                'connection_time_limit' => 300, # 5 minutes limit
                 'connection_class'  => $auth->getConnectionClass(),
                 'connection_config' => $config
             ];


### PR DESCRIPTION
This PR attempts to avoid errors / exceptions that cannot be managed from PHP userspace when an SMTP object is destructed. It also adds a connection timeout of 5 minutes so old connections can be recreated on the fly.