### PR TITLE
Ability to remove staff login link from the client login page

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -598,6 +598,10 @@ class OsticketConfig extends Config {
         return $this->get('client_name_format');
     }
 
+    function isRemoveStaffLoginLinkEnabled() {
+        return $this->get('remove_staff_login_link');
+    }
+
     function getDefaultDeptId() {
         return $this->get('default_dept_id');
     }
@@ -1327,6 +1331,7 @@ class OsticketConfig extends Config {
             'max_page_size'=>$vars['max_page_size'],
             'log_level'=>$vars['log_level'],
             'log_graceperiod'=>$vars['log_graceperiod'],
+            'remove_staff_login_link' => isset($vars['remove_staff_login_link']) ? 1 : 0,
             'time_format'=>$vars['time_format'],
             'date_format'=>$vars['date_format'],
             'datetime_format'=>$vars['datetime_format'],

--- a/include/client/login.inc.php
+++ b/include/client/login.inc.php
@@ -54,10 +54,12 @@ if ($cfg && $cfg->isClientRegistrationEnabled()) {
     <?php echo __('Not yet registered?'); ?> <a href="account.php?do=create"><?php echo __('Create an account'); ?></a>
     </div>
 <?php } ?>
+<?php if ($cfg && !$cfg->isRemoveStaffLoginLinkEnabled()) { ?>
     <div>
     <b><?php echo __("I'm an agent"); ?></b> —
     <a href="<?php echo ROOT_PATH; ?>scp/"><?php echo __('sign in here'); ?></a>
     </div>
+<?php } ?>
     </div>
 </div>
 </form>

--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -92,6 +92,11 @@ enable_richtext:
         If enabled, this will permit the use of rich text formatting between
         Clients and Agents.
 
+remove_staff_login_link:
+    title: Remove Staff Login Link
+    content: >
+        If enabled, this will remove the Staff Login Link from the client login page.
+
 enable_avatars:
     title: Enable Avatars on Thread View
     content: >

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -124,6 +124,15 @@ $gmtime = Misc::gmtime();
             </td>
         </tr>
         <tr>
+            <td width="220"><?php echo __('Remove Staff Login Link');?>:</td>
+            <td>
+                <input type="checkbox" name="remove_staff_login_link" <?php
+                echo $config['remove_staff_login_link'] ? 'checked="checked"': ''; ?>>
+                <?php echo __('Removes the staff login link from the client login interface');?>
+                <i class="help-tip icon-question-sign" href="#remove_staff_login_link"></i>
+            </td>
+        </tr>
+        <tr>
             <td><?php echo __('Show Avatars'); ?>:</td>
             <td>
                 <input type="checkbox" name="enable_avatars" <?php


### PR DESCRIPTION
Added the ability to remove the Staff Login Link from the client login page from the "Settings > System" page.