### PR TITLE
Drop old PHP version checks

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -310,12 +310,6 @@ class Bootstrap {
         if (extension_loaded('iconv'))
             iconv_set_encoding('internal_encoding', 'UTF-8');
 
-        if (intval(phpversion()) < 7) {
-            function random_int($a, $b) {
-                return rand($a, $b);
-            }
-        }
-
         function mb_str_wc($str) {
             return count(preg_split('~[^\p{L}\p{N}\'].+~u', trim($str)));
         }

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -176,21 +176,12 @@ class Format {
             } while (!$done);
         }
 
-        static $phpversion;
-        if (!isset($phpversion))
-            $phpversion = phpversion();
-
         $body = $doc->getElementsByTagName('body');
         if (!$body->length)
             return $html;
 
-        if ($phpversion > '5.3.6') {
-            $html = $doc->saveHTML($doc->getElementsByTagName('body')->item(0)->firstChild);
-        }
-        else {
-            $html = $doc->saveHTML();
-            $html = preg_replace('`^<!DOCTYPE.+?>|<\?xml .+?>|</?html>|</?body>|</?head>|<meta .+?/?>`', '', $html); # <?php
-        }
+        $html = $doc->saveHTML($doc->getElementsByTagName('body')->item(0)->firstChild);
+
         return preg_replace('`^<div>|</div>$`', '', trim($html));
     }
 
@@ -384,8 +375,6 @@ class Format {
     }
 
     static function htmlchars($var, $sanitize = false) {
-        static $phpversion = null;
-
         if (is_array($var)) {
             $result = array();
             foreach ($var as $k => $v)
@@ -397,15 +386,8 @@ class Format {
         if ($sanitize)
             $var = Format::sanitize($var);
 
-        if (!isset($phpversion))
-            $phpversion = phpversion();
-
-        $flags = ENT_COMPAT;
-        if ($phpversion >= '5.4.0')
-            $flags |= ENT_HTML401;
-
         try {
-            return htmlspecialchars( (string) $var, $flags, 'UTF-8', false);
+            return htmlspecialchars( (string) $var, ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
         } catch(Exception $e) {
             return $var;
         }
@@ -416,11 +398,7 @@ class Format {
         if(is_array($var))
             return array_map(array('Format','htmldecode'), $var);
 
-        $flags = ENT_COMPAT;
-        if (phpversion() >= '5.4.0')
-            $flags |= ENT_HTML401;
-
-        return htmlspecialchars_decode($var, $flags);
+        return htmlspecialchars_decode($var, ENT_COMPAT | ENT_HTML401);
     }
 
     static function http_query_string(string $query, array $filter = null) {

--- a/include/cli/modules/package.php
+++ b/include/cli/modules/package.php
@@ -108,8 +108,7 @@ class Packager extends Deployment {
         if (!$zip->open($name, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true)
             return false;
 
-        $php56plus = version_compare(phpversion(), '5.6.0', '>');
-        $addFiles = function($dir) use (&$addFiles, $zip, $path, $php56plus) {
+        $addFiles = function($dir) use (&$addFiles, $zip, $path) {
             $files = array_diff(scandir($dir), array('.','..'));
             $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             foreach ($files as $file) {
@@ -117,16 +116,14 @@ class Packager extends Deployment {
                 $local = str_replace($path, '', $full);
                 if (is_dir($full))
                     $addFiles($full);
-                else
+                else {
                     // XXX: AddFile() will keep the file open and run
                     //      out of OS open file handles
                     $zip->addFromString($local, file_get_contents($full));
-                    // This only works on PHP >= v5.6
-                    if ($php56plus) {
-                        // Set the Unix mode of the file
-                        $stat = stat($full);
-                        $zip->setExternalAttributesName($local, ZipArchive::OPSYS_UNIX, $stat['mode'] << 16);
-                    }
+                    // Set the Unix mode of the file
+                    $stat = stat($full);
+                    $zip->setExternalAttributesName($local, ZipArchive::OPSYS_UNIX, $stat['mode'] << 16);
+                }
             }
         };
         $addFiles($path);

--- a/include/tnef_decoder.php
+++ b/include/tnef_decoder.php
@@ -346,9 +346,7 @@ class TnefAttributeStreamReader extends TnefStreamReader {
 
         case self::TypeInt64:
             // 8-byte signed integer= INT64.
-            $x = $this->_getx(8);
-            if (phpversion() >= '5.6.3')
-                list($x) = unpack('P', $x);
+            list($x) = unpack('P', $this->_getx(8));
             return $x;
 
         case self::TypeAppTime:


### PR DESCRIPTION
Since osTicket need now PHP 8, we can remove some version checks for older PHP versions.