### PR TITLE
Fixes broken reference to `SessionData`

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -1594,7 +1594,7 @@ abstract class PasswordPolicy extends ServiceRegistry {
                 return false;
         }
 
-        return SessionData::objects()->filter($criteria)->delete();
+        return DatabaseSessionRecord::objects()->filter($criteria)->delete();
     }
 }
 Signal::connect('auth.clean', array('PasswordPolicy', 'cleanSessions'));


### PR DESCRIPTION
In [class.auth.php:1597](https://github.com/osTicket/osTicket/blob/58bf538df9aeaf740142471c27a6f182a2f02326/include/class.auth.php#L1597) the class SessionData is still referenced. However in https://github.com/osTicket/osTicket/commit/47df2b440971457bc5c22197b5596f49a8b28317 this class was completely overhauled. Therefore this references a non-existing class and function.

Fixes #6359