### PR TITLE
issue: Html Typo

### DIFF
--- a/include/client/tickets.inc.php
+++ b/include/client/tickets.inc.php
@@ -171,7 +171,7 @@ foreach (Topic::getHelpTopics(true) as $id=>$name) {
 
 
 <h1 style="margin:10px 0">
-    <a href="<?php echo Html::refresh_url(); ?>"
+    <a href="<?php echo Http::refresh_url(); ?>"
         ><i class="refresh icon-refresh"></i>
     <?php echo __('Tickets'); ?>
     </a>


### PR DESCRIPTION
This addresses a small typo where the class `Html` was used instead of `Http`.