### PR TITLE
Move Scroll Up overlay to the bottom on the View Ticket page.

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -3267,13 +3267,13 @@ td.indented {
     display: inline;
     background-color: #eee;
     background-color: rgba(0,0,0,0.1);
-    position: absolute;
-    top: 0px;
+    position: fixed;
+    bottom: 0px;
     right: 20px;
     padding: 8px 8px 5px;
-    border-radius: 0 0 5px 5px;
+    border-radius: 5px 5px 0 0;
     border: 1px dotted #888;
-    border-top: none;
+    border-bottom: none;
     color: #888 !important;
     box-shadow: 0 3px 8px -6px rgba(0,0,0,0.9);
   }


### PR DESCRIPTION
This has been moved to the bottom of the page as it sat over the top of the Ticket Action buttons at the top right hand side of the page.