### PR TITLE
issue: putenv() Disabled

### DIFF
--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -776,7 +776,9 @@ class TextDomain {
             return;
 
         // Define locale for C-libraries
-        putenv('LC_ALL=' . $info['code']);
+        // Check if putenv() is available - some hosts disable it
+        if (function_exists('putenv'))
+            putenv('LC_ALL=' . $info['code']);
         self::setLocale(LC_ALL, $info['code']);
     }
 


### PR DESCRIPTION
This addresses issue #6564 where `putenv()` may be disabled on some hosts. This adds a check to make sure the function exists before calling it to avoid fatal errors.