### PR TITLE
issue: glob() Empty Array

### DIFF
--- a/include/cli/modules/deploy.php
+++ b/include/cli/modules/deploy.php
@@ -87,7 +87,7 @@ class Deployment extends Unpacker {
                     $root, $recurse - 1, $exclude);
             }
         }
-        if (!$contents || !glob($destination.'{,.}*', GLOB_BRACE|GLOB_NOSORT)) {
+        if (!$contents || !empty(glob($destination.'{,.}*', GLOB_BRACE|GLOB_NOSORT))) {
             if ($verbose)
                 $this->stdout->write("(delete-folder): $destination\n");
             if (!$dryrun)


### PR DESCRIPTION
With PHP 8.2 `glob()` now returns an empty array if all paths are restricted instead of `false`. This updates the only check we have on this to check for empty array instead.