### PR TITLE
oauth2: Strict Matching Bug

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -1346,6 +1346,7 @@ class SmtpAccount extends EmailAccount {
         // matching.
         if ($vars['smtp_active'] == 1
                 && ($vars['smtp_auth_bk'] === 'mailbox')
+                && (strpos($vars['auth_bk'], 'oauth2') === 0)
                 && !$this->checkStrictMatching())
             $_errors['smtp_auth_bk'] = sprintf('%s and %s', __('Resource Owner'), __('Email Mismatch'));
 


### PR DESCRIPTION
This addresses an issue where we were checking strict matching when using basic authentication. This is due to a small oversight in the smtp save checks. This adds a line to check if auth_bk is set to oauth2 before checking strict matching.