### PR TITLE
issue: Linked Icon annotation

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1845,7 +1845,7 @@ extends QueueColumnAnnotation {
     function getDecoration($row, $text) {
         $flags = $row['flags'];
         $linked = ($flags & Ticket::FLAG_LINKED) != 0;
-        if ($linked && $_REQUEST['a'] == 'search')
+        if ($linked)
             return '<i class="icon-link"></i>';
     }
 


### PR DESCRIPTION
This addresses an issue where Linked Icon annotation was not being displayed when added to a queue column; it was shown only in search queues