### PR TITLE
php: Update Minimum Version (1.18.x)

### DIFF
--- a/include/class.setup.php
+++ b/include/class.setup.php
@@ -18,7 +18,7 @@ class SetupWizard {
 
     //Mimimum requirements
     static protected $prereq = array(
-            'php' => '8.0',
+            'php' => '8.1',
             'mysql' => '5.0');
 
     //Version info - same as the latest version.


### PR DESCRIPTION
This updates the minimum required PHP Version for 1.18.x from 8.0 to 8.1 to fit the laminas-mail requirements.