### PR TITLE
issue: Featured FAQs

### DIFF
--- a/include/class.faq.php
+++ b/include/class.faq.php
@@ -347,7 +347,7 @@ class FAQ extends VerySimpleModel {
 
     static function getFeatured() {
         return self::objects()
-            ->filter(array('ispublished__in'=>array(1,2), 'category__ispublic'=>1))
+            ->filter(array('ispublished'=>2, 'category__ispublic__in'=>[1,2]))
             ->order_by('-ispublished');
     }
 


### PR DESCRIPTION
This addresses a small logic issue where we are adding Public and Featured FAQs in the Featured sidebar when it should only be Featured ones. This updates the ORM statement to only show FAQs that are set to Featured and belong to a Public or Featured Category.