### PR TITLE
issue: Choice/Selection Field Searches

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1917,7 +1917,7 @@ class SelectionField extends FormField {
         $name = $name ?: $this->get('name');
         $val = $value;
         if ($value && is_array($value))
-            $val = '"?'.implode('("|,|$)|"?', array_keys($value)).'("|,|$)';
+            $val = '"?(?<![0-9])'.implode('("|,|$)|"?(?<![0-9])', array_keys($value)).'("|,|$)';
         switch ($method) {
         case '!includes':
             return Q::not(array("{$name}__regex" => $val));

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2085,7 +2085,7 @@ class ChoiceField extends FormField {
         $name = $name ?: $this->get('name');
         $val = $value;
         if ($value && is_array($value))
-            $val = '"?'.implode('("|,|$)|"?', array_keys($value)).'("|,|$)';
+            $val = '"?(?<![0-9])'.implode('("|,|$)|"?(?<![0-9])', array_keys($value)).'("|,|$)';
         switch ($method) {
         case '!includes':
             return Q::not(array("{$name}__regex" => $val));


### PR DESCRIPTION
This addresses a small issue where when searching for a Choice/Selection Field value using `includes` criteria it sometimes shows records it's not supposed to. This is due to the REGEX used to find the value. Let's say you have two different List Options:
1. ID = 2 | Value = List Item 2
2. ID = 22 | Value = List Item 22

Now, let’s say you make a search criteria of `List => Includes => List Item 2`. The REGEX we use is `\"?2(\"|,|$)` which will essentially match `*2` instead of just `2`. This means it will include Tickets with with values of `List Item 22` as it contains a `2` as well.

This updates the REGEX to add `(?<![0-9])` before the ID/Key to ensure it does not match numbers that contain this ID/Key. Instead it will have to be an exact match of the ID/Key.