### PR TITLE
mailer: Undefined SmtpAccount::getName()

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -552,6 +552,10 @@ class EmailAccount extends VerySimpleModel {
         return $this->email;
     }
 
+    public function getName() {
+        return $this->getEmail()->getName();
+    }
+
     public function getAccessToken() {
         $cred = $this->getFreshCredentials();
         return $cred ? $cred->getAccessToken($this->getConfigSignature()) : null;

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -593,7 +593,7 @@ class Mailer {
                             // get Account Email
                             (string) $smtpAccount->getEmail()->getEmail(),
                             // Try to keep the name if available
-                            $this->getFromName() ?: $smtpAccount->getName());
+                            $this->getFromName() ?: $smtpAccount->getName() ?: $this->getEmail());
                 }
                 // Attempt to send the Message.
                 if (($smtp=$smtpAccount->getSmtpConnection())


### PR DESCRIPTION
This addresses an issue where when attempting to send mail from an SmtpAccount we attempt to get the From name with `getName()` which throws a fatal error. This updates class EmailAccount and adds a new `getName()` method that gets the From name from the associated email relation. This provides the needed name and prevents fatal error from being thrown. In addition, this adds a further fail-safe where if no name is returned we will use the email address as the name.