### PR TITLE
session: User Logged Out

### DIFF
--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -171,7 +171,7 @@ trait UserSessionTrait {
         // If ttl is 0 then session is destroyed immediatetly
         $_SESSION['TTD'] = time() + $ttl; // now + ttl
         if (($id=osTicketSession::regenerate($ttl)))
-            $this->session_id = $id;
+            $this->session->session_id = $id;
         // unset TTD on the new session - new life my boy!
         unset($_SESSION['TTD']);
         return $id;


### PR DESCRIPTION
This addresses an issue where Users login, do something, and get randomly shown the login screen. If they refresh the page it shows them authenticated as normal again. This is due to a Session ID mismatch in `isvalidSession()`. When `refreshSession()` calls `regenerateSession()` it's supposed regenerate the session and update the session ID however it updates the local ID which `refreshSession()` later does. This updates `regenerateSession()` to where it updates the session ID and allows `refreshSession()` to update the local ID. This deduplicates the local ID update and corrects the ID mismatch.