### PR TITLE
Auto-Close Answered Tickets

### DIFF
--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -28,6 +28,16 @@ class Cron {
     static function TicketMonitor() {
         require_once(INCLUDE_DIR.'class.ticket.php');
         Ticket::checkOverdue(); //Make stale tickets overdue
+        global $cfg;
+        $depts=Dept::getDepartments();
+        $a = 0;
+        foreach($depts as $d) {
+            $b=ConfigItem::getConfigsByNamespace('dept.' . array_search($d,$depts),'autoclose_grace_period');
+            $a+=$b->ht['value']?$b->ht['value']:0;
+        }
+        if($a>0) {
+            Ticket::closeAnswered(); //Close answered tickets
+        }
         // Cleanup any expired locks
         require_once(INCLUDE_DIR.'class.lock.php');
         Lock::cleanup();

--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -447,6 +447,10 @@ implements TemplateVariable, Searchable {
         return $this->message_auto_response;
     }
 
+    function autoRespONClosedMessage() {
+        return ConfigItem::getConfigsByNamespace('dept.' . $this->getId() ,'closed_auto_response')->ht['value'];
+    }
+
     function noreplyAutoResp() {
          return $this->noreply_autoresp;
     }
@@ -490,6 +494,8 @@ implements TemplateVariable, Searchable {
         $ht['status'] = $this->getStatus();
         $ht['assignment_flag'] = $this->getAssignmentFlag();
         $ht['disable_reopen_auto_assign'] =  $this->disableReopenAutoAssign();
+        $ht['closed_auto_response'] = ConfigItem::getConfigsByNamespace('dept.' . $this->getId() ,'closed_auto_response')->ht['value'];
+        $ht['autoclose_grace_period'] = ConfigItem::getConfigsByNamespace('dept.' . $this->getId() ,'autoclose_grace_period')->ht['value']?:0;
         return $ht;
     }
 
@@ -868,6 +874,29 @@ implements TemplateVariable, Searchable {
         $this->group_membership = $vars['group_membership'];
         $this->ticket_auto_response = isset($vars['ticket_auto_response'])?$vars['ticket_auto_response']:1;
         $this->message_auto_response = isset($vars['message_auto_response'])?$vars['message_auto_response']:1;
+        if ($this->getId()) {
+            $chelper = new OsticketConfig;
+            $chelper->section = 'dept.' . $this->getId();
+            $chelper->load();
+            if (isset($chelper->config['closed_auto_response'])) {
+                $chelper->update('closed_auto_response', isset($vars['closed_auto_response']) ? $vars['closed_auto_response'] : 1);
+            } else {
+                $chelper->set('closed_auto_response', isset($vars['closed_auto_response']) ? $vars['closed_auto_response'] : 1);
+            }
+            if (isset($chelper->config['autoclose_grace_period'])) {
+                if (strlen($vars['autoclose_grace_period']) == 0) {
+                    $chelper->update('autoclose_grace_period','0');
+                } else {
+                    $chelper->update('autoclose_grace_period', isset($vars['autoclose_grace_period']) ? $vars['autoclose_grace_period'] : '0');
+                }
+            } else {
+                if (strlen($vars['autoclose_grace_period']) == 0) {
+                    $chelper->set('autoclose_grace_period','0');
+                } else {
+                    $chelper->set('autoclose_grace_period', isset($vars['autoclose_grace_period']) ? $vars['autoclose_grace_period'] : '0');
+                }
+            }
+        }
         $this->flags = $vars['flags'] ?: 0;
 
         $this->setFlag(self::FLAG_ASSIGN_MEMBERS_ONLY, isset($vars['assign_members_only']));
@@ -921,6 +950,17 @@ implements TemplateVariable, Searchable {
             if ($wasnew) {
                 // The ID wasn't available until after the commit
                 $this->path = $this->getFullPath();
+
+                $chelper = new OsticketConfig;
+                $chelper->section = 'dept.' . $this->getId();
+                $chelper->load();
+                $chelper->set('closed_auto_response', isset($vars['closed_auto_response']) ? $vars['closed_auto_response'] : 1);
+                if (strlen($vars['autoclose_grace_period']) == 0) {
+                    $chelper->set('autoclose_grace_period','0');
+                } else {
+                    $chelper->set('autoclose_grace_period', isset($vars['autoclose_grace_period']) ? $vars['autoclose_grace_period'] : '0');
+                }
+
                 $this->save();
             }
             return true;

--- a/include/class.template.php
+++ b/include/class.template.php
@@ -28,6 +28,14 @@ class EmailTemplateGroup {
         'c.task' => /* @trans */ 'Task Email Templates',
     );
     static $all_names=array(
+        'ticket.autoclose'=>array(
+            'group'=>'a.ticket.user',
+            'name'=>/* @trans */ 'Closed Ticket Auto-reply',
+            'desc'=>/* @trans */ 'Closed  Ticket Notification sent to user, if enabled, on tickets that are closed by an agent or automatically by the system.',
+            'context' => array(
+                'ticket', 'signature', 'message', 'recipient'
+            ),
+        ),
         'ticket.autoresp'=>array(
             'group'=>'a.ticket.user',
             'name'=>/* @trans */ 'New Ticket Auto-response',
@@ -319,6 +327,10 @@ class EmailTemplateGroup {
 
     function getAutoReplyMsgTemplate() {
         return $this->getMsgTemplate('ticket.autoreply');
+    }
+
+    function getClosedMsgTemplate() {
+        return $this->getMsgTemplate('ticket.autoclose');
     }
 
     function getReplyMsgTemplate() {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1533,6 +1533,7 @@ implements RestrictedAccess, Threadable, Searchable {
                 $ecb = function($t) use ($status) {
                     $t->logEvent('closed', array('status' => array($status->getId(), $status->getName())), null, 'closed');
                     $t->deleteDrafts();
+                    $t->emailClosed();
                 };
                 break;
             case 'open':
@@ -4742,6 +4743,56 @@ implements RestrictedAccess, Threadable, Searchable {
         foreach ($overdue as $ticket)
             $ticket->markOverdue();
 
+    }
+
+    // Close Answered tickets based on Answered Ticket Auto-Close time from Agents > Departments screen
+    static function closeAnswered() {
+        global $cfg;
+        $days  = 0;
+        $depts = Dept::getDepartments();
+        foreach( $depts as $deptmt )
+        {
+            $cgp_ind = array_search($deptmt,$depts);
+            $cgp     = ConfigItem::getConfigsByNamespace('dept.' . array_search($deptmt,$depts),'autoclose_grace_period');
+            $days    = $cgp->ht['value'] ? $cgp->ht['value'] : 0;
+            if($days != 0){
+                $pending = static::objects()
+                    ->filter(array(
+                        'isanswered' => 1,
+                        'status__state' => 'open',
+                        Q::any(array(
+                            Q::all(array(
+                                'dept_id__exact' =>$cgp_ind,
+                                'duedate__isnull' => true,
+                                'updated__lt' => SqlFunction::NOW()->minus(SqlInterval::DAY($days)))
+                                )
+                            ))
+                        ))
+                    ->limit(100);
+                foreach ($pending as $ticket) {
+                    $ticket->setStatus('3', 'Ticket Closed by the SYSTEM after '.$days.' days of no activity.');
+                }
+            }
+        }
+    }
+
+    // Email closed tickets based on Closed Ticket Autoresponder setting from Agents > Departments screen
+    function emailClosed() {
+        global $thisstaff, $cfg;
+        $dept      = $this->getDept();
+        $signature = $dept->getSignature();
+        $poster    = $this->getName();
+        $variables = array (
+                    'signature' => $signature,
+                    'staff' => $thisstaff,
+                    'poster' => $poster,
+                    'recipient' => $this->getOwner());
+        if ((($email = $dept->getEmail() ) && ($tpl = $dept->getTemplate() ) && ($msg = $tpl->getClosedMsgTemplate() ) && ($dept->autoRespONClosedMessage() == 1) ) && $this->getStatusId() == 3) {
+            $msg = $this->replaceVars ( $msg->asArray (), $variables );
+            if ($cfg->stripQuotedReply() && ($tag = $cfg->getReplySeparator() ) )
+                $msg ['body'] = "<p style=\"display:none\">$tag<p>" . $msg ['body'];
+            $email->send ( $this->getEmail (), $msg ['subj'], $msg ['body']);
+        }
     }
 
     static function agentActions($agent, $options=array()) {

--- a/include/i18n/en_US/help/tips/staff.department.yaml
+++ b/include/i18n/en_US/help/tips/staff.department.yaml
@@ -126,6 +126,20 @@ new_message:
         You may disable the Auto-Response sent to the User to confirm
         a newly posted message for tickets in this Department.
 
+closed_auto_response:
+    title: Closed Ticket Auto Response
+    content: >
+        You may disable the Auto-Response sent to the User when a ticket
+        is closed by this Department or automatically if the <strong>Auto-Close
+        Tickets After x Days</strong> is enabled below.
+
+autoclose_grace_period:
+    title: Auto-Close Answered Tickets After x Days
+    content: >
+        Enter the number of Days before an answered ticket will be Auto-Closed by the system.
+        <br><br>
+        Enter <span class="doc-desc-opt">0</span> to disable the Auto-Close feature.
+
 auto_response_email:
     title: Auto Response Email
     content: >

--- a/include/i18n/en_US/templates/email/ticket.autoclose.yaml
+++ b/include/i18n/en_US/templates/email/ticket.autoclose.yaml
@@ -1,0 +1,30 @@
+#
+# Email template: ticket.autoclose.yaml
+#
+# Ticket Name - Closed Ticket Auto-reply
+#
+# Sent to a user when a ticket is closed by an agent or automatically by the system
+#
+---
+notes: |
+    Sent to a user when a ticket is closed by the system.
+
+    Available variables for replacement: %{ticket.*}, %{response}
+
+subject: |
+    Re: %{ticket.subject} [#%{ticket.number}] Closed
+body: |
+    <h3><strong>Dear %{recipient.name.first},</strong></h3>
+    Thank you for contacting the %{ticket.dept}.<br>
+    This message is to confirm that we have resolved and closed your ticket <strong>%{ticket.number}</strong> on your behalf.
+    <br>
+    <br>
+    <div style="color: rgb(127, 127, 127);">Your %{company.name} Team,<br>
+    %{signature}</div>
+    <hr>
+    <div style="color: rgb(127, 127, 127); font-size: small;"><em>We hope
+    we have sufficiently answered your questions.  If you wish to provide 
+    additional comments or information, please reply to this email
+    or <a href="%{recipient.ticket_link}"><span
+    style="color: rgb(84, 141, 212);" >login to your account</span></a> for
+    a complete archive of your support requests.</em></div>

--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -308,6 +308,26 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info, true);
         </tr>
         <tr>
             <td width="180">
+                <?php echo __('Closed Ticket');?>:
+            </td>
+            <td>
+                <span>
+                <input type="checkbox" name="closed_auto_response" value="0" <?php echo !$info['closed_auto_response']?'checked="checked"':''; ?> >  
+                <?php echo __('<strong>Disable</strong> for this Department'); ?>
+                <i class="help-tip icon-question-sign" href="#closed_auto_response"></i>
+                </span>
+            </td>
+        </tr>
+         <tr>
+            <td><?php echo __('Auto-Close Tickets After'); ?>:</td>  
+            <td>  
+                <input type="text" name="autoclose_grace_period" size=4 value="<?php echo $info['autoclose_grace_period']; ?>">&nbsp;Day(s)&nbsp;  
+                <font class="error"><?php echo $errors['autoclose_grace_period']; ?></font>  
+                <i class="help-tip icon-question-sign" href="#autoclose_grace_period"></i>  
+            </td>  
+        </tr>
+        <tr>
+            <td width="180">
                 <?php echo __('Auto-Response Email'); ?>:
             </td>
             <td>


### PR DESCRIPTION
This adds the ability to automatically close answered tickets after "X" amount of days of inactivity from the customer.

New Email Template created for "Closed Tickets"
The ability has also been added to the system to send Closed Ticket emails to customers.

Both of the above can be set per department (Admin Panel > Agents > Departments > Selected Department).