### PR TITLE
issue: Status List Overflow

### DIFF
--- a/include/staff/templates/status-options.tmpl.php
+++ b/include/staff/templates/status-options.tmpl.php
@@ -47,7 +47,7 @@ if (!$nextStatuses)
 </span>
 <div id="action-dropdown-statuses"
     class="action-dropdown anchor-right">
-    <ul>
+    <ul <?php if (count($nextStatuses) > 20) echo 'style="height:500px;overflow-y:scroll"'; ?>>
 <?php foreach ($nextStatuses as $status) { ?>
         <li>
             <a class="no-pjax <?php


### PR DESCRIPTION
This addresses an issue where having more than 20 ticket statuses run off the page when selecting ticket statuses from Changes Status action button. This adds a check for how many status you have an if more than 20 we add styling so the list is scrollable.