### PR TITLE
Fix PR #6283: DB column value of "local backend" is 'client' and not 'local'

### DIFF
--- a/pwreset.php
+++ b/pwreset.php
@@ -22,7 +22,7 @@ if($_POST) {
                     $banner = __('Password reset is not enabled for your account. Contact your administrator');
                 }
                 elseif (!$acct->hasPassword()
-                        || (($bk=$acct->backend) && ($bk !== 'local')))
+                        || (($bk=$acct->backend) && ($bk !== 'client')))
                     $banner = __('Unable to reset password. Contact your administrator');
                 elseif ($acct->sendResetEmail()) {
                     $inc = 'pwreset.sent.php';


### PR DESCRIPTION
PR #6283 make it impossible for users to reset their password.
They now receive the error: **"Unable to reset password. Contact your administrator"**

This is because, in table `ost_user` the `backend` field contains `client` and not `local` for local authentication backend...

NOTE: this issue was already pointed out by other users here:
https://github.com/osTicket/osTicket/commit/06e334fa89c755a133023f2afe0ce36ca92dfae3