### PR TITLE
Missing Check for Ticket Transfer Agent Release

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2673,7 +2673,7 @@ implements RestrictedAccess, Threadable, Searchable {
             // currently assigned agent (if any)
             if ($this->isAssigned()
                 && ($staff=$this->getStaff())
-                && $dept->assignMembersOnly()
+                && ( $dept->assignMembersOnly() || $dept->assignPrimaryOnly() ) // Should fire if Department is set to Members Only or Primary Only
                 && !$dept->isMember($staff)
             ) {
                 $this->staff_id = 0;


### PR DESCRIPTION
Tickets were remaining assigned to agents when they weren't part of the destination department. 
This happens on departments that are set for `Ticket Assignment: Primary Members`

I found this to be because the transfer function only checked if 
ticket is assigned
able to get staff assigned to ticket
department set to members only
agent not member of department

The check needs to be for both possibilities.