### PR TITLE
issue: Canned Response Inline Images

### DIFF
--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -120,10 +120,11 @@ extends InstrumentedList {
         }
         $attachments = array();
         // Format $new for upload() with new name
-        foreach ($ids as $id=>$name) {
+        foreach ($ids as $id=>$value) {
+            if (is_array($value)) list('id' => $id, 'name' => $value) = $value;
             $attachments[] = array(
                     'id' => $id,
-                    'name' => $name
+                    'name' => $value
                 );
         }
         // Everything remaining in $attachments is truly new

--- a/include/class.draft.php
+++ b/include/class.draft.php
@@ -81,6 +81,7 @@ class Draft extends VerySimpleModel {
             foreach ($files as $F) {
                 $attachments[] = array(
                     'id' => $F->getId(),
+                    'name' => $F->getName(),
                     'inline' => true
                 );
             }

--- a/include/staff/cannedresponse.inc.php
+++ b/include/staff/cannedresponse.inc.php
@@ -95,7 +95,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                 <?php
                 $attachments = $canned_form->getField('attachments');
                 if ($canned && $attachments) {
-                    $attachments->setAttachments($canned->attachments);
+                    $attachments->setAttachments($canned->attachments->window(['inline' => false]));
                 }
                 print $attachments->render(); ?>
                 <br/>


### PR DESCRIPTION
This addresses an issue where saving edits made to a canned response with two or more inline images either breaks the page or causes 500 error. This is due to incorrectly formatted array of IDs for the inline images causing further issues with `$att->file->getId()` on render.

This adds a check in `keepOnlyFileIds()` to see if the `$value` from the array of IDs is an array itself. If so, we will break apart the `$value` array into `$id` (File ID) => `$value` (File Name) to match the expected format. If the `$value` is not an array, it will use the existing format (as before). This is important as we have two different array formats for the File IDs depending on what method is called to generate them. We need to be able to account for both formats. In addition, this adds the file name to the `$attachment` array in `getAttachmentIds()` so we can save the new attachment name (if different).

Lastly, this fixes an issue where the Canned Response attachment upload field was blindly including all attachments rather than excluding the inline images.