### PR TITLE
First PHPstan configuration

### DIFF
--- a/.phpstan/bootstrap.php
+++ b/.phpstan/bootstrap.php
@@ -1,0 +1,46 @@
+<?php
+
+define('TABLE_PREFIX', '%');
+
+//Bootstrap::loadConfig();
+Bootstrap::defineTables(TABLE_PREFIX);
+Bootstrap::loadCode();
+
+//--------------------------------------------------------------------------------
+// Define functions from Bootstrap::i18n_prep()
+//--------------------------------------------------------------------------------
+function mb_str_wc($str) {}
+
+//--------------------------------------------------------------------------------
+// Define functions from Internationalization::bootstrap()
+//--------------------------------------------------------------------------------
+function _N($msgid, $plural, $n) {}
+function _S($msgid) {}
+function _NS($msgid, $plural, $count) {}
+function _P($context, $msgid) {}
+function _NP($context, $singular, $plural, $n) {}
+function _L($msgid, $locale) {}
+function _NL($msgid, $plural, $n, $locale) {}
+
+//--------------------------------------------------------------------------------
+// Include some other important files...
+//--------------------------------------------------------------------------------
+include_once INCLUDE_DIR . 'api.cron.php'; //For LocalCronApiController
+include_once INCLUDE_DIR . 'ajax.tickets.php'; //For AjaxController(s)
+include_once INCLUDE_DIR . 'class.app.php'; //For Application
+include_once INCLUDE_DIR . 'class.avatar.php'; //For RandomAvatar
+include_once INCLUDE_DIR . 'class.captcha.php'; //For Captcha
+include_once INCLUDE_DIR . 'class.cli.php'; //For Module
+
+//--------------------------------------------------------------------------------
+// Dummy class for AuditEntry...
+//--------------------------------------------------------------------------------
+class AuditEntry extends VerySimpleModel {
+
+	static $show_view_audits;
+
+	static function getTableInfo($objectId, $export=false, $type='') {}
+
+	static function getDescription($event, $export=false, $userType='') {}
+
+}

--- a/include/cli/modules/deploy.php
+++ b/include/cli/modules/deploy.php
@@ -252,7 +252,7 @@ class Deployment extends Unpacker {
         $this->readManifest($this->destination.'/.MANIFEST');
 
         $exclusions = array("$rootPattern/include/*", "$rootPattern/.git*",
-            "*.sw[a-z]","*.md", "*.txt");
+            "*.sw[a-z]","*.md", "*.txt", "$rootPattern/.phpstan*", "$rootPattern/phpstan.neon");
         if (!$options['setup'])
             $exclusions[] = "$rootPattern/setup/*";
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,16 @@
+parameters:
+	level: 0
+	paths:
+		- .
+	excludePaths:
+		analyse:
+			- include/laminas-mail
+			- include/mpdf
+			- include/pear
+			- setup/test
+		analyseAndScan:
+			- .phpstan
+			- setup/test/tests/stubs.php
+	bootstrapFiles:
+		- bootstrap.php
+		- .phpstan/bootstrap.php


### PR DESCRIPTION
I have a first running [PHPstan](https://phpstan.org/) configuration. 👍

It creates a `phpstan.neon` file in the root path and a `.phpstan` folder for a own bootstrap file.

This new file and folder will ignored when running `php manage.php deploy`.

Currently I using the [docker command](https://phpstan.org/user-guide/docker) to run PHPstan on the osTicket sources:

```
docker pull ghcr.io/phpstan/phpstan

docker run --rm -v /path/to/osticket/source:/app ghcr.io/phpstan/phpstan analyse
```

No automatic mode at the moment, but a start! And maybe we should first fix all problems. The PRs #6383 and #6397 fix at least the first easy things.