### PR TITLE
Made that own plugin applications can be registered again and no exce…

### DIFF
--- a/include/class.app.php
+++ b/include/class.app.php
@@ -23,7 +23,7 @@ class Application {
     private static $staff_apps;
     private static $admin_apps;
 
-    function registerStaffApp($desc, $href, $info=array()) {
+    static function registerStaffApp($desc, $href, $info=array()) {
         self::$staff_apps[] = array_merge($info,
             array('desc'=>$desc, 'href'=>$href));
     }
@@ -32,7 +32,7 @@ class Application {
         return self::$staff_apps;
     }
 
-    function registerClientApp($desc, $href, $info=array()) {
+    static function registerClientApp($desc, $href, $info=array()) {
         self::$client_apps[] = array_merge($info,
             array('desc'=>$desc, 'href'=>$href));
     }
@@ -41,7 +41,7 @@ class Application {
         return self::$client_apps;
     }
 
-    function registerAdminApp($desc, $href, $info=array()) {
+    static function registerAdminApp($desc, $href, $info=array()) {
         self::$admin_apps[] = array_merge($info,
             array('desc'=>$desc, 'href'=>$href));
     }


### PR DESCRIPTION
Linking own plugin applications was no longer possible, because the method was not static.

This fix makes it possible to register custom plugin applications again:
![grafik](https://github.com/osTicket/osTicket/assets/45294783/7b3636c6-09e5-4ac9-a8d5-fc7a2f8fb1fb)
