### PR TITLE
patches: Latest 10/03/2023

### DIFF
--- a/include/ajax.search.php
+++ b/include/ajax.search.php
@@ -188,10 +188,15 @@ class SearchAjaxAPI extends AjaxController {
                         'root' => 'T',
                         'staff_id' => $thisstaff->getId()
                         ));
+            $new = true;
         }
 
         if (false === $this->_saveSearch($search))
             return;
+
+        //store saved search count when it is created
+        if ($new)
+            $search->counts($thisstaff, false);
 
         $info = array(
                 'msg' => sprintf('%s %s %s',

--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -78,7 +78,7 @@ class TicketApiController extends ApiController {
             $data['attachments'] = array();
 
         //Validate attachments: Do error checking... soft fail - set the error and pass on the request.
-        if ($data['attachments'] && is_array($data['attachments'])) {
+        if (isset($data['attachments']) && is_array($data['attachments'])) {
             foreach($data['attachments'] as &$file) {
                 if ($file['encoding'] && !strcasecmp($file['encoding'], 'base64')) {
                     if(!($file['data'] = base64_decode($file['data'], true)))

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -253,7 +253,7 @@ class ApiController extends Controller {
                 return $this->exerr(415, __('Unsupported data format'));
         }
 
-        if (!($data = $parser->parse($stream))) {
+        if (!($data = $parser->parse($stream)) || !is_array($data)) {
             $this->exerr(400, $parser->lastError());
         }
 

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1164,6 +1164,7 @@ class AdvancedSearchSelectionField extends ChoiceField {
         switch ($method) {
             case 'includes':
             case '!includes':
+                if (!$value) return;
                 $Q = new Q();
                 if (count($value) > 1)
                     $Q->add(array("{$name}__in" => array_keys($value)));

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -897,8 +897,8 @@ implements TemplateVariable {
             // a response to an existing thread entry
             if ($ost)
                 $ost->log(LOG_ERR, _S('Email loop detected'), sprintf(
-                _S('It appears as though %s is being used as a forwarded or fetched email account and is also being used as a user / system account. Please correct the loop or seek technical assistance.'),
-                $mailinfo['email']),
+                _S('It appears as though %s is being used as a forwarded or fetched email account and is also being used as a user / system account. Please correct the loop or seek technical assistance.\n\n%s'),
+                $mailinfo['email'], $mailinfo['header']),
 
                 // This is quite intentional -- don't continue the loop
                 false,

--- a/include/staff/templates/org-profile.tmpl.php
+++ b/include/staff/templates/org-profile.tmpl.php
@@ -150,7 +150,7 @@ if ($ticket && $ticket->getOwnerId() == $user->getId())
                     <?php echo __('Auto Add Members From'); ?>:
                 </td>
                 <td>
-                    <input type="text" size="40" maxlength="60" name="domain"
+                    <input type="text" size="40" maxlength="256" name="domain"
                         value="<?php echo $info['domain']; ?>" />
                     <br/><span class="error"><?php echo $errors['domain']; ?></span>
                 </td>

--- a/include/staff/templates/schedule-holidays.tmpl.php
+++ b/include/staff/templates/schedule-holidays.tmpl.php
@@ -1,6 +1,6 @@
 <?php
 //  Holidays schedules
-$holidays = $_POST ? $_POST['holidays'] : ($schedule->getHolidays() ?:
+$holidays = $_POST && isset($_POST['holidays']) ? $_POST['holidays'] : ($schedule->getHolidays() ?:
         array());
 $schedules = HolidaysSchedule::getSchedules();
 //    ->order_by('name')
@@ -18,7 +18,7 @@ $schedules = HolidaysSchedule::getSchedules();
                 <td>
                     <input type="checkbox" name="holidays[]"
                         value="<?php echo $id; ?>"
-                        <?php echo in_array($id, $holidays) ?
+                        <?php echo in_array($id, $holidays ?: []) ?
                         'checked="checked"' : ''; ?>
                         class="schedule-holiday nowarn"/>
                     &nbsp;


### PR DESCRIPTION
This is a pull containing recent small patches we've aggregated since last release. This includes the following:
- Adding code to store a Saved Search count on creation.
- Addresses an issue where sometimes attachments can sometimes not be set in the `$data` array.
- Addresses an issue where sometimes the returned `$data` from the parser can be a type other than an array.
- Addresses an issue where sometimes an Agent will add Search criteria with `!includes` but don't add a value.
- Adds code to append the offending mail headers when an Email Loop is detected.
- Adds the concept of Retry Codes so we can attempt to reconnect to MySQL in the event of certain error codes (2006 and 1213).
- Adds a small patch that increases the Auto Add Members From input max length from 60 to 256 to allow more domains.
- Fixes an issue where sometimes the holidays for schedules can be empty.