### PR TITLE
issue: TicketDenied errno

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -164,7 +164,7 @@ class TicketApiController extends ApiController {
 
         $error = sprintf('%s :%s',
                 _S('Unable to create new ticket'), $error);
-        return $this->exerr(500, $error, $title);
+        return $this->exerr($errors['errno'] ?: 500, $error, $title);
     }
 
     function processEmailRequest() {


### PR DESCRIPTION
This addresses an issue where emails being rejected by Banlist is causing excessive processing errors and refuses to move the mail. This is due to our logic expecting `403` exception code for TicketDenied but we are using `500` in `TicketApiController::createTicket()`. This updates the `exerr()` line to use the `$errors['errno']` if it exists otherwise default to `500`.