### PR TITLE
issue: Checkbox Template Variable

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1789,6 +1789,10 @@ class BooleanField extends FormField {
         return ($value) ? __('Yes') : __('No');
     }
 
+    function asVar($value, $id=false) {
+        return $this->toString($value);
+    }
+
     function getClean($validate=true) {
         if (!isset($this->_clean)) {
             $this->_clean = (isset($this->value))


### PR DESCRIPTION
This addresses an issue where when using a Checkbox on an Email Template the variable is replaced with `1` if checked and doesn't get replaced at all if unchecked. This is due to the `BooleanField` class not having an `asVar()` method so it uses the `FormField::asVar()` method which calls `to_php()`. This method returns an integer for BooleanField which is not what we want. This adds a new method called `asVar()` to the `BooleanField` class that calls `toString()` which will return `Yes` if checked and `No` if unchecked.