### PR TITLE
validator: Email Domain Verification

### DIFF
--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -185,7 +185,7 @@ class Validator {
         // full-stop trailing char so that the default domain of the server
         // is not added automatically
         if ($verify and !dns_get_record($m->host.'.', DNS_MX))
-            return 0 < @count(dns_get_record($m->host.'.', DNS_A|DNS_AAAA));
+            return (count(dns_get_record($m->host.'.', DNS_A|DNS_AAAA) ?: []));
 
         return true;
     }


### PR DESCRIPTION
To truly verify an email, osTicket uses DNS lookup by checking MX record, if that fails it defaults to checking A / AAAA record of the email domain. 

This PR handle a case where a domain doesn't have MX or A records.
