### PR TITLE
Extra controls for Help Topics to allow restricting them to Organizations and/or Primary Contacts

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -131,6 +131,7 @@ class Bootstrap {
 
         define('TOPIC_TABLE',$prefix.'help_topic');
         define('TOPIC_FORM_TABLE',$prefix.'help_topic_form');
+        define('TOPIC_ORGANIZATION_TABLE',$prefix.'help_topic_organization');
         define('SLA_TABLE', $prefix.'sla');
 
         define('EMAIL_TABLE',$prefix.'email');

--- a/include/class.client.php
+++ b/include/class.client.php
@@ -85,6 +85,8 @@ implements EmailContact, ITicketUser, TemplateVariable {
 
     function getId() { return ($this->user) ? $this->user->getId() : null; }
     function getEmail() { return ($this->user) ? $this->user->getEmail() : null; }
+    function isPrimaryContact() { return ($this->user) ? $this->user->isPrimaryContact() : null; }
+    function getOrganization() { return ($this->user) ? $this->user->getOrganization() : null; }
     function getName() {
         return ($this->user) ? $this->user->getName() : null;
     }

--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -160,6 +160,55 @@ class OrganizationModel extends VerySimpleModel {
     static function getPermissions() {
         return self::$perms;
     }
+
+    static function getOrganizations($localize=true) {
+        global $cfg;
+        static $organizations, $names = array();
+
+        // If localization is specifically requested, then rebuild the list.
+        if (!$names || $localize) {
+            $objects = self::objects()->values_flat(
+                'id', 'name'
+            )
+            ->order_by('name');
+
+            // Fetch information for all topics, in declared sort order
+            $organizations = array();
+            foreach ($objects as $O) {
+                list($id, $name) = $O;
+                $organizations[$id] = array('name'=>$name);
+            }
+
+            $localize_this = function($id, $default) use ($localize) {
+                if (!$localize)
+                    return $default;
+
+                $tag = _H("organization.name.{$id}");
+                $O = CustomDataTranslation::translate($tag);
+                return $O != $tag ? $O : $default;
+            };
+
+            foreach ($organizations as $id=>$info) {
+                $name = $localize_this($id, $info['name']);
+                $loop = array($id=>true);
+                $names[$id] = $name;
+            }
+
+        }
+
+        // Apply requested filters
+        $requested_names = array();
+        foreach ($names as $id=>$n) {
+            $info = $organizations[$id];
+            $requested_names[$id] = $n;
+        }
+
+        return $requested_names;
+    }
+
+    static function getAllOrganizations($localize=false) {
+        return self::getOrganizations($localize);
+    }
 }
 include_once INCLUDE_DIR.'class.role.php';
 RolePermission::register(/* @trans */ 'Organizations',

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -484,9 +484,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         return $depts;
     }
 
-    function getTopicNames($publicOnly=false, $disabled=false) {
+    function getTopicNames($publicOnly=false, $disabled=false, $client=null, $isAgentView=false) {
         $allInfo = !$this->hasPerm(Dept::PERM_DEPT) ? true : false;
-        $topics = Topic::getHelpTopics($publicOnly, $disabled, true, array(), $allInfo);
+        if ($isAgentView)
+            $topics = Topic::getHelpTopics($publicOnly, $disabled, true, array(), $allInfo, false, false, $client);
+        else
+            $topics = Topic::getHelpTopics($publicOnly, $disabled, true, array(), $allInfo, true, true, $client);
         $topicsClean = array();
 
         if (!$this->hasPerm(Dept::PERM_DEPT) && $staffDepts = $this->getDepts()) {

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -57,10 +57,15 @@ implements TemplateVariable, Searchable {
                 'reverse' => 'TopicFormModel.topic',
                 'null' => true,
             ),
+            'organizations' => array(
+                'reverse' => 'TopicOrganizationModel.topic',
+                'null' => true,
+            ),
         ),
     );
 
     var $_forms;
+    var $_organizations;
 
     const DISPLAY_DISABLED = 2;
 
@@ -183,6 +188,17 @@ implements TemplateVariable, Searchable {
         return $this->_forms;
     }
 
+    function getOrganizations() {
+        if (!isset($this->_organizations)) {
+            $this->_organizations = array();
+            foreach ($this->organizations->select_related('organization') as $O) {
+                $this->_organizations[$O->organization->id] = $O->organization;
+            }
+        }
+
+        return $this->_organizations;
+    }
+
     function autoRespond() {
         return !$this->noautoresp;
     }
@@ -210,6 +226,10 @@ implements TemplateVariable, Searchable {
 
     function isPublic() {
         return ($this->ispublic);
+    }
+
+    function orgPcOnly() {
+        return ($this->orgpconly);
     }
 
     function getHashtable() {
@@ -319,25 +339,25 @@ implements TemplateVariable, Searchable {
             $this->flags &= ~$flag;
     }
 
-    static function getHelpTopics($publicOnly=false, $disabled=false, $localize=true, $whitelist=array(), $allData=false) {
+    static function getHelpTopics($publicOnly=false, $disabled=false, $localize=true, $whitelist=array(), $allData=false, $primaryContactOnly=false, $limitByOrganization=false, $client=null) {
       global $cfg;
       static $topics, $names = array();
 
       // If localization is specifically requested, then rebuild the list.
       if (!$names || $localize) {
           $objects = self::objects()->values_flat(
-              'topic_id', 'topic_pid', 'ispublic', 'flags', 'topic', 'dept_id'
+              'topic_id', 'topic_pid', 'ispublic', 'flags', 'topic', 'dept_id', 'orgpconly'
           )
           ->order_by('sort');
 
           // Fetch information for all topics, in declared sort order
           $topics = array();
           foreach ($objects as $T) {
-              list($id, $pid, $pub, $flags, $topic, $deptId) = $T;
+              list($id, $pid, $pub, $flags, $topic, $deptId, $orgpconly) = $T;
 
               $display = ($flags & self::FLAG_ACTIVE);
-              $topics[$id] = array('pid'=>$pid, 'public'=>$pub,
-                  'disabled'=>!$display, 'topic'=>$topic, 'dept_id'=>$deptId);
+              $topics[$id] = array('pid'=>$pid, 'public'=>$pub, 'dept_id'=>$deptId,
+                  'disabled'=>!$display, 'orgpconly'=>$orgpconly, 'topic'=>$topic);
           }
 
           $localize_this = function($id, $default) use ($localize) {
@@ -374,10 +394,25 @@ implements TemplateVariable, Searchable {
       $topicsClean = array();
       foreach ($names as $id=>$n) {
           $info = $topics[$id];
+          $to = TopicOrganizationModel::objects()->filter(array(
+            'topic_id'=>$id
+          ));
+          $to_org_ids=array();
+          foreach ($to as $oid=>$to_obj) {
+              array_push($to_org_ids,$to_obj->organization_id);
+          }
           if ($publicOnly && !$info['public'])
               continue;
-          //if topic is disabled + we're not getting all topics OR topic is not in whitelist
+          // If the Help Topic is protected and we are an unauthenticated user ... ignore its listing
+          if (is_null($client))
+              if ($info['orgpconly'] == 1 || $to_org_ids)
+                  continue;
+          // If topic is disabled + we're not getting all topics OR topic is not in whitelist
           if ($info['disabled'] && (!$disabled || ($whitelist && !in_array($id, $whitelist))))
+              continue;
+          if ($primaryContactOnly && $info['orgpconly'] == 1 && $client && $client->isPrimaryContact() == 0)
+              continue;
+          if ($limitByOrganization && $client && count($to) > 0 && !in_array($client->getOrganization()->id, $to_org_ids))
               continue;
           if ($disabled === self::DISPLAY_DISABLED && $info['disabled'])
               $n .= " - ".__("(disabled)");
@@ -399,8 +434,8 @@ implements TemplateVariable, Searchable {
       return $requested_names;
     }
 
-    static function getPublicHelpTopics() {
-        return self::getHelpTopics(true);
+    static function getPublicHelpTopics($client) {
+        return self::getHelpTopics(true, false, true, true, false, true, true, $client);
     }
 
     static function getAllHelpTopics($localize=false) {
@@ -482,6 +517,7 @@ implements TemplateVariable, Searchable {
         $this->page_id = $vars['page_id'] ?: 0;
         $this->isactive = $vars['isactive'];
         $this->ispublic = $vars['ispublic'];
+        $this->orgpconly = $vars['orgpconly'];
         $this->sequence_id = $vars['custom-numbers'] ? $vars['sequence_id'] : 0;
         $this->number_format = $vars['number_format'];
         $this->setFlag(self::FLAG_CUSTOM_NUMBERS, ($vars['custom-numbers']));
@@ -545,6 +581,7 @@ implements TemplateVariable, Searchable {
                 static::updateSortOrder();
             }
             $this->updateForms($vars, $errors);
+            $this->updateOrganizations($vars, $errors);
         }
         return $rv;
     }
@@ -604,6 +641,43 @@ implements TemplateVariable, Searchable {
         return true;
     }
 
+    function updateOrganizations($vars, &$errors) {
+        // Consider all the organizations in the request
+        $current = array();
+        if (is_array($vars['organizations'])) {
+            $organization_ids = $vars['organizations'];
+        } else {
+            $organization_ids = array();
+        }
+        if (is_array($organization_ids)) {
+            $organizations = TopicOrganizationModel::objects()
+                ->select_related('organization')
+                ->filter(array('topic_id' => $this->getId()));
+            foreach ($organizations as $O) {
+                if (false !== ($idx = array_search($O->organization_id, $organization_ids))) {
+                    $current[] = $O->organization_id;
+                    $O->save();
+                    unset($organization_ids[$idx]);
+                }
+                elseif ($O->organization->get('type') != 'T') {
+                    $O->delete();
+                }
+            }
+            foreach ($organization_ids as $id) {
+                if (in_array($id, $current)) {
+                    // Don't add a form more than once
+                    continue;
+                }
+                $to = new TopicOrganizationModel(array(
+                    'topic_id' => $this->getId(),
+                    'organization_id' => $id
+                ));
+                $to->save();
+            }
+        }
+        return true;
+    }
+
     function save($refetch=false) {
         if ($this->dirty)
             $this->updated = SqlFunction::NOW();
@@ -648,6 +722,22 @@ class TopicFormModel extends VerySimpleModel {
             ),
             'form' => array(
                 'constraint' => array('form_id' => 'DynamicForm.id'),
+            ),
+        ),
+    );
+}
+
+// Basic Organization Relationship Model
+class TopicOrganizationModel extends VerySimpleModel {
+    static $meta = array(
+        'table' => TOPIC_ORGANIZATION_TABLE,
+        'pk' => array('id'),
+        'joins' => array(
+            'topic' => array(
+                'constraint' => array('topic_id' => 'Topic.topic_id'),
+            ),
+            'organization' => array(
+                'constraint' => array('organization_id' => 'Organization.id'),
             ),
         ),
     );

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -404,7 +404,7 @@ implements TemplateVariable, Searchable {
           if ($publicOnly && !$info['public'])
               continue;
           // If the Help Topic is protected and we are an unauthenticated user ... ignore its listing
-          if (is_null($client))
+          if (is_null($client) && ($limitByOrganization === true || $primaryContactOnly === true))
               if ($info['orgpconly'] == 1 || $to_org_ids)
                   continue;
           // If topic is disabled + we're not getting all topics OR topic is not in whitelist

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -74,7 +74,7 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
                       });">
                 <option value="" selected="selected">&mdash; <?php echo __('Select a Help Topic');?> &mdash;</option>
                 <?php
-                if($topics=Topic::getPublicHelpTopics()) {
+                if($topics=Topic::getPublicHelpTopics($thisclient)) {
                     foreach($topics as $id =>$name) {
                         echo sprintf('<option value="%d" %s>%s</option>',
                                 $id, ($info['topicId']==$id)?'selected="selected"':'', $name);

--- a/include/i18n/en_US/help/tips/manage.helptopic.yaml
+++ b/include/i18n/en_US/help/tips/manage.helptopic.yaml
@@ -53,6 +53,20 @@ parent_topic:
         Topic will appear first in the listing with this <span
         class="doc-desc-title">Help Topic</span> listed behind the parent.
 
+allowed_organizations:
+    title: Allowed Organizations
+    content: >
+        Select which organizations can see and submit this <span
+        class="doc-desc-title">Help Topic</span>. The default is to
+        allow all organizations to see the topic.
+        
+organization_pc_only:
+    title: Primary Contacts Only
+    content: >
+        This determines whether or not a <span class="doc-desc-title">
+        Help Topic</span> is available to all users or just the 
+        primary contacts of the organization.
+
 custom_form:
     title: Custom Form
     content: >

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -108,7 +108,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                 <?php echo __('Allowed Organizations');?>:
             </td>
             <td>
-                <select name="organizations[]" id="js-organizations-allow-list" class="multi-select" data-placeholder="<?php echo __('Select'); ?>" multiple="multiple">
+                <select name="organizations[]" id="js-organizations-allow-list" data-placeholder="<?php echo __('Select'); ?>" multiple="multiple">
                     <?php $allOrganizations = Organization::getAllOrganizations();
                     foreach ($allOrganizations as $id => $name) { ?>
                         <option value="<?php echo $id; ?>"<?php echo (in_array($id,$topic_organization_ids))?'selected':''; ?>><?php echo $name; ?></option>

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -1,6 +1,7 @@
 <?php
 if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access Denied');
 $info = $qs = $forms = array();
+$topic_organization_ids=array();
 if($topic && $_REQUEST['a']!='add') {
     $title=__('Update Help Topic');
     $action='update';
@@ -11,12 +12,17 @@ if($topic && $_REQUEST['a']!='add') {
     $trans['name'] = $topic->getTranslateTag('name');
     $qs += array('id' => $topic->getId());
     $forms = $topic->getForms();
+    $topic_organizations = $topic->getOrganizations();
+    foreach ($topic_organizations as $topic_org_obj) {
+        array_push($topic_organization_ids,$topic_org_obj->id);
+    }
 } else {
     $title=__('Add New Help Topic');
     $action='create';
     $submit_text=__('Add Topic');
     // $info['isactive']=isset($info['isactive'])?$info['isactive']:1;
     $info['ispublic']=isset($info['ispublic'])?$info['ispublic']:1;
+    $info['orgpconly']=isset($info['orgpconly'])?$info['orgpconly']:0;
     $qs += array('a' => $_REQUEST['a']);
     $forms = TicketForm::objects();
 }
@@ -93,6 +99,33 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                     <?php
                     } ?>
                 </select> <i class="help-tip icon-question-sign" href="#parent_topic"></i>
+                &nbsp;<span class="error">&nbsp;<?php echo $errors['pid']; ?></span>
+            </td>
+        </tr>
+
+        <tr>
+            <td width="180">
+                <?php echo __('Allowed Organizations');?>:
+            </td>
+            <td>
+                <select name="organizations[]" class="multi-select" multiple>
+                    <?php $allOrganizations = Organization::getAllOrganizations();
+                    foreach ($allOrganizations as $id => $name) { ?>
+                        <option value="<?php echo $id; ?>" <?php echo (in_array($id,$topic_organization_ids))?'selected':''; ?>><?php echo $name; ?></option>
+                    <?php
+                    } ?>
+                </select> <i class="help-tip icon-question-sign" href="#allowed_organizations"></i>
+                &nbsp;<span class="error">&nbsp;<?php echo $errors['pid']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <td width="180">
+                <?php echo __('Primary Contacts Only');?>:
+            </td>
+            <td>
+                <input type="radio" name="orgpconly" value="1" <?php echo $info['orgpconly']?'checked="checked"':''; ?>> <?php echo __('Enforced'); ?>
+                <input type="radio" name="orgpconly" value="0" <?php echo !$info['orgpconly']?'checked="checked"':''; ?>> <?php echo __('Disabled'); ?>
+                <i class="help-tip icon-question-sign" href="#organization_pc_only"></i>
                 &nbsp;<span class="error">&nbsp;<?php echo $errors['pid']; ?></span>
             </td>
         </tr>

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -108,14 +108,20 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                 <?php echo __('Allowed Organizations');?>:
             </td>
             <td>
-                <select name="organizations[]" class="multi-select" multiple>
+                <select name="organizations[]" id="js-organizations-allow-list" class="multi-select" data-placeholder="<?php echo __('Select'); ?>" multiple="multiple">
                     <?php $allOrganizations = Organization::getAllOrganizations();
                     foreach ($allOrganizations as $id => $name) { ?>
-                        <option value="<?php echo $id; ?>" <?php echo (in_array($id,$topic_organization_ids))?'selected':''; ?>><?php echo $name; ?></option>
-                    <?php
+                        <option value="<?php echo $id; ?>"<?php echo (in_array($id,$topic_organization_ids))?'selected':''; ?>><?php echo $name; ?></option>
+                        <?php
                     } ?>
                 </select> <i class="help-tip icon-question-sign" href="#allowed_organizations"></i>
                 &nbsp;<span class="error">&nbsp;<?php echo $errors['pid']; ?></span>
+                <script type="text/javascript">
+                    $(function() {
+                        $("#js-organizations-allow-list")
+                            .select2({'minimumResultsForSearch':10, 'width': '300px'});
+                    });
+                </script>
             </td>
         </tr>
         <tr>

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -228,7 +228,7 @@ if ($_POST)
                             }
                           });">
                     <?php
-                    if ($topics=$thisstaff->getTopicNames(false, false)) {
+                    if ($topics=$thisstaff->getTopicNames(false, false, null, true)) {
                         if (count($topics) == 1)
                             $selected = 'selected="selected"';
                         else { ?>

--- a/include/upgrader/streams/core.sig
+++ b/include/upgrader/streams/core.sig
@@ -1,1 +1,1 @@
-83a22ba22b1a6a624fcb1da03882ac1b
+a35e88e0a97e4eb28eaccf47b4bb9e2c

--- a/include/upgrader/streams/core/83a22ba2-a35e88e0.patch.sql
+++ b/include/upgrader/streams/core/83a22ba2-a35e88e0.patch.sql
@@ -1,0 +1,20 @@
+-- Patch to add support for Organization restrictions
+-- for help topics. This table provides the necessary 
+-- many to many relationships needed for this feature.
+CREATE TABLE `%TABLE_PREFIX%help_topic_organization` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `organization_id` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `topic-organization` (`topic_id`,`organization_id`)
+) DEFAULT CHARSET=utf8;
+
+-- Adds the ability to restrict help topics to only the
+-- primary contact of an organization. This is used for
+-- allowing only managers, etc. access to certain topics.
+ALTER TABLE `%TABLE_PREFIX%help_topic` ADD COLUMN orgpconly tinyint(1) unsigned NOT NULL DEFAULT '0' AFTER ispublic;
+
+-- Finished with patch
+UPDATE `%TABLE_PREFIX%config`
+    SET `value` = 'a35e88e0a97e4eb28eaccf47b4bb9e2c'
+    WHERE `key` = 'schema_signature' AND `namespace` = 'core';

--- a/open.php
+++ b/open.php
@@ -28,6 +28,10 @@ if ($_POST) {
         elseif(strcmp($_SESSION['captcha'], md5(strtoupper($_POST['captcha']))))
             $errors['captcha']=sprintf('%s - %s', __('Invalid'), __('Please try again!'));
     }
+    // Do we have access to the desired Help Topic?
+    if (!in_array(intval($vars['topicId'] ?? 0), array_keys(Topic::getPublicHelpTopics($thisclient)))) {
+        $errors['topicId']=sprintf('%s - %s', __('Invalid'), __('Please try again!'));
+    }
 
     $tform = TicketForm::objects()->one()->getForm($vars);
     $messageField = $tform->getField('message');

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -3685,6 +3685,11 @@ select {
     margin-bottom: 10px;
 }
 
+select.multi-select {
+    height:100px;
+    line-height:100px;
+}
+
 a.attachment {
     padding-left: 1.2em;
     display: block;

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -3685,11 +3685,6 @@ select {
     margin-bottom: 10px;
 }
 
-select.multi-select {
-    height:100px;
-    line-height:100px;
-}
-
 a.attachment {
     padding-left: 1.2em;
     display: block;

--- a/scp/helptopics.php
+++ b/scp/helptopics.php
@@ -173,11 +173,14 @@ if($_POST){
                         break;
                     case 'delete':
                         $i=1;
+                        $h = TopicOrganizationModel::objects()->filter(array(
+                            'topic_id__in'=>$_POST['ids']
+                        ))->delete();
                         $topics = Topic::objects()->filter(array(
                             'topic_id__in'=>$_POST['ids']
                         ));
 
-                        //dont allow deletion of all topics
+                        // Don't allow deletion of all topics
                         if (($count >= $allTopics) ||
                              count($diff) == count($activeTopics)) {
                             $errors['err'] = __('At least one Topic must be Active');

--- a/setup/inc/streams/core/install-mysql.sql
+++ b/setup/inc/streams/core/install-mysql.sql
@@ -460,6 +460,7 @@ CREATE TABLE `%TABLE_PREFIX%help_topic` (
   `topic_id` int(11) unsigned NOT NULL auto_increment,
   `topic_pid` int(10) unsigned NOT NULL default '0',
   `ispublic` tinyint(1) unsigned NOT NULL default '1',
+  `orgpconly` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `noautoresp` tinyint(3) unsigned NOT NULL default '0',
   `flags` int(10) unsigned DEFAULT '0',
   `status_id` int(10) unsigned NOT NULL default '0',
@@ -484,6 +485,15 @@ CREATE TABLE `%TABLE_PREFIX%help_topic` (
   KEY `staff_id` (`staff_id`,`team_id`),
   KEY `sla_id` (`sla_id`),
   KEY `page_id` (`page_id`)
+) DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `%TABLE_PREFIX%help_topic_organization`;
+CREATE TABLE `%TABLE_PREFIX%help_topic_organization` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `organization_id` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `topic-organization` (`topic_id`,`organization_id`)
 ) DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `%TABLE_PREFIX%help_topic_form`;


### PR DESCRIPTION
This PR is based on https://github.com/osTicket/osTicket/pull/5564 by Karl Perkins (which, in turn, is based on https://github.com/osTicket/osTicket/pull/3494 by Eli Keimig).

**Changes** in regard to the last PR: 

- We made it work with the latest osTicket version.
- Replaced “each” function calls as they got deprecated in PHP 7.2 and removed in PHP 8.0.
- If a Help Topic is set to be shown only to allowed organizations or primary contacts it won’t be shown for anonymous users (validation is both frontend and backend).


The PR adds the functionality needed to enable Help Topics to be restricted to Organizations and/or Primary Contacts without affecting the existing Help Topics. 

All the changes provide additional features without **backward compatibility** issues:

- On an upgrade/new install, the default behavior of an existing Help Topic is to show it to everyone.
- The default behavior of any newly added Help Topic with no specified "Allowed Organizations" or “Primary Contacts Only” set to “no”,  is to show it to everyone.
- Because of this, you have the freedom to just ignore the new functionality if it doesn’t fit your business logic.
- The agents, when creating a new ticket for another person, see all Help Topics so they can manually assign if needed, a restricted Help Topic to a specific user’s ticket.


**How to use it?**

To use this functionality you need to add your organizations: 

![msf1](https://user-images.githubusercontent.com/2778861/215405700-90d23c1e-9abe-4bab-bbff-06bb04fbb2ae.png)

Then add/update Help Topics from the Admin Panel:

![Screenshot from 2023-01-27 08-27-24](https://user-images.githubusercontent.com/2778861/215405587-4f7bdc58-8e81-4f4f-90c2-5be7485cdd3a.png)

With the desired permissions: 

- “**Allowed Organizations**” - Select which organizations can see and submit the current Help Topic. The default is to allow all organizations to see the topic.
- “**Primary Contacts Only**” - This determines whether or not a Help Topic is available to all users or just the primary contacts of the organization.

Then, on the frontend, the specific Help Topic will either: 

- Appear: 

  - To unauthenticated users, if there are no permissions set to the Help Topic.
  - To registered users, if they are a part of an allowed organization (if “Primary Contacts Only” is set to “Disabled”).
  - To registered users, if they are a part of an allowed organization and are a primary contact for an allowed organization (if “Primary Contacts Only” was set to “Enforced”).

- Not appear:
  - To unauthenticated users, if there are any permissions set to the Help Topic.
  - To registered users, if they are not part of an allowed organization.
  - To registered users, if they are not part of an allowed organization and they are not a primary contact for any of the allowed organizations (if “Primary Contacts Only” was set to “Enforced”).

![Screenshot from 2023-01-26 11-08-33](https://user-images.githubusercontent.com/2778861/215405656-c5234623-d453-4a03-9189-85c68a411777.png)


