### PR TITLE
ContentAjaxAPI::log conflicts AjaxController::log

### DIFF
--- a/include/ajax.content.php
+++ b/include/ajax.content.php
@@ -19,7 +19,7 @@ require_once INCLUDE_DIR.'class.ajax.php';
 
 class ContentAjaxAPI extends AjaxController {
 
-    function log($id) {
+    function log_vars($id) {
 
         if($id && ($log=Log::lookup($id))) {
             $content=sprintf('<div

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -41,7 +41,7 @@ $dispatcher = patterns('',
         url_get('^faq/(?P<id>\d+)$', 'faq')
     )),
     url('^/content/', patterns('ajax.content.php:ContentAjaxAPI',
-        url_get('^log/(?P<id>\d+)', 'log'),
+        url_get('^log/(?P<id>\d+)', 'log_vars'),
         url_get('^context$', 'context'),
         url_get('^ticket_variables', 'ticket_variables'),
         url_get('^signature/(?P<type>\w+)(?:/(?P<id>\d+))?$', 'getSignature'),


### PR DESCRIPTION
When viewing "System logs"  entries details popup window is empty and there is a corresponding php error log :

_PHP Fatal error:  Declaration of ContentAjaxAPI::log($id) must be compatible with ApiController::log($title, $msg, $level = LOG_WARN) in /var/www/osticket/web.1.17.git/include/ajax.content.php on line 22_

class ContentAjaxAPI extends AjaxController {
    function **log(**$id) {