### PR TITLE
i18n: Schedules getDays()

### DIFF
--- a/include/class.schedule.php
+++ b/include/class.schedule.php
@@ -1049,13 +1049,15 @@ class ScheduleEntry extends VerySimpleModel {
     }
 
     static function getDays() {
-        static $translated = false;
-        if (!$translated) {
-            foreach (static::$days as $k=>$v)
-                static::$days[$k] = __($v);
-        }
+        return self::$days;
+    }
 
-        return static::$days;
+    static function getTranslatedDays() {
+        static $translated = null;
+        if (!isset($translated))
+            $translated = array_map(function ($d) { return __($d); }, static::getDays());
+
+        return $translated;
     }
 
     static function getWeeks() {
@@ -1176,7 +1178,7 @@ extends AbstractForm {
                     'default' => "",
                     'layout' => new GridFluidCell(6),
                     'label' => __('Day of the Week'),
-                    'choices' => ScheduleEntry::getDays() + array(
+                    'choices' => ScheduleEntry::getTranslatedDays() + array(
                         'weekdays' => sprintf('%s (%s)',
                             __('Weekdays'), __('Mon-Fri')),
                         'weekends' => sprintf('%s (%s)',
@@ -1212,7 +1214,7 @@ extends AbstractForm {
                     'default' => "",
                     'layout' => new GridFluidCell(6),
                     'label' => __('Day'),
-                    'choices' => ScheduleEntry::getDays(),
+                    'choices' => ScheduleEntry::getTranslatedDays(),
                     'validator-error' => __('Selection required'),
                     'visibility' => new VisibilityConstraint(
                         new Q(array('monthly__neq'=>'day')),
@@ -1241,7 +1243,7 @@ extends AbstractForm {
                     'default' => '',
                     'layout' => new GridFluidCell(4),
                     'label' => __('Day'),
-                    'choices' => ScheduleEntry::getDays(),
+                    'choices' => ScheduleEntry::getTranslatedDays(),
                     'validator-error' => __('Selection required'),
                     'configuration'=>array('prompt'=>__('Day')),
                     'visibility' => new VisibilityConstraint(


### PR DESCRIPTION
This addresses an issue where using a non-english language breaks the Ticket view page for Tickets with no Due Date, SLA with grace period longer than 41 hours, and the SLA is attached to a Schedule with working days. This is due to mistakenly translating the day names in `getDays()` function at times we shouldn't be. PHP only likes English day names during actual date calculations. This adds a new parameter to `getDays()` called `$translate` that defaults to `false`. If `true` we will translate the day names, otherwise they will remain in English.