### PR TITLE
Fix ajax path for addRemoteCollaborator

### DIFF
--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -244,7 +244,7 @@ $dispatcher = patterns('',
         url_get('^(?P<tid>\d+)/collaborators/(?P<manage>\d+)$', 'showCollaborators'),
         url_post('^(?P<tid>\d+)/collaborators$', 'updateCollaborators'),
         url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/(?P<uid>\d+)$', 'addCollaborator'),
-        url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/auth:(?P<bk>\w+):(?P<id>.+)$', 'addRemoteCollaborator'),
+        url_get('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)/auth:(?P<bk>[\w.]+):(?P<id>.+)$', 'addRemoteCollaborator'),
         url('^(?P<tid>\d+)/add-collaborator/(?P<type>\w+)$', 'addCollaborator'),
         url_get('^(?P<tid>\d+)/collaborators/(?P<cid>\d+)/view$', 'viewCollaborator'),
         url_post('^(?P<tid>\d+)/collaborators/(?P<cid>\d+)$', 'updateCollaborator')


### PR DESCRIPTION
The plugin instance is in format %s.%s as evident from the following line.

https://github.com/osTicket/osTicket/blob/4689926b2d3d25754f0ddcf8d4e181a2817f6d56/include/class.util.php#L367

As a result we have to allow dot in the URL pattern matching, otherwise there is no match and adding remote collaborators doesn't work.