### PR TITLE
 Fix tasks access

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -284,7 +284,6 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
 
         // Check access based on department or assignment
         if (!$staff->canAccessDept($this->getDept())
-                && $this->isOpen()
                 && $staff->getId() != $this->getStaffId()
                 && !$staff->isTeamMember($this->getTeamId()))
             return false;


### PR DESCRIPTION
This addresses the issue when all the closed tasks are accessible by all the agent regardless of their department or assignment https://github.com/osTicket/osTicket/pull/6414). https://forum.osticket.com/d/102309-any-agent-can-access-any-closed-task