### PR TITLE
mysql: Update Minimum Version

### DIFF
--- a/include/class.setup.php
+++ b/include/class.setup.php
@@ -19,7 +19,7 @@ class SetupWizard {
     //Mimimum requirements
     static protected $prereq = array(
             'php' => '8.0',
-            'mysql' => '5.0');
+            'mysql' => '5.5');
 
     //Version info - same as the latest version.
 


### PR DESCRIPTION
This updates the minimum required MySQL Version from 5.0 to 5.5. We've stated "5.5 or better" for a while but never actually enforced it in our installer/upgrader.