### PR TITLE
issue: SystemSessionHandler

### DIFF
--- a/include/class.session.php
+++ b/include/class.session.php
@@ -68,7 +68,7 @@ namespace osTicket\Session {
             } else {
                 // local handler is being used force this namespace
                 $handler = sprintf('%s\%s', __NAMESPACE__, $backend);
-                $impl = 'AbstractSessionhandler';
+                $impl = ($bk == 'system') ? 'SystemSessionHandler' : 'AbstractSessionHandler';
             }
 
             // Make sure handler / backend class exits
@@ -544,7 +544,7 @@ namespace osTicket\Session {
      * Use this session handler when you don't care about session data.
      *
      */
-    class NoopSessionStorageBackend extends AbstractSessionhandler {
+    class NoopSessionStorageBackend extends AbstractSessionHandler {
         public function read($id) {
             return "";
         }


### PR DESCRIPTION
This addresses an issue where if using an old database such as v1.6 ST and attempting to upgrade you get a fatal error of `osTicket\Session\SystemSessionHandler: must implement osTicket\Session\AbstractSessionhandler`. This is because the `SystemSessionHandler` class does not extend `AbstractSessionHandler` (rightfully so). We seemingly force `AbstractSessionHandler` without taking the `SystemSessionHandler` into account. This adds a check to see if using `SystemSessionHandler` and if so sets `$impl` as such; allowing the check to pass and the session to be initiated. This also updates the capitalization of the `AbstractSessionhandler` class in two places.