### PR TITLE
oauth2: Strict Matching

### DIFF
--- a/include/ajax.email.php
+++ b/include/ajax.email.php
@@ -39,4 +39,21 @@ class EmailAjaxAPI extends AjaxController {
         $template = sprintf('email-%sauth.tmpl.php', $authtype);
         include INCLUDE_DIR . "staff/templates/$template";
     }
+
+    /*
+     * Delete the OAuth2 token
+     */
+    function deleteToken($id, $type) {
+        // Check to make sure the email exists
+        if (!($email=Email::lookup($id)))
+            Http::response(404, 'Unknown Email');
+        // Get the authentication account
+        if (!($account=$email->getAuthAccount($type)))
+            Http::response(404, 'Unknown Authentication Type');
+        // Destory the account config which will delete the token
+        if ($account->destroyConfig())
+            Http::response(201, __('Token Deleted Successfully.'));
+        // Couldn't delete the Token
+        Http::response(404, 'Unable to delete token.');
+    }
 }

--- a/include/class.email.php
+++ b/include/class.email.php
@@ -1394,10 +1394,16 @@ class SmtpAccount extends EmailAccount {
  *
  */
 class EmailAccountConfig extends Config {
+    /*
+     * Get strict matching (default: true)
+     */
     public function getStrictMatching() {
-        return $this->get('strict_matching', false);
+        return $this->get('strict_matching', true);
     }
 
+    /*
+     * Set strict matching
+     */
     public function setStrictMatching($mode) {
         return $this->set('strict_matching', !!$mode);
     }

--- a/include/class.email.php
+++ b/include/class.email.php
@@ -536,7 +536,8 @@ class EmailAccount extends VerySimpleModel {
             $id = sprintf('%s:%d',
                 $this->getAuthBk(), $this->getId());
             if ($this->isOAuthAuth())
-                $id .= sprintf(':%d', $this->getAuthId());
+                $id .= sprintf(':%d:%b',
+                    $this->getAuthId(), $this->isStrict()); #TODO: Remove strict and delegate to email account
 
             $this->bkId = $id;
         }

--- a/include/class.email.php
+++ b/include/class.email.php
@@ -983,6 +983,13 @@ class EmailAccount extends VerySimpleModel {
         return $this->save();
     }
 
+    /*
+     * Destory the account config
+     */
+    function destroyConfig() {
+        return $this->getConfig()->destroy();
+    }
+
     function update($vars, &$errors) {
         return false;
     }
@@ -1010,7 +1017,7 @@ class EmailAccount extends VerySimpleModel {
 
     function delete() {
         // Destroy the Email config
-        $this->getConfig()->destroy();
+        $this->destroyConfig();
         // Delete the Plugin instance
         if ($this->isOAuthAuth() && ($i=$this->getOAuth2Instance()))
             $i->delete();

--- a/include/class.oauth2.php
+++ b/include/class.oauth2.php
@@ -95,6 +95,10 @@ namespace osTicket\OAuth2 {
             return $this->hasExpired();
         }
 
+        public function isMatch($email, $strict=false) {
+            return !$strict ? true : (strcasecmp($this->getResourceOwnerEmail(), $email) === 0);
+        }
+
         public function getAuthRequest() {
             if ($this->hasExpired())
                 throw new Exception('Access Token is Expired');

--- a/include/i18n/en_US/help/tips/emails.email.yaml
+++ b/include/i18n/en_US/help/tips/emails.email.yaml
@@ -170,3 +170,12 @@ header_spoofing:
         This advanced setting is generally used when sending mail from
         aliases of this mail box.
 
+strict_matching:
+    title: Strict Email Matching
+    content: >
+        <b>Enable</b> this option to require the Email Address and the Token's Resource Owner to match.
+        This is useful for preventing accidental authorization of a completely different account.
+        <br><br>
+        <b>Disable</b> this option to allow a different Resource Owner for the Token than the Email
+        Address. This is useful for Shared Mailboxes/Aliases/etc. where you need to use a Service
+        Account or Global Admin to authorize on behalf of the email.

--- a/include/staff/templates/email-oauth2auth.tmpl.php
+++ b/include/staff/templates/email-oauth2auth.tmpl.php
@@ -189,8 +189,17 @@ $(function() {
               url: 'ajax.php/' + $(this).attr('href').substr(1),
               type: 'POST',
               success: function(json) {
-                  $.toggleOverlay(false);
-                  $('#popup').hide();
+                  // Remove the Token tab completely
+                  $('#popup a[href="#token"]').parent().remove();
+                  $('#popup div#token').remove();
+                  // Add success banner
+                  $('#popup form').before('<div id="msg_notice">'+json+'</div>');
+                  // Load the IdP tab
+                  $('#popup a[href="#idp"]').click();
+              },
+              error: function(json) {
+                  // Add error banner
+                  $('#popup form').before('<div id="msg_error">'+json.responseText+'</div>');
               }
             });
         }

--- a/include/staff/templates/email-oauth2auth.tmpl.php
+++ b/include/staff/templates/email-oauth2auth.tmpl.php
@@ -14,7 +14,7 @@ $info = Format::htmlchars(($errors && $_POST)
         ? array_merge($info, $_POST) : $info, true);
 $action = sprintf('#email/%d/auth/config/%s/%s',
         $email->getId(), $type, $auth);
-$email = $account->getEmail()->email;
+$addr = $account->getEmail()->email;
 ?>
 <h3><?php echo __('OAuth2 Authorization'); ?></h3>
 <b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
@@ -84,7 +84,7 @@ if (isset($errors['err'])) {
                     <input size="35" type="text" autofocus
                         name="name"
                         disabled="disabled"
-                        value="<?php echo $email; ?>"/>&nbsp;
+                        value="<?php echo $addr; ?>"/>&nbsp;
                     <input type="checkbox" name="strict_matching"
                         <?php if ($info['strict_matching']) echo 'checked="checked"'; ?>>
                     &nbsp;<?php echo __('Strict Matching'); ?>

--- a/include/staff/templates/email-oauth2auth.tmpl.php
+++ b/include/staff/templates/email-oauth2auth.tmpl.php
@@ -123,7 +123,14 @@ if (isset($errors['err'])) {
                      __('Expired Access Token gets auto-refreshed on use'));
         }
         ?>
-        <table class="form_table" width="940" border="0" cellspacing="0" cellpadding="2">
+        <a class="red button action-button pull-right" style="margin-bottom:8px;"
+            id="token-delete" data-toggle="tooltip"
+            href="<?php echo sprintf('#email/%d/auth/config/%s/delete', $email->getId(), $type); ?>"
+            title="Delete" data-original-title="Delete">
+                <i class="icon-trash"></i>&nbsp;<?php echo __('Delete Token'); ?>
+        </a>
+        <div class="clear"></div>
+        <table class="form_table" width="100%" border="0" cellspacing="0" cellpadding="2">
         <thead>
             <tr>
                 <th colspan="2">
@@ -173,3 +180,21 @@ if (isset($errors['err'])) {
     </span>
 </p>
 </form>
+<script type="text/javascript">
+$(function() {
+    $('#oauth-tabs_container').on('click', 'a#token-delete', function(e) {
+        e.preventDefault();
+        if (confirm(__('Are you sure?'))) {
+            $.ajax({
+              url: 'ajax.php/' + $(this).attr('href').substr(1),
+              type: 'POST',
+              success: function(json) {
+                  $.toggleOverlay(false);
+                  $('#popup').hide();
+              }
+            });
+        }
+        return false;
+    });
+});
+</script>

--- a/include/staff/templates/email-oauth2auth.tmpl.php
+++ b/include/staff/templates/email-oauth2auth.tmpl.php
@@ -14,6 +14,7 @@ $info = Format::htmlchars(($errors && $_POST)
         ? array_merge($info, $_POST) : $info, true);
 $action = sprintf('#email/%d/auth/config/%s/%s',
         $email->getId(), $type, $auth);
+$email = $account->getEmail()->email;
 ?>
 <h3><?php echo __('OAuth2 Authorization'); ?></h3>
 <b><a class="close" href="#"><i class="icon-remove-circle"></i></a></b>
@@ -51,20 +52,11 @@ if (isset($errors['err'])) {
         <thead>
             <tr>
                 <th colspan="2">
-                    <em><?php echo __('Name and Status'); ?></em>
+                    <em><?php echo __('General Settings'); ?></em>
                 </th>
             </tr>
         </thead>
         <tbody>
-            <tr>
-                <td width="180" class="required"><?php echo __('Name'); ?>:</td>
-                <td>
-                    <input size="50" type="text" autofocus
-                        name="name"
-                        value="<?php echo $info['name']; ?>"/>
-                    <span class="error">*<br/> <?php echo  $errors['name']; ?></span>
-                </td>
-            </tr>
             <tr>
                 <td width="180" class="required"><?php echo __('Status'); ?>:</td>
                 <td><select name="isactive">
@@ -75,6 +67,29 @@ if (isset($errors['err'])) {
                         ?>><?php echo $desc; ?></option>
                     <?php } ?>
                     </select>
+                </td>
+            </tr>
+            <tr>
+                <td width="180" class="required"><?php echo __('Name'); ?>:</td>
+                <td>
+                    <input size="50" type="text" autofocus
+                        name="name"
+                        value="<?php echo $info['name']; ?>"/>
+                    <span class="error">*<br/> <?php echo  $errors['name']; ?></span>
+                </td>
+            </tr>
+            <tr>
+                <td width="180"><b><?php echo __('Email Address'); ?>:</b></td>
+                <td>
+                    <input size="35" type="text" autofocus
+                        name="name"
+                        disabled="disabled"
+                        value="<?php echo $email; ?>"/>&nbsp;
+                    <input type="checkbox" name="strict_matching"
+                        <?php if ($info['strict_matching']) echo 'checked="checked"'; ?>>
+                    &nbsp;<?php echo __('Strict Matching'); ?>
+                    <i class="help-tip icon-question-sign" href="#strict_matching"></i>
+                    <span class="error"><br/> <?php echo $errors['name']; ?></span>
                 </td>
             </tr>
         </tbody>

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -316,6 +316,7 @@ $dispatcher = patterns('',
     )),
     url('^/email', patterns('ajax.email.php:EmailAjaxAPI',
         url_post('^/(?P<id>\d+)/stash$', 'stashFormData'),
+        url_post('^/(?P<id>\d+)/auth/config/(?P<type>\w+)/delete$', 'deleteToken'),
         url('^/(?P<id>\d+)/auth/config/(?P<type>\w+)/(?P<auth>.+)$', 'configureAuth'),
     ))
 );


### PR DESCRIPTION
This is a rewrite of osTicket/osTicket-plugins#263 where it was attempting to implement Strict Matching. This fully implements Strict Matching and adds functionality to check for this when retrieving a token and when saving SMTP with Same As Remote Mailbox. This also adds a new disabled field to the General Settings to show what email will be used as well as a help tip that further explains Strict Matching.