### PR TITLE
issue: FileUpload False

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -4036,7 +4036,7 @@ class FileUploadField extends FormField {
         if (isset($this->attachments) && $this->attachments) {
             $this->attachments->keepOnlyFileIds($value);
         }
-        return JsonDataEncoder::encode($value);
+        return JsonDataEncoder::encode($value) ?? NULL;
     }
 
     function parse($value) {


### PR DESCRIPTION
This addresses an issue where when doing full Ticket edit with a FileUpload field and you don't supply a file the form_entry_value for the corresponding field updates to `false`. This causes an issue with IS NULL criteria so this adds a check to see if a value is present, if not, then we return `NULL` instead of JSON encoding a `false` string value.