### PR TITLE
print: Hidden Thread Events

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2115,6 +2115,7 @@ class ThreadEvent extends VerySimpleModel {
                 case 'timestamp':
                     $timeFormat = null;
                     if ($mode != self::MODE_CLIENT && $thisstaff
+                            && (!isset($_REQUEST['a']) || $_REQUEST['a']!='print')
                             && !strcasecmp($thisstaff->datetime_format,
                                 'relative')) {
                         $timeFormat = function ($timestamp) {

--- a/include/staff/templates/ticket-print.tmpl.php
+++ b/include/staff/templates/ticket-print.tmpl.php
@@ -255,7 +255,7 @@ if ($entries->exists(true)) {
             //       changes in dates between thread items.
             if ($this->includeevents) {
                 while ($event && $cmp($event->timestamp, $entry->created)) {
-                    $event->render(ThreadEvent::MODE_CLIENT);
+                    $event->render(ThreadEvent::MODE_STAFF);
                     $events->next();
                     $event = $events->current();
                 }
@@ -294,7 +294,7 @@ if ($entries->exists(true)) {
 }
 // Emit all other events
 while ($event) {
-    $event->render(ThreadEvent::MODE_CLIENT);
+    $event->render(ThreadEvent::MODE_STAFF);
     $events->next();
     $event = $events->current();
 } ?>


### PR DESCRIPTION
This addresses an issue reported on the Forum where when a field is set to not visible to Users it is hidden from the Staff Ticket Print PDF. This is due to the ThreadEvent MODE that is being used (MODE_CLIENT). This uses the User Ticket Print template instead of the Staff Ticket Print template which hides some thread events and other data. This updates the utilized MODE to MODE_STAFF so that the appropriate data is printed. This also addresses an issue where if the Staff has Relative time configured it shows in the Ticket Print which should not happen. This adds a check for `$_REQUEST['a']` and if it's set we make sure it’s not `print` to avoid printing relative times.