### PR TITLE
issue: File Upload Type

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3910,10 +3910,11 @@ class FileUploadField extends FormField {
         return $F;
     }
 
-    static function isValidFile($file) {
-        // Make sure mime type is valid
-        if (strcasecmp(FileObject::mime_type($file['tmp_name']),
-                    $file['type']) !== 0)
+    static function isValidFile($file, $strict=false) {
+        // If strict check mime type
+        if ($strict
+                &&!empty($file['type'])
+                && strcasecmp(FileObject::mime_type($file['tmp_name']), $file['type']) !== 0)
             return false;
 
         // Check invalid image hacks


### PR DESCRIPTION
This addresses an issue where uploading a file throws an Invalid File error even though the file is valid and there are no file restrictions. This is due to doing `strcasecmp()` on a variable that is some times empty. This adds a check to see if that variable has a value before doing the comparison to avoid false positives. In addition, this adds a new paramter called `$strict` that if true we run the mime type check. By default `$strict` is false which skips the check. We will eventually add a configurable setting to enable strict mime type check if preferred.