### PR TITLE
issue: Department Export

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -604,7 +604,7 @@ implements TemplateVariable, Searchable {
                 return true;
     }
 
-    function export($dept, $criteria=null, $filename='') {
+    static function export($dept, $criteria=null, $filename='') {
         include_once(INCLUDE_DIR.'class.error.php');
         $members = $dept->getMembers();
 


### PR DESCRIPTION
This addresses a small issue where when attempting to export Agents in any Department you get a fatal error of calling non-static method statically. This updates the export method for the Department class to static so that exports will function and no errors are thrown.