### PR TITLE
issue: Inline-Images Canned Responses

### DIFF
--- a/scp/canned.php
+++ b/scp/canned.php
@@ -71,11 +71,8 @@ if ($_POST) {
                 $canned->attachments->keepOnlyFileIds($keepers, false);
 
                 // Attach inline attachments from the editor
-                if (isset($_POST['draft_id'])
-                        && ($draft = Draft::lookup($_POST['draft_id']))) {
-                    $images = Draft::getAttachmentIds($_POST['response']);
-                    $canned->attachments->keepOnlyFileIds($images, true);
-                }
+                $images = Draft::getAttachmentIds($_POST['response']);
+                $canned->attachments->keepOnlyFileIds($images, true);
 
                 // XXX: Handle nicely notifying a user that the draft was
                 // deleted | OR | show the draft for the user on the name
@@ -104,10 +101,8 @@ if ($_POST) {
                     $premade->attachments->upload($keepers);
 
                 // Attach inline attachments from the editor
-                if (isset($_POST['draft_id'])
-                        && ($draft = Draft::lookup($_POST['draft_id'])))
-                    $premade->attachments->upload(
-                        Draft::getAttachmentIds($_POST['response']), true);
+                $premade->attachments->upload(
+                    Draft::getAttachmentIds($_POST['response']), true);
 
                 // Delete this user's drafts for new canned-responses
                 Draft::deleteForNamespace('canned', $thisstaff->getId());


### PR DESCRIPTION
This addresses an issue where inline images only used in canned responses and saved before a draft could be generated would erroneously be deleted by the orphan file cleanup routine. This caused the inline images to appear broken on use as they no longer exist. This is due to a check for a `draft_id` before creating an attachment record for each inline file. We do not need to check for a `draft_id` as we always have a `response` in the POST with the most current data (eg. there might be content added before a new draft can be saved). This removes the checks in both `create` and `update` cases so that attachment records can be created (with `inline = 1`) to avoid being deleted by file cleanup.