### PR TITLE
issue: Queue Counts Incorrect

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -984,7 +984,13 @@ class SavedQueue extends CustomQueue {
             }
 
             if ($Q->constraints && !$empty) {
-                $expr = SqlCase::N()->when(new SqlExpr(new Q($Q->constraints)), new SqlField('ticket_id'));
+                $constraints = $Q->constraints;
+                // Add path_constraints to get the correct counts
+                foreach ($Q->path_constraints as $pc) {
+                    if (!empty($pc[0]->constraints))
+                        $constraints[] = $pc[0];
+                }
+                $expr = SqlCase::N()->when(new SqlExpr(new Q($constraints)), new SqlField('ticket_id'));
                 $query->aggregate(array(
                     "q{$queue->id}" => SqlAggregate::COUNT($expr, true)
                 ));


### PR DESCRIPTION
This addresses an issue where when a Queue is filtering by a specific field the counts are incorrect. This is due to using only the `constraints` instead of both `constraints` and `path_constraints`. This updates the `counts()` method to include the `path_constraints` if set so that the counts are properly calculated.