### PR TITLE
php: Update Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requirements
   * MySQL database version 5.5 (or greater)
 
 ### Recommendations
-  * fileinfo, gd, gettext, imap, intl, json, mbstring, Zend OPcache, phar,
+  * ctype, fileinfo, gd, gettext, imap, intl, json, mbstring, Zend OPcache, phar,
     xml, xml-dom, and zip extensions for PHP
   * APCu module enabled and configured for PHP
 

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -11,7 +11,11 @@ $extensions = array(
             ),
         'imap' => array(
             'name' => 'imap',
-            'desc' => __('Used for email fetching')
+            'desc' => __('Useful for email processing')
+            ),
+        'ctype' => array(
+            'name' => 'ctype',
+            'desc' => __('Required for email fetching')
             ),
         'xml' => array(
             'name' => 'xml',

--- a/setup/inc/install-prereq.inc.php
+++ b/setup/inc/install-prereq.inc.php
@@ -25,23 +25,25 @@ if(!defined('SETUPINC')) die('Kwaheri!');
             <ul class="progress">
                 <li class="<?php echo extension_loaded('gd')?'yes':'no'; ?>">Gdlib <?php echo __('Extension');?></li>
                 <li class="<?php echo extension_loaded('imap')?'yes':'no'; ?>">PHP IMAP <?php echo __('Extension');?> &mdash; <em><?php
-                    echo __('Required for mail fetching');?></em></li>
-                <li class="<?php echo extension_loaded('xml') ?'yes':'no'; ?>">PHP XML <?php echo __('Extension');?> <?php
-                    echo __('(for XML API)');?></li>
-                <li class="<?php echo extension_loaded('dom') ?'yes':'no'; ?>">PHP XML-DOM <?php echo __('Extension');?> <?php
-                    echo __('(for HTML email processing)');?></li>
-                <li class="<?php echo extension_loaded('json')?'yes':'no'; ?>">PHP JSON <?php echo __('Extension');?> <?php
-                    echo __('(faster performance)');?></li>
+                    echo __('Useful for email processing');?></em></li>
+                <li class="<?php echo extension_loaded('ctype')?'yes':'no'; ?>">PHP CTYPE <?php echo __('Extension');?> &mdash; <em><?php
+                    echo __('Required for email fetching');?></em></li>
+                <li class="<?php echo extension_loaded('xml') ?'yes':'no'; ?>">PHP XML <?php echo __('Extension');?> &mdash; <?php
+                    echo __('Required for XML API');?></li>
+                <li class="<?php echo extension_loaded('dom') ?'yes':'no'; ?>">PHP XML-DOM <?php echo __('Extension');?> &mdash; <?php
+                    echo __('Useful for HTML email processing');?></li>
+                <li class="<?php echo extension_loaded('json')?'yes':'no'; ?>">PHP JSON <?php echo __('Extension');?> &mdash; <?php
+                    echo __('Recommended for faster performance');?></li>
                 <li class="<?php echo extension_loaded('mbstring')?'yes':'no'; ?>">Mbstring <?php echo __('Extension');?> &mdash; <?php
-                    echo __('recommended for all installations');?></li>
+                    echo __('Recommended for all installations');?></li>
                 <li class="<?php echo extension_loaded('phar')?'yes':'no'; ?>">Phar <?php echo __('Extension');?> &mdash; <?php
-                    echo __('recommended for plugins and language packs');?></li>
+                    echo __('Recommended for plugins and language packs');?></li>
                 <li class="<?php echo extension_loaded('intl')?'yes':'no'; ?>">Intl <?php echo __('Extension');?> &mdash; <?php
-                    echo __('recommended for improved localization');?></li>
+                    echo __('Recommended for improved localization');?></li>
                 <li class="<?php echo extension_loaded('apcu')?'yes':'no'; ?>">APCu <?php echo __('Extension');?> &mdash; <?php
-                    echo __('(faster performance)');?></li>
+                    echo __('Recommended for faster performance');?></li>
                 <li class="<?php echo extension_loaded('Zend OPcache')?'yes':'no'; ?>">Zend OPcache <?php echo __('Extension');?> &mdash; <?php
-                    echo __('(faster performance)');?></li>
+                    echo __('Recommended for faster performance');?></li>
             </ul>
             <div id="bar">
                 <form method="post" action="install.php">


### PR DESCRIPTION
This updates the PHP Prerequisites to include the `ctype` extension needed for email fetching as part of the `laminas-mail` package. This adds the extension to the installer prerequisites as well as the system information page and the `README.md`. Lastly, this updates the installer prerequisites wording and structure so they all match and look streamlined.