### PR TITLE
issue: i18n Audit Exports

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2286,7 +2286,7 @@ class Event extends VerySimpleModel {
     static function getStates($dropdown=false) {
         $names = array();
         if ($dropdown)
-            $names = array(__('All'));
+            $names = array('All');
 
         $events = self::objects()->values_flat('name');
         foreach ($events as $val)


### PR DESCRIPTION
This addresses an issue where attempting to use `All` Event type in any other language than English the export will fail. This removes the translation method from `All` so that the English version is used for the option's `key`. This doesn't affect the visible word as it gets translated downstream.