### PR TITLE
Fix staff mobile field class

### DIFF
--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -84,7 +84,7 @@ if ($avatar->isChangeable()) { ?>
         <tr>
           <td><?php echo __('Mobile Number');?>:</td>
           <td>
-            <input type="tel" size="18" name="mobile" class="auto phone"
+            <input type="tel" size="18" name="mobile" class="auto mobile"
               value="<?php echo Format::htmlchars($staff->mobile); ?>" />
             <div class="error"><?php echo $errors['mobile']; ?></div>
           </td>

--- a/include/staff/staff.inc.php
+++ b/include/staff/staff.inc.php
@@ -104,7 +104,7 @@ $extras = new ArrayObject();
         <tr>
           <td><?php echo __('Mobile Number');?>:</td>
           <td>
-            <input type="tel" size="18" name="mobile" class="auto phone"
+            <input type="tel" size="18" name="mobile" class="auto mobile"
               value="<?php echo Format::htmlchars($staff->mobile); ?>" />
             <div class="error"><?php echo $errors['mobile']; ?></div>
           </td>


### PR DESCRIPTION
The classes for mobile field are currently the same as for the phone field. As a consequence for example the following code cannot work
https://github.com/osTicket/osTicket/blob/4689926b2d3d25754f0ddcf8d4e181a2817f6d56/scp/js/scp.js#L335-L337

It expects the mobile field to have classes "auto mobile" which this PR fixes.