### PR TITLE
fetcher: Default Department

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -171,7 +171,7 @@ class TicketApiController extends ApiController {
         return $this->processEmail();
     }
 
-    function processEmail($data=false) {
+    function processEmail($data=false, array $defaults = []) {
 
         try {
             if (!$data)
@@ -182,6 +182,7 @@ class TicketApiController extends ApiController {
             throw new EmailParseError($ex->getMessage());
         }
 
+        $data = array_merge($defaults, $data);
         $seen = false;
         if (($entry = ThreadEntry::lookupByEmailHeaders($data, $seen))
             && ($message = $entry->postEmail($data))

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -75,13 +75,13 @@ class Fetcher {
         return ($this->mbox && $this->mbox->noop());
     }
 
-    function processMessage(int $i) {
+    function processMessage(int $i, array $defaults = []) {
         try {
             // Please note that the returned object could be anything from
             // ticket, task to thread entry or a boolean.
             // Don't let TicketApi call fool you!
             return $this->getTicketsApi()->processEmail(
-                    $this->mbox->getRawEmail($i));
+                    $this->mbox->getRawEmail($i), $defaults);
         } catch (\TicketDenied $ex) {
             // If a ticket is denied we're going to report it as processed
             // so it can be moved out of the Fetch Folder or Deleted based
@@ -126,12 +126,15 @@ class Fetcher {
             $messages = range(1, min($max, $messageCount));
         }
 
+        $defaults = [
+            'emailId' => $this->getEmailId()
+        ];
         $msgs = $errors = 0;
         // TODO: Use message UIDs instead of ids
         foreach ($messages as $i) {
             try {
                 // Okay, let's try to create a ticket
-                if (($result=$this->processMessage($i))) {
+                if (($result=$this->processMessage($i, $defaults))) {
                     // Mark the message as "Seen" (IMAP only)
                     $this->mbox->markAsSeen($i);
                     // Attempt to move the message if archive folder is set or


### PR DESCRIPTION
When fetching a mailbox, osTicket routes fetched emails to a department based on `To` or `Delivered-To` header entries. This allows for ability to fetch aliased emails from one primary account and route them based on configured system emails. On failure to match, the email (ticket) is routed to the department of the email account being fetched.

With the email backend overhaul in v1.17 - a bug was instroduced where unmatched emails ended up being routed to default department instead of the department of the email being fetched.

This PR addresses the issue...