### PR TITLE
session: Collab View Ticket

### DIFF
--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -216,7 +216,7 @@ class ClientSession extends EndUser {
         parent::__construct($user);
         $this->class ='client';
         // XXX: Change the key to user-id
-        $this->session = new UserSession($user->getId());
+        $this->session = new UserSession($user->getUserId());
         $this->setSessionToken();
         $this->maxidletime = $cfg->getClientTimeout();
     }


### PR DESCRIPTION
This addresses an issue where if a Collaborator views a Ticket via the Check Ticket Status button in the Client Portal and then tries to repeat the process with an additional Ticket it will redirect to login page. This is due to when instantiating the session we use `$user->getId()` which causes a problem when the User is a Collaborator. When instantiating a session for a Collaborator object `getId()` returns the Collaborator ID, not the Collaborator's User ID. This updates the call from `getId()` to `getUserId()` which gets the correct User ID from the Collaborator object (and others).