### PR TITLE
mysqli: Multi-Host Failure

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -214,15 +214,16 @@ class Bootstrap {
         $hosts = explode(',', DBHOST);
         foreach ($hosts as $host) {
             $ferror  = null;
-            if (!db_connect($host, DBUSER, DBPASS, $options)) {
-                $ferror = sprintf('Unable to connect to the database — %s',
-                        db_connect_error());
-            }elseif(!db_select_database(DBNAME)) {
-                $ferror = sprintf('Unknown or invalid database: %s',
-                        DBNAME);
-           }
-           // break if no error
-           if (!$ferror) break;
+            try {
+                if (!db_connect($host, DBUSER, DBPASS, $options))
+                    $ferror = sprintf('Unable to connect to the database — %s', db_connect_error());
+                elseif (!db_select_database(DBNAME))
+                    $ferror = sprintf('Unknown or invalid database: %s', DBNAME);
+            } catch (mysqli_sql_exception $e) {
+                $ferror = sprintf('Database error — %s', $e->getMessage());
+            }
+            // break if no error
+            if (!$ferror) break;
         }
 
         if ($ferror) //Fatal error


### PR DESCRIPTION
This is a rewrite of #6641. This addresses an issue where if PHP has MySQLi Error Reporting enabled (enabled by default starting with PHP 8.1), there are multiple configured database hosts, and one host fails to connect the system throws a fatal error. We previously attempted to silence fatal errors with `@` suppression however STRICT MySQLi Error Reporting bypasses this and still throws an error. This updates the `db_connect()` call in `bootstrap.php` and wraps it with a try/catch. If `db_connect()` fails, we will catch the exception and set `$ferror` same as before. This also adds a check to ensure `$ferror` is not set before calling `db_select_database()` to ensure the previous connection attempt was successful. Doing so will ensure the system attempts to connect to all configured hosts without exiting and only croaks when no hosts are reachable.