### PR TITLE
issue: getRealPath() Stub

### DIFF
--- a/setup/test/tests/stubs.php
+++ b/setup/test/tests/stubs.php
@@ -243,6 +243,7 @@ class HashPassword {
 
 class SplFileObject {
     function fseek() {}
+    function getRealPath() {}
 }
 
 class AuditEntry {


### PR DESCRIPTION
This addresses an issue where lint tests fails due to `getRealPath()` not being defined. This is from SplFileObject so we just need to add a stub to ignore it in the tests.