### PR TITLE
issue: Task Last Respondent

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -350,23 +350,21 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
     }
 
     function getLastRespondent() {
-
         if (!isset($this->lastrespondent)) {
             $this->lastrespondent = Staff::objects()
                 ->filter(array(
-                'staff_id' => static::objects()
+                'staff_id' => $this->getThread()->entries
                     ->filter(array(
-                        'thread__entries__type' => 'R',
-                        'thread__entries__staff_id__gt' => 0
+                        'type' => 'R',
+                        'staff_id__gt' => 0
                     ))
-                    ->values_flat('thread__entries__staff_id')
-                    ->order_by('-thread__entries__id')
-                    ->limit('1,1')
+                    ->values_flat('staff_id')
+                    ->order_by('-id')
+                    ->limit('1')
                 ))
                 ->first()
                 ?: false;
         }
-
         return $this->lastrespondent;
     }
 


### PR DESCRIPTION
This addresses an issue where `Task::getLastRespondent()` returns the wrong Agent leading to the wrong people receiving alerts, etc. This updates the `Task::getLastRespondent()` function to make it limit the last respondent search to the Task's own Thread Entries rather than searching through all entries.