### PR TITLE
format: Viewable Images Bug

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -588,9 +588,7 @@ class Format {
         $cids = $images = array();
         $options +=array(
                 'disposition' => 'inline');
-        if ($format)
-            $html = Format::htmlchars($html, true);
-        return preg_replace_callback('/("|&quot;)cid:([\w._-]{32})("|&quot;)/',
+        $html = preg_replace_callback('/("|&quot;)cid:([\w._-]{32})("|&quot;)/',
         function($match) use ($options, $images) {
             if (!($file = AttachmentFile::lookup($match[2])))
                 return $match[0];
@@ -598,6 +596,7 @@ class Format {
             return sprintf('"%s" data-cid="%s"',
                 $file->getDownloadUrl($options), $match[2]);
         }, $html);
+        return $format ? Format::htmlchars($html, true) : $html;
     }
 
 


### PR DESCRIPTION
This addresses a small bug where `Format::viewableImages()` was using unencoded quotes instead of encoded quotes to replace the `<img src=` matches. This means when the content is added to a textarea’s `draft-data-original` attribute the unencoded quotes break the attribute and displays raw HTML content. This moves the `Format::htmlchars()` call after the `preg_replace_callback()` so the quotes can be properly encoded (if needed).