### PR TITLE
mysql: Support Sidecar Database Proxies

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -202,13 +202,21 @@ class Bootstrap {
                 'key' => DBSSLKEY
             );
 
-        if (!db_connect(DBHOST, DBUSER, DBPASS, $options)) {
-            $ferror=sprintf('Unable to connect to the database — %s',db_connect_error());
-        }elseif(!db_select_database(DBNAME)) {
-            $ferror=sprintf('Unknown or invalid database: %s',DBNAME);
+        $hosts = explode(',', DBHOST);
+        foreach ($hosts as $host) {
+            $ferror  = null;
+            if (!db_connect($host, DBUSER, DBPASS, $options)) {
+                $ferror = sprintf('Unable to connect to the database — %s',
+                        db_connect_error());
+            }elseif(!db_select_database(DBNAME)) {
+                $ferror = sprintf('Unknown or invalid database: %s',
+                        DBNAME);
+           }
+           // break if no error
+           if (!$ferror) break;
         }
 
-        if($ferror) //Fatal error
+        if ($ferror) //Fatal error
             self::croak($ferror);
     }
 

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -62,6 +62,10 @@ function db_connect($host, $user, $passwd, $options = array()) {
 
     // Connect
     $start = microtime(true);
+    // Specify the connection timeout (if defined)
+    if (defined('DBCONNECT_TIMEOUT'))
+        $__db->options(MYSQLI_OPT_CONNECT_TIMEOUT, DBCONNECT_TIMEOUT);
+
     if (!@$__db->real_connect($host, $user, $passwd, null, $port, $socket))
         return NULL;
 

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -40,10 +40,15 @@ define('ADMIN_EMAIL','%ADMIN-EMAIL');
 # Mysql Login info
 #
 define('DBTYPE','mysql');
+#  DBHOST can have comma separated hosts (e.g db1:6033,db2:6033)
 define('DBHOST','%CONFIG-DBHOST');
 define('DBNAME','%CONFIG-DBNAME');
 define('DBUSER','%CONFIG-DBUSER');
 define('DBPASS','%CONFIG-DBPASS');
+
+# Database TCP/IP Connect Timeout (default: 3 seconds)
+# Timeout is important when DBHOST has multiple proxies to try
+# define('DBCONNECT_TIMEOUT', 3);
 
 # Table prefix
 define('TABLE_PREFIX','%CONFIG-PREFIX');


### PR DESCRIPTION
When running osTicket in a multi-node cluster setup - it makes sense to connect to the database via a load balancer or a database proxy (assuming VIP with failover support). It's great for redundancy -  however - this adds extra time (miliseconds) because of the extra network hop latency.

To save a few miliseconds - when osTicket (the Application) is also hosted on the same node or container running the database proxy - then it might make sense to attempt a local connection first before attemp is made via the VIP (sidecar pattern).

This PR adds multiple database hosts support, comma separated, when defining DBHOST in osTicket config file (`ost-config.php`). It also adds a new _Database Option_ to define `DBCONNECT_TIME` used to set `MYSQLI_OPT_CONNECT_TIMEOUT`. Connection timeout is important with multiple hosts so connection attempts (done sequencially) can timeout relatively quickly.