### PR TITLE
issue: strftime() Deprecation

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -2035,7 +2035,7 @@ class TicketsAjaxAPI extends AjaxController {
             } else {
                 $filename = sprintf('%s Tickets-%s.csv',
                         $queue->getName(),
-                        strftime('%Y%m%d'));
+                        date('Ymd'));
             }
 
             try {

--- a/include/class.export.php
+++ b/include/class.export.php
@@ -259,7 +259,7 @@ class Export {
 
         // Filename or stream to export agents to
         $filename = $filename ?: sprintf('Agents-%s.csv',
-                strftime('%Y%m%d'));
+                date('Ymd'));
         Http::download($filename, "text/$how");
         $depts = Dept::getDepartments(null, true, Dept::DISPLAY_DISABLED);
         echo self::dumpQuery($agents, array(
@@ -296,7 +296,7 @@ static function departmentMembers($dept, $agents, $filename='', $how='csv') {
 
     // Filename or stream to export depts' agents to
     $filename = $filename ?: sprintf('%s-%s.csv', $dept->getName(),
-            strftime('%Y%m%d'));
+            date('Ymd'));
     Http::download($filename, "text/$how");
     echo self::dumpQuery($agents, array(
                 '::getName'  =>  'Name',

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -756,6 +756,7 @@ class Format {
         if ($cfg && $cfg->isForce24HourTime())
             $format = str_replace('X', 'R', $format);
 
+        // TODO: Deprecated; replace this soon
         return strftime($format, $timestamp);
     }
 

--- a/include/staff/templates/queue-export.tmpl.php
+++ b/include/staff/templates/queue-export.tmpl.php
@@ -8,7 +8,7 @@ if (isset($cache['filename']))
 else
     $filename = trim(sprintf('%s Tickets - %s.csv',
             Format::htmlchars($queue->getName() ?: ''),
-            strftime('%Y%m%d')));
+            date('Ymd')));
 
 if (isset($cache['delimiter']))
     $delimiter = $cache['delimiter'];

--- a/scp/dashboard.php
+++ b/scp/dashboard.php
@@ -21,7 +21,7 @@ if ($_POST['export']) {
     $report = new OverviewReport($_POST['start'], $_POST['period']);
     switch (true) {
     case ($data = $report->getTabularData($_POST['export'])):
-        $ts = strftime('%Y%m%d');
+        $ts = date('Ymd');
         $group = Format::slugify($_POST['export']);
         $delimiter = ',';
         if (class_exists('NumberFormatter')) {

--- a/scp/orgs.php
+++ b/scp/orgs.php
@@ -99,7 +99,7 @@ if ($_POST) {
     }
 } elseif (!$org && $_REQUEST['a'] == 'export') {
     require_once(INCLUDE_DIR.'class.export.php');
-    $ts = strftime('%Y%m%d');
+    $ts = date('Ymd');
     if (!($query=$_SESSION[':Q:orgs']))
         $errors['err'] = __('Query token not found');
     elseif (!Export::saveOrganizations($query, __('organizations')."-$ts.csv", 'csv'))
@@ -119,7 +119,7 @@ if ($org) {
             return;
         } elseif ($_REQUEST['a'] == 'export' && ($query=$_SESSION[':O:tickets'])) {
             $filename = sprintf('%s-tickets-%s.csv',
-                    $org->getName(), strftime('%Y%m%d'));
+                    $org->getName(), date('Ymd'));
             if (!Export::saveTickets($query, NULL, $filename, 'csv'))
                 $errors['err'] = __('Unable to dump query results.')
                     .' '.__('Internal error occurred');

--- a/scp/tasks.php
+++ b/scp/tasks.php
@@ -231,7 +231,7 @@ if($task) {
             $thisstaff->hasPerm(Task::PERM_CREATE, false))
         $inc = 'task-open.inc.php';
     elseif($_REQUEST['a'] == 'export') {
-        $ts = strftime('%Y%m%d');
+        $ts = date('Ymd');
         if (!($query=$_SESSION[':Q:tasks']))
             $errors['err'] = __('Query token not found');
         elseif (!Export::saveTasks($query, "tasks-$ts.csv", 'csv'))

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -540,7 +540,7 @@ if($ticket) {
       require_once(sprintf('phar:///%s/plugins/audit.phar/class.audit.php', INCLUDE_DIR));
       $show = AuditEntry::$show_view_audits;
       $filename = sprintf('%s-audits-%s.csv',
-              $ticket->getNumber(), strftime('%Y%m%d'));
+              $ticket->getNumber(), date('Ymd'));
       $tableInfo = AuditEntry::getTableInfo($ticket, true);
       if (!Export::audits('ticket', $filename, $tableInfo, $ticket, 'csv', $show))
           $errors['err'] = __('Unable to dump query results.')

--- a/scp/users.php
+++ b/scp/users.php
@@ -178,7 +178,7 @@ if ($_POST) {
     }
 } elseif(!$user && $_REQUEST['a'] == 'export') {
     require_once(INCLUDE_DIR.'class.export.php');
-    $ts = strftime('%Y%m%d');
+    $ts = date('Ymd');
     if (!($query=$_SESSION[':Q:users']))
         $errors['err'] = __('Query token not found');
     elseif (!Export::saveUsers($query, __("users")."-$ts.csv", 'csv'))
@@ -198,7 +198,7 @@ if ($user ) {
             return;
         } elseif ($_REQUEST['a'] == 'export' && ($query=$_SESSION[':U:tickets'])) {
             $filename = sprintf('%s-tickets-%s.csv',
-                    $user->getName(), strftime('%Y%m%d'));
+                    $user->getName(), date('Ymd'));
             if (!Export::saveTickets($query, '', $filename, 'csv'))
                 $errors['err'] = __('Unable to dump query results.')
                     .' '.__('Internal error occurred');


### PR DESCRIPTION
This replaces the now deprecated `strftime()` with `date()`. This also adds a TODO to class Format to replace an instance there. It will need some refactoring though so we are leaving it out of this commit.