### PR TITLE
i18n: Lang URL Param

### DIFF
--- a/include/class.i18n.php
+++ b/include/class.i18n.php
@@ -251,7 +251,7 @@ class Internationalization {
 
     static function isLanguageInstalled($code) {
         $langs = self::availableLanguages();
-        return isset($langs[strtolower($code)]);
+        return isset($langs[strtolower((string) $code)]);
     }
 
     static function isLanguageEnabled($code) {


### PR DESCRIPTION
This addresses issue #6573 where the `lang` URL param is not sanity checked and throws a fatal error if it contains anything but a string. This forces the `lang` param to a string when passing to `strtolower()` to avoid fatal errors. The `isLanguageInstalled()` function will still behave the same way as before by returning `false` if passed an invalid `lang` code -or- if the `lang` code is valid just doesn't exist in the available languages.