### PR TITLE
issue: MTA Typo

### DIFF
--- a/include/staff/settings-emails.inc.php
+++ b/include/staff/settings-emails.inc.php
@@ -150,7 +150,7 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config)
                     $accounts = SmtpAccount::objects()->filter(['active' => 1]);
                     foreach ($accounts as $account) {
                         $id = $account->getId();
-                        $email = sprintf('%s &lt;%sl&gt;',
+                        $email = sprintf('%s &lt;%s&gt;',
                                 $account->email->getName(),
                                 $account->email->getEmail());
                         ?>


### PR DESCRIPTION
This addresses a small typo (#6351) where `l` was being added to each email string for the Default MTA setting. This removes the `l` so the emails are displayed properly.