### PR TITLE
Fix: assigned team gets no alerts if also assigned to agent

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3228,7 +3228,7 @@ implements RestrictedAccess, Threadable, Searchable {
             if ($cfg->alertAssignedONNewMessage() && $ticket->isAssigned()) {
                 if ($staff = $ticket->getStaff())
                     $recipients[] = $staff;
-                elseif ($team = $ticket->getTeam())
+                if ($team = $ticket->getTeam())
                     $recipients = array_merge($recipients, $team->getMembersForAlerts());
             }
 


### PR DESCRIPTION
If a ticket is assigned to a team and to a specific agent at the same time then the team gets no alerts when a client posts a new message to the ticket.