### PR TITLE
i18n: Tasks Department ID Missing

### DIFF
--- a/include/staff/tasks.inc.php
+++ b/include/staff/tasks.inc.php
@@ -152,7 +152,7 @@ $tasks->annotate(array(
     ),
 ));
 
-$tasks->values('id', 'number', 'created', 'staff_id', 'team_id',
+$tasks->values('id', 'number', 'created', 'staff_id', 'dept_id', 'team_id',
         'staff__firstname', 'staff__lastname', 'team__name',
         'dept__name', 'cdata__title', 'flags', 'ticket__number', 'ticket__ticket_id');
 // Apply requested quick filter


### PR DESCRIPTION
This addresses a small issue where the Department Name is not translated on the Task Queues. This is due to the Task values missing the Department ID used to generate the object_hash for the translation table. This adds the `dept_id` to the Task Values so the translations are properly found.