### PR TITLE
Fix raw mail content generation

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -515,7 +515,7 @@ namespace osTicket\Mail {
          *
          */
         public function getRawEmail(int $i) {
-            return $this->getRawHeader($i) . $this->getRawContent($i);
+            return $this->getRawHeader($i) . "\r\n\r\n" . $this->getRawContent($i);
         }
 
         /*

--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -515,7 +515,7 @@ namespace osTicket\Mail {
          *
          */
         public function getRawEmail(int $i) {
-            return $this->getRawHeader($i) . "\r\n\r\n" . $this->getRawContent($i);
+            return trim($this->getRawHeader($i)) . "\r\n\r\n" . $this->getRawContent($i);
         }
 
         /*


### PR DESCRIPTION
Ensure proper splitting of mail headers and mail body using "\r\n\r\n" or "\n\n" as delimiters.