### PR TITLE
issue: Remove Old Login Code

### DIFF
--- a/login.php
+++ b/login.php
@@ -147,9 +147,6 @@ if (!$nav) {
     $nav->setActiveNav('status');
 }
 
-// Browsers shouldn't suggest saving that username/password
-Http::response(422);
-
 require CLIENTINC_DIR.'header.inc.php';
 require CLIENTINC_DIR.$inc;
 require CLIENTINC_DIR.'footer.inc.php';

--- a/scp/login.php
+++ b/scp/login.php
@@ -131,9 +131,6 @@ elseif ($thisstaff && $thisstaff->isValid()) {
     Http::redirect($dest);
 }
 
-// Browsers shouldn't suggest saving that username/password
-Http::response(422);
-
 define("OSTSCPINC",TRUE); //Make includes happy!
 include_once(INCLUDE_DIR.'staff/login.tpl.php');
 ?>


### PR DESCRIPTION
This removes old and tired code from the login pages where we throw `Http::response(422);` to "prevent browsers from suggesting saving the username and password". This is no longer the case as browsers no longer play by these rules. The only way to properly do this nowadays is to set an attribute on the form (or input) tag to disable autocomplete. We don't want to do this either as that would prevent password managers from autofilling the auth info.

Throwing a 422 code prevents some setups from accepting logins due to 4XX codes being error codes in nature. Removing this code seemingly has no negative impact whatsoever.

A short backstory, this was [originally a 401 code](https://github.com/osTicket/osTicket/commit/a99b9ce81ed2de174460bff0c74e348fe30408c8) to prevent browsers from suggesting saving the auth info. Later it was [changed to a 422 code](https://github.com/osTicket/osTicket/commit/772d5c59a976ee9103448a9075c23d6a99afb34e) to make IE play nice.