### PR TITLE
Fix inline images not showing in FAQ/canned response editor

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -598,6 +598,20 @@ class Format {
         }, $html);
     }
 
+    // Same as Format::viewableImages() but specialized for content encoded with Format::htmlchars()
+    static function viewableImagesSpecial($html, $options=array()) {
+        $cids = $images = array();
+        $options +=array(
+                'disposition' => 'inline');
+        return preg_replace_callback('/&quot;cid:([\w._-]{32})&quot;/',
+        function($match) use ($options, $images) {
+            if (!($file = AttachmentFile::lookup($match[1])))
+                return $match[0];
+
+            $attributes = sprintf('"%s" data-cid="%s"', $file->getDownloadUrl($options), $match[1]);
+            return Format::htmlchars($attributes, false);
+        }, $html);
+    }
 
     /**
      * Thanks, http://us2.php.net/manual/en/function.implode.php

--- a/include/staff/cannedresponse.inc.php
+++ b/include/staff/cannedresponse.inc.php
@@ -8,9 +8,7 @@ if($canned && $_REQUEST['a']!='add'){
     $info=$canned->getInfo();
     $info['id']=$canned->getId();
     $qs += array('id' => $canned->getId());
-    // Replace cid: scheme with downloadable URL for inline images
-    $info['response'] = $canned->getResponseWithImages();
-    $info['notes'] = Format::viewableImages($info['notes']);
+    $info['response'] = $canned->getResponse();
 }else {
     $title=__('Add New Canned Response');
     $action='create';
@@ -20,6 +18,9 @@ if($canned && $_REQUEST['a']!='add'){
 }
 $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
 
+// Replace cid: scheme with downloadable URL for inline images
+$info['response'] = Format::viewableImagesSpecial($info['response']);
+$info['notes'] = Format::viewableImagesSpecial($info['notes']);
 ?>
 <form action="canned.php?<?php echo Http::build_query($qs); ?>" method="post" class="save" enctype="multipart/form-data">
  <?php csrf_token(); ?>

--- a/include/staff/faq.inc.php
+++ b/include/staff/faq.inc.php
@@ -11,8 +11,8 @@ if($faq && $faq->getId()){
     $info=$faq->getHashtable();
     $info['id']=$faq->getId();
     $info['topics']=$faq->getHelpTopicsIds();
-    $info['answer']=Format::viewableImages($faq->getAnswer());
-    $info['notes']=Format::viewableImages($faq->getNotes());
+    $info['answer']=$faq->getAnswer();
+    $info['notes']=$faq->getNotes();
     $qs += array('id' => $faq->getId());
     $langs = $cfg->getSecondaryLanguages();
     $translations = $faq->getAllTranslations();
@@ -22,7 +22,7 @@ if($faq && $faq->getId()){
                 $trans = $t->getComplex();
                 $info['trans'][$tag] = array(
                     'question' => $trans['question'],
-                    'answer' => Format::viewableImages($trans['answer']),
+                    'answer' => $trans['answer'],
                 );
                 break;
             }
@@ -39,6 +39,15 @@ if($faq && $faq->getId()){
 }
 //TODO: Add attachment support.
 $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
+
+// Replace cid: scheme with downloadable URL for inline images
+$info['answer'] = Format::viewableImagesSpecial($info['answer']);
+$info['notes'] = Format::viewableImagesSpecial($info['notes']);
+foreach ($langs as $tag) {
+    $answer = &$info['trans'][$tag]['answer'];
+    $answer = Format::viewableImagesSpecial($answer);
+}
+
 $qstr = Http::build_query($qs);
 ?>
 <form action="faq.php?<?php echo $qstr; ?>" method="post" class="save" enctype="multipart/form-data">


### PR DESCRIPTION
Format::htmlchars() was called on contents handed over to HTML editor. This would remove the image URLs to file.php. This fix keeps the file.php URLs intact making the image preview work while editing FAQs and canned responses.