### PR TITLE
session: Regenerate Session Id

### DIFF
--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -137,7 +137,10 @@ trait UserSessionTrait {
 
         // If TIME_BOMB is set and less than the current time we need to regenerate
         // session id to help mitigate session fixation attacks.
-        if (isset($_SESSION['TIME_BOMB'])
+        // Only regenerate on GET to avoid invalidating data in-flight on a
+        // POST request
+        if ($_SERVER['REQUEST_METHOD'] === 'GET'
+                && isset($_SESSION['TIME_BOMB'])
                 && ($_SESSION['TIME_BOMB'] < time())
                 && ($id=$this->regenerateSession())) {
             // unset timer and set next one based on maxlife for the user or


### PR DESCRIPTION
To avoid session fixation, osTicket regenerates Session Id on-login and on every session timeout set for the User/Agent even with activity.

This PR changes the logic to make sure that the regenerate `TIME BOMB` only goes off on a GET request - this is necessary so we don't invalidate data in-flight on a POST request since osTicket Forms API backend uses session_id to generate form field names as well as CSRF token used on forms.