### PR TITLE
issue: Static forTask()

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1211,7 +1211,7 @@ class DynamicFormEntry extends VerySimpleModel {
         return $entries[$ticket_id];
     }
 
-    function forTask($id, $force=false) {
+    static function forTask($id, $force=false) {
         static $entries = array();
         if (!isset($entries[$id]) || $force) {
             $stuff = DynamicFormEntry::objects()->filter(array(


### PR DESCRIPTION
This addresses an issue where printing a Ticket with Tasks or printing a Task itself will throw a fatal error of `Non-static method DynamicFormEntry::forTask() cannot be called statically`. This updates the `forTask()` method to be static to avoid fatal errors.