### PR TITLE
Fix agent details not clearing on change

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -333,7 +333,7 @@ var scp_prep = function() {
         onselect: function (obj) {
             var fObj=$('.staff-username.typeahead').closest('form');
             $.each(['first','last','email','phone','mobile'], function(i,k) {
-                if (obj[k]) $('.auto.'+k, fObj).val(obj[k]);
+                $('.auto.'+k, fObj).val(obj[k] ? obj[k] : '');
             });
         },
         property: "username"
@@ -1402,7 +1402,7 @@ $(document).on('click.inline-edit', 'a.inline-edit', function(e) {
                 $('#msg-txt').text(obj.msg);
                 $('div#msg_notice').show();
             }
-            // If Help Topic was set and statuses are returned 
+            // If Help Topic was set and statuses are returned
             if (obj.statuses) {
                 var reply = $('select[name=reply_status_id]');
                 var note = $('select[name=note_status_id]');


### PR DESCRIPTION
If you use for example LDAP plugin, the agent details are automatically filled in if you select a username. However, the fields are not cleared in case the next selection is missing some of the values. Instead the details of the previous selection are left behind.

This PR ensures that the details of the previous person will be cleared in case the next person is missing some of the details.