### PR TITLE
Set focus to search field on canned response selection

### DIFF
--- a/include/client/profile.inc.php
+++ b/include/client/profile.inc.php
@@ -98,3 +98,12 @@ $selected = ($info['lang'] == $l['code']) ? 'selected="selected"' : ''; ?>
         window.location.href='index.php';"/>
 </p>
 </form>
+<script type="text/javascript">
+    // set focus to select2:search_field
+    $('form select').on('select2:open', function (e) {
+      var select2 = $(e.target).data('select2');
+      if (!select2.options.get('multiple')) {
+        select2.dropdown.$search.get(0).focus();
+      }
+    });
+</script>

--- a/include/staff/templates/merge-tickets.tmpl.php
+++ b/include/staff/templates/merge-tickets.tmpl.php
@@ -317,6 +317,9 @@ $(document).ready(function() {
         var value = $("#delete-child").prop("checked") ? 1 : 0;
         (value == 1) ? $('#savewarning').show() : $('#savewarning').hide();
     }
+    if (typeof set_select2_focus === "function") {
+        set_select2_focus();
+    }
 });
 </script>
 

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -212,14 +212,6 @@ var scp_prep = function() {
             redactor.api('selection.save');
     });
 
-    // set focus to select2:search_field
-    $('form select#cannedResp').on('select2:open', function (e) {
-        const select2 = $(e.target).data('select2');
-        if (!select2.options.get('multiple')) {
-            select2.dropdown.$search.get(0).focus();
-        }
-    });
-
     $('form select#cannedResp').change(function() {
 
         var fObj = $(this).closest('form');
@@ -549,6 +541,17 @@ var scp_prep = function() {
       });
     });
   });
+  set_select2_focus();
+};
+
+var set_select2_focus = function() {
+    // set focus to select2:search_field
+    $('form select').on('select2:open', function (e) {
+      var select2 = $(e.target).data('select2');
+      if (!select2.options.get('multiple')) {
+        select2.dropdown.$search.get(0).focus();
+      }
+    });
 };
 
 $(document).ready(scp_prep);

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -212,6 +212,14 @@ var scp_prep = function() {
             redactor.api('selection.save');
     });
 
+    // set focus to select2:search_field
+    $('form select#cannedResp').on('select2:open', function (e) {
+        const select2 = $(e.target).data('select2');
+        if (!select2.options.get('multiple')) {
+            select2.dropdown.$search.get(0).focus();
+        }
+    });
+
     $('form select#cannedResp').change(function() {
 
         var fObj = $(this).closest('form');


### PR DESCRIPTION
Since jQuery is updated to 3.6.x, there is no focus set to the search field into the select2 dropdown field, where you can search your canned responses. So you have to click in it on every ticket resonse, using canned responses.

This pull request will set the focus again...