### PR TITLE
issue: Duplicate User Copy/Paste Import

### DIFF
--- a/include/class.import.php
+++ b/include/class.import.php
@@ -189,7 +189,7 @@ implements Iterator {
             foreach ($this->headers as $h => $label) {
                 $f = $this->fields[$h];
                 $f->_errors = array();
-                $T = $f->parse($csv[$i]);
+                $T = $f->parse(trim($csv[$i]));
                 if ($f->validateEntry($T) && $f->errors())
                     throw new ImportDataError(sprintf(__(
                         /* 1 will be a field label, and 2 will be error messages */


### PR DESCRIPTION
This addresses an issue where the Copy/Paste Import feature for Users sometimes creates a duplicate account for an existing User. This occurs when using a string like `User Name, email@domain.tld`, however, does not occur when using a string like `User Name,email@domain.tld`. This is due to the extra space after the comma as we are not trimming extra spaces correctly. This adds `trim()` to the values before they are used so that they correctly match existing values and avoids duplicates.