### PR TITLE
Separate Claim from Assign

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -865,7 +865,7 @@ class TicketsAjaxAPI extends AjaxController {
             Http::response(404, __('No such ticket'));
 
         // Check for premissions and such
-        if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_ASSIGN)
+        if (!$ticket->checkStaffPerm($thisstaff, Ticket::PERM_CLAIM)
                 || !$ticket->isOpen() // Claim only open
                 || $ticket->getStaff() // cannot claim assigned ticket
                 || !($form = $ticket->getClaimForm($_POST)))

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -108,6 +108,7 @@ implements RestrictedAccess, Threadable, Searchable {
     const PERM_CREATE   = 'ticket.create';
     const PERM_EDIT     = 'ticket.edit';
     const PERM_ASSIGN   = 'ticket.assign';
+    const PERM_CLAIM    = 'ticket.claim';
     const PERM_RELEASE  = 'ticket.release';
     const PERM_TRANSFER = 'ticket.transfer';
     const PERM_REFER    = 'ticket.refer';
@@ -139,6 +140,11 @@ implements RestrictedAccess, Threadable, Searchable {
                 /* @trans */ 'Assign',
                 'desc'  =>
                 /* @trans */ 'Ability to assign tickets to agents or teams'),
+            self::PERM_CLAIM => array(
+                'title' =>
+                /* @trans */ 'Claim',
+                'desc'  =>
+                /* @trans */ 'Ability to claim tickets for themself'),
             self::PERM_RELEASE => array(
                 'title' =>
                 /* @trans */ 'Release',

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -115,12 +115,12 @@ if($ticket->isOverdue())
 
             <?php
             // Assign
-            if ($ticket->isOpen() && $role->hasPerm(Ticket::PERM_ASSIGN)) {?>
+            if ($ticket->isOpen() && ( $role->hasPerm(Ticket::PERM_ASSIGN) || $role->hasPerm(Ticket::PERM_CLAIM) ))  {?>
             <span class="action-button pull-right"
                 data-dropdown="#action-dropdown-assign"
                 data-placement="bottom"
                 data-toggle="tooltip"
-                title=" <?php echo $ticket->isAssigned() ? __('Assign') : __('Reassign'); ?>"
+                title=" <?php echo $ticket->isAssigned() ? __('Reassign') : __('Assign'); ?>"
                 >
                 <i class="icon-caret-down pull-right"></i>
                 <a class="ticket-action" id="ticket-assign"
@@ -130,18 +130,27 @@ if($ticket->isOverdue())
             <div id="action-dropdown-assign" class="action-dropdown anchor-right">
               <ul>
                 <?php
+                // Count Option Types Displayed
+                $assignDropdownItems = 0;
                 // Agent can claim team assigned ticket
                 if (!$ticket->getStaff()
-                        && (!$dept->assignMembersOnly()
-                            || $dept->isMember($thisstaff))
-                        ) { ?>
+                    && ( 
+                        ($dept->assignMembersOnly() && $dept->isMember($thisstaff)) 
+                        || ($dept->assignPrimaryOnly() && $dept->isPrimaryMember($thisstaff))
+                    ) 
+                ){ 
+                    $assignDropdownItems++;
+                ?>
                  <li><a class="no-pjax ticket-action"
                     data-redirect="tickets.php?id=<?php echo
                     $ticket->getId(); ?>"
                     href="#tickets/<?php echo $ticket->getId(); ?>/claim"><i
                     class="icon-chevron-sign-down"></i> <?php echo __('Claim'); ?></a>
                 <?php
-                } ?>
+                } 
+                if ($role->hasPerm(Ticket::PERM_ASSIGN)) {
+                    $assignDropdownItems++;
+                ?>
                  <li><a class="no-pjax ticket-action"
                     data-redirect="tickets.php"
                     href="#tickets/<?php echo $ticket->getId(); ?>/assign/agents"><i
@@ -150,6 +159,15 @@ if($ticket->isOverdue())
                     data-redirect="tickets.php"
                     href="#tickets/<?php echo $ticket->getId(); ?>/assign/teams"><i
                     class="icon-group"></i> <?php echo __('Team'); ?></a>
+                <?php
+                }
+                if($assignDropdownItems==0){
+                ?>
+                  <li><span><i
+                    class="icon-info-sign"></i> <?php echo __('No Actions Possible'); ?></span>
+                <?php
+                }
+                ?>
               </ul>
             </div>
             <?php

--- a/scp/css/dropdown.css
+++ b/scp/css/dropdown.css
@@ -29,7 +29,8 @@
   margin: 0;
   line-height: 18px;
 }
-.action-dropdown ul li > a, .noclick-dropdown ul li > a {
+.action-dropdown ul li > a, .noclick-dropdown ul li > a,
+.action-dropdown ul li > span, .noclick-dropdown ul li > span{
   display: block;
   color: #555;
   text-decoration: none;


### PR DESCRIPTION
Add Checkbox for Claim on Roles Setup. Change ajax.tickets claim function to use new Claim permission. Allow Claiming on individual tickets using the Assign dropdown, but only showing options based on role permissions.