### PR TITLE
mpdf: Unicode Spaces

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -336,8 +336,9 @@ class Format {
                   ':<div dir=(3D)?"ltr">(.*?)<\/div>(.*):is', # drop Gmail "ltr" attributes
                   ':data-cid="[^"]*":',         # drop image cid attributes
                   '(position:[^!";]+;?)',
+                  ':[\x{2002}-\x{200B}]+:u',    # unicode spaces
             ),
-            array('', '', '', '', '<html', '$4', '$2 $3', '', ''),
+            array('', '', '', '', '<html', '$4', '$2 $3', '', '', ' '),
             $html);
 
         // HtmLawed specific config only


### PR DESCRIPTION
This addresses an issue where Unicode Spaces like "hair spaces" (ie. U+200A) cause fatal errors when attempting to print via mPDF. This is due to mPDF not liking Unicode Spaces very much. This adds a check for Unicode Spaces and if present will be replaced with a normal space.