### PR TITLE
issue: Email Only Attachment

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -545,8 +545,12 @@ class Mail_Parse {
             return $files;
         }
 
-        if($part==null)
+        if($part==null) {
             $part=$this->getStruct();
+            if (!$part->parts)
+                if($result=$this->getAttachments($part))
+                    $files=array_merge($files,$result);
+        }
 
         if($part->parts){
             foreach($part->parts as $k=>$p){


### PR DESCRIPTION
This addresses an issue where emails that contain only attachment(s) fail to process correctly. This is due to there being no `parts` for `$part`. This adds a check for `!$part->parts` and if true (no parts) we call `getAttachments()` on just the `$part` itself.