### PR TITLE
typo: Fix verify_email_addrs Help Tip

### DIFF
--- a/include/i18n/en_US/help/tips/settings.email.yaml
+++ b/include/i18n/en_US/help/tips/settings.email.yaml
@@ -135,5 +135,5 @@ verify_email_addrs:
     content: >
         Enable this option to check if the email address has a mail
         exchanger (MX) in the domain's DNS. This is useful to detect
-        incorrectly typed email addresses. This is perfomed in addition to
+        incorrectly typed email addresses. This is performed in addition to
         checking the email address wellformedness.


### PR DESCRIPTION
This fixes a typo with the `verify_email_addrs` help tip where `perfomed` should be `performed`.