### PR TITLE
mailer: sendmail() Failure

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -341,7 +341,7 @@ class Bootstrap {
     static function croak($message) {
         $msg = $message."\n\n".THISPAGE;
         osTicket\Mail\Mailer::sendmail(ADMIN_EMAIL, 'osTicket Fatal Error', $msg,
-            sprintf('"osTicket Alerts"<%s>', ADMIN_EMAIL));
+            sprintf('"osTicket Alerts" <%s>', ADMIN_EMAIL));
         //Display generic error to the user
         Http::response(500, "<b>Fatal Error:</b> Contact system administrator.");
     }

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -77,7 +77,7 @@ class Mailer {
             $this->from = $from;
         elseif (\Validator::is_email($from)) {
             $this->from = new \EmailAddress(
-                    sprintf('"%s" <%s>', $name ?: '', $from));
+                    str_contains($from, '<') ? $from : sprintf('"%s" <%s>', $name ?: '', $from));
         } elseif (is_string($from))
             $this->from = new \EmailAddress($from);
         elseif (($email=$this->getEmail())) {


### PR DESCRIPTION
This addresses an issue where passing a full From string (eg. `"osTicket Alerts"<user@noemail.com>`) as the `$from` parameter for `Mailer::sendmail()` causes a fatal laminas-mail error. This is due to the full string not being a valid email address. This changes the full From string to just the email address in the needed places. In addition this adds an array of `$options` with the From Name as the `from_name` option which gets used to format the full From string later down the pipeline.