### PR TITLE
issue: CDATA NULL Values

### DIFF
--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -304,7 +304,7 @@ function db_real_escape($val, $quote=false) {
     //Magic quotes crap is taken care of in main.inc.php
     $val=$__db->real_escape_string($val);
 
-    return ($quote)?"'$val'":$val;
+    return ($quote && !empty($val))?"'$val'":$val;
 }
 
 function db_input($var, $quote=true) {


### PR DESCRIPTION
This addresses an issue reported on the Forum where `Has A Value` Queue criteria for a Short Answer field (and potentially other field types) is showing results without values. A recent patch causes empty values in the CDATA table to be `''` (empty string) instead of actual `NULL`.  In SQL, `IS NOT NULL` checks against `NULL` explicitly. This means an empty string will appear with `IS NOT NULL` criteria as it's not NULL.  This updates the code to only quote values that are not empty. Empty values should remain as `NULL`.