### PR TITLE
issue: Referred Closed Tickets

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -713,7 +713,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
                 'child_thread__referrals__team__team_id__in' => $teams)));
             $assigned->add($childRefTeam);
         }
-        $visibility = Q::any(new Q(array('status__state'=>'open', $assigned)));
+        $visibility = Q::any(new Q(array('status__state__in'=>['open', 'closed'], $assigned)));
         // -- If access is limited to assigned only, return assigned
         if ($this->isAccessLimited())
             return $visibility;


### PR DESCRIPTION
This addresses an issue where Agents cannot see Referred Tickets in their Closed Queues. This is due to the `Staff::getTicketsVisibility()` function blindly using the `open` state instead of looking for `closed` as well. This updates the function to include the `closed` state in the status condition. This ensures the referred Tickets are shown in every Queue.