### PR TITLE
issue: Thread Entry Actions z-index

### DIFF
--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -16,7 +16,7 @@ if ($user && $cfg->isAvatarsEnabled())
 
 ?>
 <div class="thread-entry <?php
-    echo $entry->isSystem() ? 'system' : $entryTypes[$entry->type]; ?> <?php if ($avatar) echo 'avatar'; ?>" style="position:relative">
+    echo $entry->isSystem() ? 'system' : $entryTypes[$entry->type]; ?> <?php if ($avatar) echo 'avatar'; ?>" style="position:relative;z-index:auto;">
 <?php if ($avatar) { ?>
     <span class="<?php echo ($entry->type == 'M') ? 'pull-right' : 'pull-left'; ?> avatar">
 <?php echo $avatar; ?>


### PR DESCRIPTION
This addresses a small annoyance where the thread entry actions dropdown always appears below the subsequent thread entry. This can be very annoying and even hide some of the options. This adds `z-index` of `auto` to the `thread-entry` div so that the dropdown always appears on top.