### PR TITLE
Added Alert if Auto Assigned

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -990,6 +990,10 @@ class OsticketConfig extends Config {
         return ($this->get('note_alert_dept_manager'));
     }
 
+    function alertSendIfAutoAssignedONNewTicket() {
+        return ($this->get('ticket_alert_send_if_auto_assigned'));
+    }
+
     function alertONNewTicket() {
         return ($this->get('ticket_alert_active'));
     }
@@ -1712,6 +1716,7 @@ class OsticketConfig extends Config {
 
        if($vars['ticket_alert_active']
                 && (!isset($vars['ticket_alert_admin'])
+                    && !isset($vars['ticket_alert_send_if_auto_assigned'])
                     && !isset($vars['ticket_alert_dept_manager'])
                     && !isset($vars['ticket_alert_dept_members'])
                     && !isset($vars['ticket_alert_acct_manager']))) {
@@ -1758,6 +1763,7 @@ class OsticketConfig extends Config {
         return $this->updateAll(array(
             'ticket_alert_active'=>$vars['ticket_alert_active'],
             'ticket_alert_admin'=>isset($vars['ticket_alert_admin'])?1:0,
+            'ticket_alert_send_if_auto_assigned'=>isset($vars['ticket_alert_send_if_auto_assigned'])?1:0,
             'ticket_alert_dept_manager'=>isset($vars['ticket_alert_dept_manager'])?1:0,
             'ticket_alert_dept_members'=>isset($vars['ticket_alert_dept_members'])?1:0,
             'ticket_alert_acct_manager'=>isset($vars['ticket_alert_acct_manager'])?1:0,

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1716,6 +1716,15 @@ implements RestrictedAccess, Threadable, Searchable {
                             $recipients[] = $M;
                 }
 
+                //Send alerts to dept members if the ticket has been auto-assigned via a ticket filter or help topic.
+                if ($cfg->alertDeptMembersONNewTicket() && $cfg->alertSendIfAutoAssignedONNewTicket()
+					&& ($members = $dept->getMembersForAlerts())
+				) {
+                    foreach ($members as $M)
+                        if ($M != $manager)
+                            $recipients[] = $M;
+                }
+
                 if ($cfg->alertDeptManagerONNewTicket() && $manager) {
                     $recipients[] = $manager;
                 }

--- a/include/staff/settings-alerts.inc.php
+++ b/include/staff/settings-alerts.inc.php
@@ -21,6 +21,12 @@
         </tr>
         <tr>
             <td>
+              <input type="checkbox" name="ticket_alert_send_if_auto_assigned" <?php echo $config['ticket_alert_send_if_auto_assigned']?'checked':''; ?>>
+              <?php echo __('Send if ticket is Auto-Assigned via Ticket Filter or Help Topic'); ?>
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <input type="checkbox" name="ticket_alert_dept_manager" <?php echo $config['ticket_alert_dept_manager']?'checked':''; ?>>
                 <?php echo __('Department Manager'); ?>
             </td>


### PR DESCRIPTION
Added the option in "Settings > Tickets > Alerts and Notices" to alert the agents when a ticket is automatically assigned by a Ticket Filter or Help Topic.