### PR TITLE
issue: Disabled Queues Run Counts

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -941,6 +941,9 @@ class SavedQueue extends CustomQueue {
             ->filter(Q::any(array(
                 'flags__hasbit' => CustomQueue::FLAG_QUEUE,
                 'staff_id' => $agent->getId(),
+            )))
+            ->filter(Q::not(array(
+                'flags__hasbit' => CustomQueue::FLAG_DISABLED,
             )));
 
         if ($criteria && is_array($criteria))


### PR DESCRIPTION
This addresses an issue where Disabled Queues are still being used in counts. This is due to grabbing any CustomQueue that has the `FLAG_QUEUE` flag and/or having `staff_id` equal to the current Staff member's ID. This adds another filter `Q::not(…'flags__hasbit' => CustomQueue::FLAG_DISABLED,` that will ensure the Queue is not Disabled before using in counts.