### PR TITLE
patches: Latest 05/28/2024

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -387,8 +387,8 @@ class ApiXmlDataParser extends XmlDataParser {
     function fixup($current) {
         global $cfg;
 
-		if($current['ticket'])
-			$current = $current['ticket'];
+        if (isset($current['ticket']))
+            $current = $current['ticket'];
 
         if (!is_array($current))
             return $current;

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -242,8 +242,13 @@ class Mail_Parse {
 
 
     function getFromAddressList(){
-        return self::parseAddressList($this->getHeaderEntry('from'),
-                $this->charset);
+        if (!($header = $this->struct->headers['from']))
+            return null;
+
+        if (is_string($header) && (strpos($header, '<') !== false) && (strpos($header, '>') === false))
+            $header = $header.'>';
+
+        return Mail_Parse::parseAddressList($header, $this->charset);
     }
 
     function getDeliveredToAddressList() {

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -2871,7 +2871,7 @@ class MySqlCompiler extends SqlCompiler {
         $table = ($rmeta['view'])
             // XXX: Support parameters from the nested query
             ? $rmodel::getSqlAddParams($this)
-            : $this->quote($rmeta['table']);
+            : $this->quote($rmeta['table'], true);
         $base = "{$join}{$table} {$alias}";
         return array($base, $constraints);
     }

--- a/include/class.role.php
+++ b/include/class.role.php
@@ -322,7 +322,7 @@ class RolePermission {
     }
 
     function getInfo() {
-        return $this->perms;
+        return $this->perms ?: [];
     }
 
     function merge($perms) {


### PR DESCRIPTION
This is a pull containing recent small patches we've aggregated since last release. This includes the following:
- Adding an `isset()` check to ensure the `ticket` array key exists within the `$current` array and is set before using it.
- Adding a null coalescing operator after `$obj->getPermission()->getInfo()` in `Export::agents()` so that if the permission lookup fails or returns invalid data we will use an empty array to avoid fatal errors and let the export continue.