### PR TITLE
Added Banned identification to "User Directory"

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -443,7 +443,9 @@ if($ticket->isOverdue())
                 <tr>
                     <th><?php echo __('Email'); ?>:</th>
                     <td>
-                        <span id="user-<?php echo $ticket->getOwnerId(); ?>-email"><?php echo $ticket->getEmail(); ?></span>
+                        <span id="user-<?php echo $ticket->getOwnerId(); ?>-email"<?php 
+                        echo ($emailBanned ? ' style="color: #ff0000;" data-placement="bottom" data-toggle="tooltip" title="" data-original-title="Banned Email Address"' : '');
+                        ?>><?php echo $ticket->getEmail(); ?></span>
                     </td>
                 </tr>
 <?php   if ($user->getOrganization()) { ?>

--- a/include/staff/user-view.inc.php
+++ b/include/staff/user-view.inc.php
@@ -128,7 +128,9 @@ if ($thisstaff->hasPerm(User::PERM_EDIT)) { ?>
                 <tr>
                     <th width="150"><?php echo __('Status'); ?>:</th>
                     <td> <span id="user-<?php echo $user->getId();
-                    ?>-status"><?php echo $user->getAccountStatus(); ?></span></td>
+                    ?>-status"><?php echo $user->getAccountStatus();
+                    echo (BanList::isbanned($user->getEmail()) == 1 ? '&nbsp;&nbsp;<font color="ff0000">(Banned)</font>' : '');
+                    ?></span></td>
                 </tr>
                 <tr>
                     <th><?php echo __('Created'); ?>:</th>

--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -193,7 +193,8 @@ else
                     <a class="preview"
                         href="users.php?id=<?php echo $U['id']; ?>"
                         data-preview="#users/<?php echo $U['id']; ?>/preview"><?php
-                        echo Format::htmlchars($name); ?></a>
+                        echo Format::htmlchars($name); ?></a><?php
+                        echo (BanList::isbanned($U['default_email__address']) ? '&nbsp;&nbsp;<font color="ff0000">(Banned)</font>' : ''); ?>
                     &nbsp;
                     <?php
                     if ($U['ticket_count'])


### PR DESCRIPTION
Added a easy to see "(Banned)" in red next to the Guest text in the Status column within the User Directory to make it easier to see if an email address is banned from sending emails into the ticket system.

This has been added in the User Directory List as well as when you view individual user details.