### PR TITLE
installer: Change Email

### DIFF
--- a/include/i18n/en_US/templates/ticket/installed.yaml
+++ b/include/i18n/en_US/templates/ticket/installed.yaml
@@ -8,8 +8,8 @@
 ---
 deptId: 1 # support
 topicId: 1 # support
-name: osTicket Support
-email: support@osticket.com
+name: osTicket Team
+email: feedback@osticket.com
 source: Web # notrans
 subject: osTicket Installed!
 message: |
@@ -21,10 +21,10 @@ message: |
     href="https://osticket.com">mailing list</a> to stay up to date
     on the latest news, security alerts and updates. The osTicket forums are
     also a great place to get assistance, guidance, tips, and help from
-    other osTicket users.  In addition to the forums, the osTicket wiki
-    provides a useful collection of educational materials, documentation,
-    and notes from the community. We welcome your contributions to the
-    osTicket community.
+    other osTicket users.  In addition to the forums, the <a
+    href="https://docs.osticket.com">osTicket Docs</a> provides a useful
+    collection of educational materials, documentation, and notes from the
+    community. We welcome your contributions to the osTicket community.
     </p><p>
     If you are looking for a greater level of support, we provide
     professional services and commercial support with guaranteed response
@@ -43,7 +43,7 @@ message: |
     Cheers,
     </p><p>
     -<br/>
-    osTicket Team https://osticket.com/
+    osTicket Team - https://osticket.com/
     </p><p>
     <strong>PS.</strong> Don't just make customers happy, make happy
     customers!

--- a/include/i18n/en_US/templates/ticket/upgraded.yaml
+++ b/include/i18n/en_US/templates/ticket/upgraded.yaml
@@ -7,8 +7,8 @@
 #
 ---
 source: Web # notrans
-name: osTicket Support
-email: support@osticket.com
+name: osTicket Team
+email: feedback@osticket.com
 subject: osTicket Upgraded!
 message: |
     <p>


### PR DESCRIPTION
This updates the email included in the intial installation Ticket to `feedback[at]osticket.com`. This also updates the Ticket information to include details about the documentation site.