### PR TITLE
Add option to specify php binary used for deployment

### DIFF
--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -19,6 +19,10 @@ class Unpacker extends Module {
              code in that folder. The folder will be automatically created if
              it doesn't already exist."
         ),
+        'php' => array('-p','--php', 'metavar'=>'/path/to/php', 'help'=>
+            "Location of php binary to use, helpful if multiple php versions are
+             installed on machine."
+        ),
         'verbose' => array('-v','--verbose', 'default'=>false, 'nargs'=>0,
             'action'=>'store_true', 'help'=>
             "Move verbose logging to stdout"),
@@ -204,7 +208,11 @@ class Unpacker extends Module {
             return $location;
 
         $pipes = array();
-        $php = proc_open('php', array(
+        $php = $this->getOption('php');
+        if (!empty($php) && !is_executable($php))
+            die("PHP binary specified not found\n");
+
+        $php = proc_open($php ?: 'php', array(
             0 => array('pipe', 'r'),
             1 => array('pipe', 'w'),
         ), $pipes);


### PR DESCRIPTION
On plesk server, deployment fails as 'php' does not point to a valid binary. `/opt/plesk/php/<PHP version>/bin/php` needs to be used.

Add option to use specify location of php binary, e.g.

```sh
/opt/plesk/php/8.2/bin/php manage.php deploy -v --php=/opt/plesk/php/8.2/bin/php /var/www/vhosts/example.com/
```