### PR TITLE
issue: Position Styling.. Again

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -335,7 +335,7 @@ class Format {
                   ':<(a|span) (name|style)="(mso-bookmark\:)?_MailEndCompose">(.+)?<\/(a|span)>:', # Drop _MailEndCompose
                   ':<div dir=(3D)?"ltr">(.*?)<\/div>(.*):is', # drop Gmail "ltr" attributes
                   ':data-cid="[^"]*":',         # drop image cid attributes
-                  '(position:[^!";]+;?)',
+                  '(position: ?(-webkit-)?(static|relative|fixed|absolute|sticky|initial|inherit);?)',
             ),
             array('', '', '', '', '<html', '$4', '$2 $3', '', ''),
             $html);

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -335,9 +335,10 @@ class Format {
                   ':<(a|span) (name|style)="(mso-bookmark\:)?_MailEndCompose">(.+)?<\/(a|span)>:', # Drop _MailEndCompose
                   ':<div dir=(3D)?"ltr">(.*?)<\/div>(.*):is', # drop Gmail "ltr" attributes
                   ':data-cid="[^"]*":',         # drop image cid attributes
-                  '(position: ?(-webkit-)?(static|relative|fixed|absolute|sticky|initial|inherit);?)',
+                  '(position: ?(-webkit-)?(static|relative|fixed|absolute|sticky|initial|inherit);?)', # Position styling
+                  ':[\x{2002}-\x{200B}]+:u',    # unicode spaces
             ),
-            array('', '', '', '', '<html', '$4', '$2 $3', '', ''),
+            array('', '', '', '', '<html', '$4', '$2 $3', '', '', ' '),
             $html);
 
         // HtmLawed specific config only
@@ -536,7 +537,8 @@ class Format {
                 '/[\x{23E0}-\x{23EF}]/u',   # More Buttons
                 '/[\x{2310}-\x{231F}]/u',   # Hourglass/Watch
                 '/[\x{1000B6}]/u',          # Private Use Area (Plane 16)
-                '/[\x{2322}-\x{232F}]/u'    # Keyboard
+                '/[\x{2322}-\x{232F}]/u',   # Keyboard
+                '/[\x{00B0}|\x{00A9}]/u'    # Degrees/Copyright
             ), '', $text);
     }
 


### PR DESCRIPTION
This addresses an issue where the current REGEX for the "position" styling attribute is causing issues when emails contain legit text like "position: 100 degrees". This updates the REGEX to only look for one of the possible values instead of looking for seemingly anything.

This also adds a couple of new sanitizations including:
- Replacing unicode spaces with normal spaces
- Stripping the Degrees and Copyright unicode symbols