### PR TITLE
PHP Plugin Dependencies

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -721,7 +721,8 @@ class Plugin extends VerySimpleModel {
     function getInstallDate() { return $this->get('installed'); }
     function getInstallPath() { return $this->get('install_path'); }
     function getNotes() { return $this->get('notes') ?: $this->info['description']; }
-
+    function getPhpDependency() { return $this->get('phpDependency', $this->info['phpDependency']); }
+    
     function getStatus() {
         return __($this->isActive() ? 'Active' : 'Disabled');
     }

--- a/include/staff/plugin.inc.php
+++ b/include/staff/plugin.inc.php
@@ -30,24 +30,24 @@ $info= Format::htmlchars(($errors && $_POST) ? $_POST : array(), true);
                 $phpDep = $plugin->getPhpDependency();
 
                 if(!empty($phpDep)) {
-                        if(strpos($phpDep, ',') !==false) {
-                                // loop here and check each one.  If any fail report them back.
-                                $deps = explode(',',$phpDep);
-                                foreach ($deps as $dep) {
-                                        if(!extension_loaded($dep)) {
-                                                //TODO: combine all reports into a single log entry
-                                                $message = 'Required PHP Extension: '.$dep.' is not loaded!';
-                                                echo '<tr><td colspan="2"><span style="padding-left:20px;color:red;"> '.$message.'</span></td></tr>';
-                                                $ost->logError('Plugin: '.$plugin->getName(),$message, false);
-                                        }
+                    if(strpos($phpDep, ',') !==false) {
+                        // loop here and check each one.  If any fail report them back.
+                           $deps = explode(',',$phpDep);
+                           foreach ($deps as $dep) {
+                               if(!extension_loaded($dep)) {
+                                   //TODO: combine all reports into a single log entry
+                                   $message = 'Required PHP Extension: '.$dep.' is not loaded!';
+                                   echo '<tr><td colspan="2"><span style="padding-left:20px;color:red;"> '.$message.'</span></td></tr>';
+                                   $ost->logError('Plugin: '.$plugin->getName(),$message, false);
                                 }
-                        } else {
-                                if(!extension_loaded($phpDep)) {
-                                        $message = 'Required PHP Extension: '.$phpDep.' is not loaded!';
-                                        echo '<tr><td colspan="2"><span style="padding-left:20px;color:red;"> '.$message.'</span></td></tr>';
-                                        $ost->logError('Plugin: '.$plugin->getName(),$message, false);
-                                }
-                        }
+                             }
+                     } else {
+                         if(!extension_loaded($phpDep)) {
+                             $message = 'Required PHP Extension: '.$phpDep.' is not loaded!';
+                             echo '<tr><td colspan="2"><span style="padding-left:20px;color:red;"> '.$message.'</span></td></tr>';
+                             $ost->logError('Plugin: '.$plugin->getName(),$message, false);
+                         }
+                     }
                 } ?>
             <tr>
                 <th colspan="2">

--- a/include/staff/plugin.inc.php
+++ b/include/staff/plugin.inc.php
@@ -26,6 +26,29 @@ $info= Format::htmlchars(($errors && $_POST) ? $_POST : array(), true);
         <input type="hidden" name="id" value="<?php echo $plugin->getId(); ?>">
         <table class="form_table" width="940" border="0" cellspacing="0" cellpadding="2">
         <thead>
+            <?php
+                $phpDep = $plugin->getPhpDependency();
+
+                if(!empty($phpDep)) {
+                        if(strpos($phpDep, ',') !==false) {
+                                // loop here and check each one.  If any fail report them back.
+                                $deps = explode(',',$phpDep);
+                                foreach ($deps as $dep) {
+                                        if(!extension_loaded($dep)) {
+                                                //TODO: combine all reports into a single log entry
+                                                $message = 'Required PHP Extension: '.$dep.' is not loaded!';
+                                                echo '<tr><td colspan="2"><span style="padding-left:20px;color:red;"> '.$message.'</span></td></tr>';
+                                                $ost->logError('Plugin: '.$plugin->getName(),$message, false);
+                                        }
+                                }
+                        } else {
+                                if(!extension_loaded($phpDep)) {
+                                        $message = 'Required PHP Extension: '.$phpDep.' is not loaded!';
+                                        echo '<tr><td colspan="2"><span style="padding-left:20px;color:red;"> '.$message.'</span></td></tr>';
+                                        $ost->logError('Plugin: '.$plugin->getName(),$message, false);
+                                }
+                        }
+                } ?>
             <tr>
                 <th colspan="2">
                     <em><?php echo __('Plugin Information'); ?></em>


### PR DESCRIPTION
This PR:
- requires all plugins include PHP dependencies in their plugin.php in a comma separated format in 'phpDependency '
example: /include/plugins/pluginName/plugin.php
circa line 16: after map closes, insert a new line.

'phpDependency' =>  'ldapl',
or
'phpDependency' =>  'ldapl,dremel,jedi',

- osTicket will check to make sure the PHP dependency is enabled.  If not, will display an error message with the missing dependency name when you go to configure the plugin.
- Also logs the error to osTicket logs.
