### PR TITLE
Fix trusted proxy wildcard check

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -604,7 +604,7 @@ class osTicket {
         if (!$proxies)
             return false;
         // Wildcard set - trust all proxies
-        else if ($proxies == '*')
+        else if (in_array('*', $proxies))
             return true;
 
         return ($proxies && Validator::check_ip($ip, $proxies));


### PR DESCRIPTION
Fixes trusted proxy checking `is_trusted_proxy` to correctly detect wildcard symbols.
Fixes issue #5948 