### PR TITLE
Uncaught Error: Call to a member function getId() on bool

### DIFF
--- a/include/class.session.php
+++ b/include/class.session.php
@@ -310,6 +310,7 @@ namespace osTicket\Session {
 
         public function getRecord($id, $autocreate = false) {
             if (!isset($this->record)
+                    || !is_object($this->record)
                    // Mismatch here means new session id
                     || strcmp($id, $this->record->getId()))
                 $this->record = static::lookupRecord($id, $autocreate, $this);


### PR DESCRIPTION
To prevent following error:
PHP Fatal error: Uncaught Error: Call to a member function getId() on bool in /.../include/class.session.php:314

Logged back trace:

PHP Fatal error: Uncaught Error: Call to a member function getId() on bool in /.../include/class.session.php:314 Stack trace:
#0 /.../include/class.session.php(336): osTicket\\Session\\AbstractSessionStorageBackend->getRecord()
#1 /.../include/class.session.php(281): osTicket\\Session\\AbstractSessionStorageBackend->update()
#2 [internal function]: osTicket\\Session\\AbstractSessionHandler->write()
#3 [internal function]: session_write_close()