### PR TITLE
issue: fix square characters being printed when printing tickets that's using languages like Thai

### DIFF
--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -74,7 +74,7 @@ class Ticket2PDF extends mPDFWithLocalImages
         $this->includenotes = $notes;
         $this->includeevents = $events;
 
-	parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir()]);
+	      parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir(), 'autoLangToFont' => true, 'autoScriptToLang' => true]);
 
         $this->_print();
 	}
@@ -115,7 +115,7 @@ class Task2PDF extends mPDFWithLocalImages {
         $this->task = $task;
         $this->options = $options;
 
-        parent::__construct(['mode' => 'utf-8', 'format' => $this->options['psize'], 'tempDir'=>sys_get_temp_dir()]);
+        parent::__construct(['mode' => 'utf-8', 'format' => $this->options['psize'], 'tempDir'=>sys_get_temp_dir(), 'autoLangToFont' => true, 'autoScriptToLang' => true]);
         $this->_print();
     }
 

--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -74,7 +74,7 @@ class Ticket2PDF extends mPDFWithLocalImages
         $this->includenotes = $notes;
         $this->includeevents = $events;
 
-	      parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir(), 'autoLangToFont' => true, 'autoScriptToLang' => true]);
+        parent::__construct(['mode' => 'utf-8', 'format' => $psize, 'tempDir'=>sys_get_temp_dir(), 'autoLangToFont' => true, 'autoScriptToLang' => true]);
 
         $this->_print();
 	}
@@ -98,7 +98,7 @@ class Ticket2PDF extends mPDFWithLocalImages
             return;
         $html = ob_get_clean();
 
-        $this->autoScriptToLang;
+        $this->autoScriptToLang = true;
         $this->WriteHtml($html, 0, true, true);
     }
 }
@@ -128,7 +128,7 @@ class Task2PDF extends mPDFWithLocalImages {
         ob_start();
         include STAFFINC_DIR.'templates/task-print.tmpl.php';
         $html = ob_get_clean();
-        $this->autoScriptToLang;
+        $this->autoScriptToLang = true;
         $this->WriteHtml($html, 0, true, true);
 
     }


### PR DESCRIPTION
Tested on a fresh install of osTicket version 1.18.1

Before adding the mpdf init options, the Thai characters are printed as square brackets:
![image](https://github.com/osTicket/osTicket/assets/87350788/590d63fa-c577-45f0-b2d5-f24c052f3c1a)

After:
![image](https://github.com/osTicket/osTicket/assets/87350788/fffd8904-e5b2-4632-af8e-93166013b30b)
