### PR TITLE
Added Staff features in admin panel

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1298,6 +1298,9 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         $this->phone_ext = $vars['phone_ext'];
         $this->mobile = Format::phone($vars['mobile']);
         $this->notes = Format::sanitize($vars['notes']);
+        $this->max_page_size = $vars['max_page_size'];
+        $this->auto_refresh_rate = $vars['auto_refresh_rate'];
+        $this->default_signature_type = $vars['default_signature_type'];
 
         // Set staff password if exists
         if (!$vars['welcome_email'] && $vars['passwd1']) {

--- a/include/i18n/en_US/help/tips/staff.agent.yaml
+++ b/include/i18n/en_US/help/tips/staff.agent.yaml
@@ -102,6 +102,28 @@ primary_role_on_assign:
         <span class="doc-desc-title">extended access</span> departments.
         Otherwise the agent will have view only access.
 
+max_page_size:
+    title: Maximum Page Size
+    content: >
+        Choose the number of items shown per page in the Ticket Queues in the
+        Staff Panel. Each Agent can also customize this number for their own
+        account under <span class="doc-desc-title">Profile</span>.
+
+auto_refresh_rate:
+    title: Auto Refresh Rate
+    content: >
+        Choose the default Tickets page refresh rate in minutes for this agent.<br/>
+        Each Agent can also customize the refresh rate for their own
+        account under <span class="doc-desc-title">Profile</span>.
+
+department_signature:
+    title: Department Signature
+    content: >
+        Signature is made available as a choice, for <span
+        class="doc-desc-opt">Public</span> Departments, on Agent Responses.<br/>
+        Each Agent can also customize the refresh rate for their own
+        account under <span class="doc-desc-title">Profile</span>.
+
 daylight_saving:
     title: Daylight Saving
     content: >

--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -370,7 +370,7 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info, true);
         </tr>
         <tr>
             <td colspan=2>
-                <textarea class="richtext no-bar" name="signature" cols="21"
+                <textarea class="richtext" name="signature" cols="21"
                     rows="5" style="width: 60%;"><?php echo $info['signature']; ?></textarea>
             </td>
         </tr>

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -484,7 +484,7 @@ if (($bks=Staff2FABackend::allRegistered())) {
         </tr>
         <tr>
             <td colspan="2">
-                <textarea class="richtext no-bar" name="signature" cols="21"
+                <textarea class="richtext" name="signature" cols="21"
                     rows="5" style="width: 60%;"><?php echo $staff->signature; ?></textarea>
             </td>
         </tr>

--- a/include/staff/staff.inc.php
+++ b/include/staff/staff.inc.php
@@ -225,6 +225,66 @@ if ($bks=Staff2FABackend::allRegistered() && $current = $staff->get2FABackend())
             <br/>
         </tr>
       </tbody>
+      <!-- ================================================ -->
+      <tbody>
+        <tr class="header">
+          <th colspan="2">
+            <?php echo __('Preferences'); ?>
+          </th>
+        </tr>
+        <tr>
+            <td width="180"><?php echo __('Maximum Page size');?>:</td>
+            <td>
+                <select name="max_page_size">
+                    <option value="0">&mdash; <?php echo __('system default');?> &mdash;</option>
+                    <?php
+                    $pagelimit = $staff->max_page_size ?: $cfg->getPageSize();
+                    for ($i = 5; $i <= 50; $i += 5) {
+                        $sel=($pagelimit==$i)?'selected="selected"':'';
+                         echo sprintf('<option value="%d" %s>'.__('show %s records').'</option>',$i,$sel,$i);
+                    } ?>
+                </select> <?php echo __('per page.');?>
+                &nbsp;<i class="help-tip icon-question-sign" href="#max_page_size"></i>
+            </td>
+        </tr>
+        <tr>
+            <td width="180"><?php echo __('Auto Refresh Rate');?>:</td>
+            <td>
+                <select name="auto_refresh_rate">
+                  <option value="0">&mdash; <?php echo __('Disabled');?> &mdash;</option>
+                  <?php
+                  $y=1;
+                   for($i=1; $i <=30; $i+=$y) {
+                     $sel=($staff->auto_refresh_rate==$i)?'selected="selected"':'';
+                     echo sprintf('<option value="%d" %s>%s</option>', $i, $sel,
+                        @sprintf(_N('Every minute', 'Every %d minutes', $i), $i));
+                     if($i>9)
+                        $y=2;
+                   } ?>
+                </select>
+                <em><?php echo __('(Tickets page refresh rate in minutes.)');?>
+                &nbsp;<i class="help-tip icon-question-sign" href="#auto_refresh_rate"></i></em>
+            </td>
+        </tr>
+        <tr>
+            <td width="180"><?php echo __('Default Signature');?>:</td>
+            <td>
+                <select name="default_signature_type">
+                  <option value="none" selected="selected">&mdash; <?php echo __('None');?> &mdash;</option>
+                  <?php
+                   $options=array('mine'=>__('My Signature'),'dept'=>sprintf(__('Department Signature (%s)'),
+                       __('if set' /* This is used in 'Department Signature (>if set<)' */)));
+                  foreach($options as $k=>$v) {
+                      echo sprintf('<option value="%s" %s>%s</option>',
+                                $k,($staff->default_signature_type==$k)?'selected="selected"':'',$v);
+                  }
+                  ?>
+                </select>
+                <em><?php echo __('(This can be selected when replying to a ticket)');?>
+                &nbsp;<i class="help-tip icon-question-sign" href="#department_signature"></i></em>
+            </td>
+        </tr>
+      </tbody>
     </table>
 
     <div style="padding:8px 3px; margin-top: 1.6em">

--- a/include/staff/templates/content-manage.tmpl.php
+++ b/include/staff/templates/content-manage.tmpl.php
@@ -34,7 +34,7 @@ if (count($langs) > 1) { ?>
         lang="<?php echo $cfg->getPrimaryLanguage(); ?>" />
     <div style="margin-top: 5px">
     <div class="error"><?php echo $errors['body']; ?></div>
-    <textarea class="richtext no-bar" name="body"
+    <textarea class="richtext" name="body"
         data-root-context="<?php echo $content->getType();
         ?>"><?php echo Format::htmlchars(Format::viewableImages($info['body']));
         ?></textarea>


### PR DESCRIPTION
Added some missing features to the Admin Panel when editing a member of staff. These features were available to the agent when they logged in under "Profile" but were missing on the admin panel.

This can be very handy to see what agents have set for their preferences as well as being able to change them.

Also added the ability to edit the agents signature as HTML as this was missing in the admin panel and the staff panel.

Added the ability to edit the department signature as HTML as this was also missing.

Added the ability to edit the Authentication and Registration Templates & Pages within the "Settings > Agents > Templates" screen of the admin panel as this was also missing.