### PR TITLE
Upgrade mimeDecode.php from v1.48 to v1.5.6 2016-08-28

### DIFF
--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -28,8 +28,8 @@
  * - Redistributions in binary form must reproduce the above copyright
  *   notice, this list of conditions and the following disclaimer in the
  *   documentation and/or other materials provided with the distribution.
- * - Neither the name of the authors, nor the names of its contributors
- *   may be used to endorse or promote products derived from this
+ * - Neither the name of the authors, nor the names of its contributors 
+ *   may be used to endorse or promote products derived from this 
  *   software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -52,7 +52,7 @@
  * @author     Sean Coates <sean@php.net>
  * @copyright  2003-2006 PEAR <pear-group@php.net>
  * @license    http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version    CVS: $Id: mimeDecode.php,v 1.48 2006/12/03 13:43:33 cipri Exp $
+ * @version    CVS: $Id: mimeDecode.php 337165 2015-07-15 09:42:08Z alan_k $
  * @link       http://pear.php.net/package/Mail_mime
  */
 
@@ -62,7 +62,6 @@
  *
  * This package depends on PEAR to raise errors.
  */
-
 require_once 'PEAR.php';
 
 
@@ -91,6 +90,14 @@ require_once 'PEAR.php';
  */
 class Mail_mimeDecode extends PEAR
 {
+    /**
+     * The raw email to decode
+     *
+     * @var    string
+     * @access private
+     */
+    var $_input;
+
     /**
      * The header part of the input
      *
@@ -134,11 +141,21 @@ class Mail_mimeDecode extends PEAR
 
     /**
      * Flag to determine whether to decode headers
+     * (set to UTF8 to iconv convert headers)
+     * @var    mixed 
+     * @access private
+     */
+    var $_decode_headers;
+  
+
+    /**
+     * Flag to determine whether to include attached messages
+     * as body in the returned object. Depends on $_include_bodies
      *
      * @var    boolean
      * @access private
      */
-    var $_decode_headers;
+    var $_rfc822_bodies;
 
     /**
      * Constructor.
@@ -149,26 +166,29 @@ class Mail_mimeDecode extends PEAR
      * @param string The input to decode
      * @access public
      */
-    function __construct(&$input)
+    function __construct($input)
     {
         list($header, $body)   = $this->_splitBodyHeader($input);
 
-        $this->_input          = &$input;
-        $this->_header         = &$header;
-        $this->_body           = &$body;
+        $this->_input          = $input;
+        $this->_header         = $header;
+        $this->_body           = $body;
         $this->_decode_bodies  = false;
         $this->_include_bodies = true;
+        $this->_rfc822_bodies  = false;
     }
-
+    // BC
+    function Mail_mimeDecode($input)
+    {
+        $this->__construct($input);
+    }
+    
     /* Return raw header...added 10/23/07 by kip.
      *
      */
     function getHeader() {
         return $this->_header;
     }
-
-
-
 
     /**
      * Begins the decoding process. If called statically
@@ -181,7 +201,9 @@ class Mail_mimeDecode extends PEAR
      *                               object.
      *              decode_bodies  - Whether to decode the bodies
      *                               of the parts. (Transfer encoding)
-     *              decode_headers - Whether to decode headers
+     *              decode_headers - Whether to decode headers,
+     *                             - use "UTF8//IGNORE" to convert charset.
+     *              
      *              input          - If called statically, this will be treated
      *                               as the input
      * @return object Decoded results
@@ -190,7 +212,7 @@ class Mail_mimeDecode extends PEAR
     function decode($params = null)
     {
         // determine if this method has been called statically
-        $isStatic = !(isset($this) && get_class($this) == __CLASS__);
+        $isStatic = empty($this) || !is_a($this, __CLASS__);
 
         // Have we been called statically?
 	// If so, create an object and pass details to that.
@@ -211,15 +233,19 @@ class Mail_mimeDecode extends PEAR
 	                             $params['decode_bodies']  : false;
             $this->_decode_headers = isset($params['decode_headers']) ?
 	                             $params['decode_headers'] : false;
-            $this->_charset = isset($params['charset']) ?
-                                 $params['charset'] : 'UTF-8';
-
+            $this->_rfc822_bodies  = isset($params['rfc_822bodies']) ?
+	                             $params['rfc_822bodies']  : false;
+                                 
+            if (is_string($this->_decode_headers) && !function_exists('iconv')) {
+                 PEAR::raiseError('header decode conversion requested, however iconv is missing');
+            }
+                                 
             $structure = $this->_decode($this->_header, $this->_body);
             if ($structure === false) {
                 $structure = $this->raiseError($this->_error);
             }
         }
-
+    
         return $structure;
     }
 
@@ -233,13 +259,14 @@ class Mail_mimeDecode extends PEAR
      * @return object Results of decoding process
      * @access private
      */
-    function _decode(&$headers, &$body, $default_ctype = 'text/plain')
+    function _decode($headers, $body, $default_ctype = 'text/plain')
     {
         $return = new stdClass;
         $return->headers = array();
         $headers = $this->_parseHeaders($headers);
 
         foreach ($headers as $value) {
+            $value['value'] =  $this->_decodeHeader($value['value']);
             if (isset($return->headers[strtolower($value['name'])]) AND !is_array($return->headers[strtolower($value['name'])])) {
                 $return->headers[strtolower($value['name'])]   = array($return->headers[strtolower($value['name'])]);
                 $return->headers[strtolower($value['name'])][] = $value['value'];
@@ -252,8 +279,8 @@ class Mail_mimeDecode extends PEAR
             }
         }
 
-        reset($headers);
-        foreach ($headers as $key=>$value) {
+
+        foreach ($headers as $key => $value) {
             $headers[$key]['name'] = strtolower($headers[$key]['name']);
             switch ($headers[$key]['name']) {
 
@@ -266,7 +293,7 @@ class Mail_mimeDecode extends PEAR
                     }
 
                     if (isset($content_type['other'])) {
-                        foreach ($content_type['other'] as $p_name=>$p_value) {
+                        foreach($content_type['other'] as $p_name => $p_value) {
                             $return->ctype_parameters[$p_name] = $p_value;
                         }
                     }
@@ -276,7 +303,7 @@ class Mail_mimeDecode extends PEAR
                     $content_disposition = $this->_parseHeaderValue($headers[$key]['value']);
                     $return->disposition   = $content_disposition['value'];
                     if (isset($content_disposition['other'])) {
-                        foreach ($content_disposition['other'] as $p_name=>$p_value) {
+                        foreach($content_disposition['other'] as $p_name => $p_value) {
                             $return->d_parameters[$p_name] = $p_value;
                         }
                     }
@@ -299,6 +326,14 @@ class Mail_mimeDecode extends PEAR
                     $encoding = isset($content_transfer_encoding) ? $content_transfer_encoding['value'] : '7bit';
                     $this->_include_bodies ? $return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding) : $body) : null;
                     break;
+                
+                case 'multipart/signed': // PGP
+                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary'], true);
+                    $return->parts['msg_body'] = $parts[0]; 
+                    list($part_header, $part_body) = $this->_splitBodyHeader($parts[1]);
+                    $return->parts['sig_hdr'] = $part_header;
+                    $return->parts['sig_body'] = $part_body;
+                    break;
 
                 case 'multipart/parallel':
                 case 'multipart/appledouble': // Appledouble mail
@@ -307,8 +342,9 @@ class Mail_mimeDecode extends PEAR
                 case 'multipart/digest':
                 case 'multipart/alternative':
                 case 'multipart/related':
-                case 'multipart/relative':
+                case 'multipart/relative': //#20431 - android
                 case 'multipart/mixed':
+                case 'application/vnd.wap.multipart.related':
                     if(!isset($content_type['other']['boundary'])){
                         $this->_error = 'No boundary found for ' . $content_type['value'] . ' part';
                         return false;
@@ -317,9 +353,8 @@ class Mail_mimeDecode extends PEAR
                     $default_ctype = (strtolower($content_type['value']) === 'multipart/digest') ? 'message/rfc822' : 'text/plain';
 
                     $parts = $this->_boundarySplit($body, $content_type['other']['boundary']);
-                    while (count($parts)) {
-                        $part = array_shift($parts);
-                        list($part_header, $part_body) = $this->_splitBodyHeader($part);
+                    for ($i = 0; $i < count($parts); $i++) {
+                        list($part_header, $part_body) = $this->_splitBodyHeader($parts[$i]);
                         $part = $this->_decode($part_header, $part_body, $default_ctype);
                         if($part === false)
                             $part = $this->raiseError($this->_error);
@@ -328,8 +363,12 @@ class Mail_mimeDecode extends PEAR
                     break;
 
                 case 'message/rfc822':
+                case 'message/delivery-status': // #bug #18693
+					if ($this->_rfc822_bodies) {
+						$encoding = isset($content_transfer_encoding) ? $content_transfer_encoding['value'] : '7bit';
+						$return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding) : $body);
+					}
                     $obj = new Mail_mimeDecode($body);
-                    $return->body = $body;
                     $return->parts[] = $obj->decode(array('include_bodies' => $this->_include_bodies,
 					                                      'decode_bodies'  => $this->_decode_bodies,
 														  'decode_headers' => $this->_decode_headers));
@@ -371,7 +410,7 @@ class Mail_mimeDecode extends PEAR
             }
             for ($i = 0; $i < count($structure->parts); $i++) {
 
-
+            
                 if (!empty($structure->headers['content-type']) AND substr(strtolower($structure->headers['content-type']), 0, 8) == 'message/') {
                     $prepend      = $prepend . $mime_number . '.';
                     $_mime_number = '';
@@ -391,7 +430,7 @@ class Mail_mimeDecode extends PEAR
             $structure->mime_id = $prepend . $mime_number;
             $no_refs ? $return[$prepend . $mime_number] = '' : $return[$prepend . $mime_number] = &$structure;
         }
-
+        
         return $return;
     }
 
@@ -404,18 +443,15 @@ class Mail_mimeDecode extends PEAR
      * @return array Contains header and body section
      * @access private
      */
-    function _splitBodyHeader(&$input)
+    function _splitBodyHeader($input)
     {
-        if ($input instanceof StringView)
-            $check = $input->substr(0, 64<<10);
-        else
-            $check = &$input;
-        if (preg_match("/^.*?(\r?\n\r?\n)(.)/s", $check, $match, PREG_OFFSET_CAPTURE)) {
-            $headers = ($input instanceof StringView)
-                ? (string) $input->substr(0, $match[1][1]) : substr($input, 0, $match[1][1]);
-            $body = ($input instanceof StringView)
-                ? $input->substr($match[2][1]) : new StringView($input, $match[2][1]);
-            return array($headers, $body);
+        if (preg_match("/^(.*?)\r?\n\r?\n(.*)/s", $input, $match)) {
+            return array($match[1], $match[2]);
+        }
+        // bug #17325 - empty bodies are allowed. - we just check that at least one line 
+        // of headers exist..
+        if (count(explode("\n",$input))) {
+            return array($input, '');
         }
         $this->_error = 'Could not split header and body';
         return false;
@@ -435,18 +471,36 @@ class Mail_mimeDecode extends PEAR
         if ($input !== '') {
             // Unfold the input
             $input   = preg_replace("/\r?\n/", "\r\n", $input);
+            //#7065 - wrapping.. with encoded stuff.. - probably not needed,
+            // wrapping space should only get removed if the trailing item on previous line is a 
+            // encoded character
+            $input   = preg_replace("/=\r\n(\t| )+/", '=', $input);
             $input   = preg_replace("/\r\n(\t| )+/", ' ', $input);
+            
             $headers = explode("\r\n", trim($input));
-
+            $got_start = false;
             foreach ($headers as $value) {
+                if (!$got_start) {
+                    // munge headers for mbox style from
+                    if ($value[0] == '>') {
+                        $value = substring($value, 1); // remove mbox >
+                    }
+                    if (substr($value,0,5) == 'From ') {
+                        $value = 'Return-Path: ' . substr($value, 5);
+                    } else {
+                        $got_start = true;
+                    }
+                }
+                
                 $hdr_name = substr($value, 0, $pos = strpos($value, ':'));
                 $hdr_value = substr($value, $pos+1);
-                if($hdr_value[0] == ' ')
+                if($hdr_value[0] == ' ') {
                     $hdr_value = substr($hdr_value, 1);
+                }
 
                 $return[] = array(
                                   'name'  => $hdr_name,
-                                  'value' => $this->_decode_headers ? $this->_decodeHeader($hdr_value) : $hdr_value
+                                  'value' =>  $hdr_value
                                  );
             }
         } else {
@@ -463,48 +517,192 @@ class Mail_mimeDecode extends PEAR
      * robust as it could be. Eg. header comments
      * in the wrong place will probably break it.
      *
+     * Extra things this can handle
+     *   filename*0=......
+     *   filename*1=......
+     *
+     *  This is where lines are broken in, and need merging.
+     *
+     *   filename*0*=ENC'lang'urlencoded data.
+     *   filename*1*=ENC'lang'urlencoded data.
+     *
+     * 
+     *
      * @param string Header value to parse
      * @return array Contains parsed result
      * @access private
      */
     function _parseHeaderValue($input)
     {
-
-        if (($pos = strpos($input, ';')) !== false) {
-
-            $return['value'] = trim(substr($input, 0, $pos));
-            $input = trim(substr($input, $pos+1));
-
-            if (strlen($input) > 0) {
-
-                // This splits on a semi-colon, if there's no preceeding backslash
-                // Now works with quoted values; had to glue the \; breaks in PHP
-                // the regex is already bordering on incomprehensible
-                $splitRegex = '/([^;\'"]*[\'"]([^\'"]*([^\'"]*)*)[\'"][^;\'"]*|([^;]+))(;|$)/';
-                preg_match_all($splitRegex, $input, $matches);
-                $parameters = array();
-                for ($i=0; $i<count($matches[0]); $i++) {
-                    $param = $matches[0][$i];
-                    while (substr($param, -2) == '\;') {
-                        $param .= $matches[0][++$i];
-                    }
-                    $parameters[] = $param;
-                }
-
-                for ($i = 0; $i < count($parameters); $i++) {
-                    $param_name  = trim(substr($parameters[$i], 0, $pos = strpos($parameters[$i], '=')), "'\";\t\\ ");
-                    $param_value = trim(str_replace('\;', ';', substr($parameters[$i], $pos + 1)), "'\";\t\\ ");
-                    if ($param_value[0] == '"') {
-                        $param_value = substr($param_value, 1, -1);
-                    }
-                    $return['other'][$param_name] = $param_value;
-                    $return['other'][strtolower($param_name)] = $param_value;
-                }
-            }
-        } else {
+         if (($pos = strpos($input, ';')) === false) {
+            $input = $this->_decodeHeader($input);
             $return['value'] = trim($input);
+            return $return;
         }
 
+
+
+        $value = substr($input, 0, $pos);
+        $value = $this->_decodeHeader($value);
+        $return['value'] = trim($value);
+        $input = trim(substr($input, $pos+1));
+
+        if (!strlen($input) > 0) {
+            return $return;
+        }
+        // at this point input contains xxxx=".....";zzzz="...."
+        // since we are dealing with quoted strings, we need to handle this properly..
+        $i = 0;
+        $l = strlen($input);
+        $key = '';
+        $val = false; // our string - including quotes..
+        $q = false; // in quote..
+        $lq = ''; // last quote..
+
+        while ($i < $l) {
+            
+            $c = $input[$i];
+            //var_dump(array('i'=>$i,'c'=>$c,'q'=>$q, 'lq'=>$lq, 'key'=>$key, 'val' =>$val));
+
+            $escaped = false;
+            if ($c == '\\') {
+                $i++;
+                if ($i == $l-1) { // end of string.
+                    break;
+                }
+                $escaped = true;
+                $c = $input[$i];
+            }            
+
+
+            // state - in key..
+            if ($val === false) {
+                if (!$escaped && $c == '=') {
+                    $val = '';
+                    $key = trim($key);
+                    $i++;
+                    continue;
+                }
+                if (!$escaped && $c == ';') {
+                    if ($key) { // a key without a value..
+                        $key= trim($key);
+                        $return['other'][$key] = '';
+                    }
+                    $key = '';
+                }
+                $key .= $c;
+                $i++;
+                continue;
+            }
+                     
+            // state - in value.. (as $val is set..)
+
+            if ($q === false) {
+                // not in quote yet.
+                if ((!strlen($val) || $lq !== false) && $c == ' ' ||  $c == "\t") {
+                    $i++;
+                    continue; // skip leading spaces after '=' or after '"'
+                }
+                
+                // do not de-quote 'xxx*= itesm.. 
+                $key_is_trans = $key[strlen($key)-1] == '*';
+                
+                if (!$key_is_trans && !$escaped && ($c == '"' || $c == "'")) {
+                    // start quoted area..
+                    $q = $c;
+                    // in theory should not happen raw text in value part..
+                    // but we will handle it as a merged part of the string..
+                    $val = !strlen(trim($val)) ? '' : trim($val);
+                    $i++;
+                    continue;
+                }
+                // got end....
+                if (!$escaped && $c == ';') {
+                     
+                    $return['other'][$key] = trim($val);
+                    $val = false;
+                    $key = '';
+                    $lq = false;
+                    $i++;
+                    continue;
+                }
+
+                $val .= $c;
+                $i++;
+                continue;
+            }
+            
+            // state - in quote..
+            if (!$escaped && $c == $q) {  // potential exit state..
+                
+                // end of quoted string..
+                $lq = $q;
+                $q = false;
+                $i++;
+                continue;
+            }
+                
+            // normal char inside of quoted string..
+            $val.= $c;
+            $i++;
+        }
+        
+        // do we have anything left..
+        if (strlen(trim($key)) || $val !== false) {
+           
+            $val = trim($val);
+          
+            $return['other'][$key] = $val;
+        }
+       
+        
+        $clean_others = array();
+        // merge added values. eg. *1[*]
+        foreach($return['other'] as $key =>$val) {
+            if (preg_match('/\*[0-9]+\**$/', $key)) {
+                $key = preg_replace('/(.*)\*[0-9]+(\**)$/', '\1\2', $key);
+                if (isset($clean_others[$key])) {
+                    $clean_others[$key] .= $val;
+                    continue;
+                }
+                
+            }
+            $clean_others[$key] = $val;
+            
+        }
+         
+        // handle language translation of '*' ending others.
+        foreach( $clean_others as $key =>$val) {
+            if ( $key[strlen($key)-1] != '*') {
+                $clean_others[strtolower($key)] = $val;
+                continue;
+            }
+            unset($clean_others[$key]);
+            $key = substr($key,0,-1);
+            //extended-initial-value := [charset] "'" [language] "'"
+            //              extended-other-values
+            $match = array();
+            $info = preg_match("/^([^']+)'([^']*)'(.*)$/", $val, $match);
+             
+            $clean_others[$key] = urldecode($match[3]);
+            $clean_others[strtolower($key)] = $clean_others[$key];
+            $clean_others[strtolower($key).'-charset'] = $match[1];
+            $clean_others[strtolower($key).'-language'] = $match[2];
+            
+            
+        }
+        
+        
+        $return['other'] = $clean_others;
+        
+        // decode values.
+        foreach($return['other'] as $key =>$val) {
+            $charset = isset($return['other'][$key . '-charset']) ?
+                $return['other'][$key . '-charset']  : false;
+            
+            $return['other'][$key] = $this->_decodeHeader($val, $charset);
+        }
+        
         return $return;
     }
 
@@ -516,7 +714,7 @@ class Mail_mimeDecode extends PEAR
      * @return array Contains array of resulting mime parts
      * @access private
      */
-    function _boundarySplit($input, $boundary)
+    function _boundarySplit($input, $boundary, $eatline = false)
     {
         $parts = array();
 
@@ -526,28 +724,22 @@ class Mail_mimeDecode extends PEAR
         if ($boundary == $bs_check) {
             $boundary = $bs_possible;
         }
+        // eatline is used by multipart/signed.
+        $tmp = $eatline ?
+            preg_split("/\r?\n--".preg_quote($boundary, '/')."(|--)\n/", $input) :
+            preg_split("/--".preg_quote($boundary, '/')."((?=\s)|--)/", $input);
 
-        if ($input instanceof StringView) {
-            $parts = $input->split('--' . $boundary);
-            array_shift($parts);
-
-            if (count($parts) > 0
-                && $parts[count($parts)-1]->substr(0, 2)->__toString() == '--'
-            ) {
-                // Drop the last part if it starts with '--' as such would
-                // be past the end of a multipart section
-                array_pop($parts);
+        $len = count($tmp) -1;
+        for ($i = 1; $i < $len; $i++) {
+            if (strlen(trim($tmp[$i]))) {
+                $parts[] = $tmp[$i];
             }
-
-            return $parts;
         }
-
-        $tmp = explode('--' . $boundary, $input);
-
-        for ($i = 1; $i < count($tmp) - 1; $i++) {
-            $parts[] = $tmp[$i];
+        
+        // add the last part on if it does not end with the 'closing indicator'
+        if (!empty($tmp[$len]) && strlen(trim($tmp[$len])) && $tmp[$len][0] != '-') {
+            $parts[] = $tmp[$len];
         }
-
         return $parts;
     }
 
@@ -561,8 +753,11 @@ class Mail_mimeDecode extends PEAR
      * @return string Decoded header value
      * @access private
      */
-    function _decodeHeader($input)
+    function _decodeHeader($input, $default_charset=false)
     {
+        if (!$this->_decode_headers) {
+            return $input;
+        }
         // Remove white space between encoded-words
         $input = preg_replace('/(=\?[^?]+\?(q|b)\?[^?]*\?=)(\s)+=\?/i', '\1=?', $input);
 
@@ -586,20 +781,18 @@ class Mail_mimeDecode extends PEAR
                         $text = str_replace('='.$value, chr(hexdec($value)), $text);
                     break;
             }
-
-            //Convert decoded text to the desired charset.
-            if($charset && $this->_charset && strcasecmp($this->_charset, $charset)) {
-                if(function_exists('iconv'))
-                    $text = iconv($charset, $this->_charset.'//IGNORE', $text);
-                elseif(function_exists('mb_convert_encoding'))
-                    $text = mb_convert_encoding($text, $this->_charset, $charset);
-                elseif(!strcasecmp($this->_charset, 'utf-8')) //forced blind utf8 encoding.
-                    $text = function_exists('imap_utf8')?imap_utf8($text):utf8_encode($text);
+            if (is_string($this->_decode_headers)) {
+                $conv = @iconv($charset, $this->_decode_headers, $text);
+                $text = ($conv === false) ? $text : $conv;
             }
-
             $input = str_replace($encoded, $text, $input);
         }
-
+        
+        if ($default_charset  && is_string($this->_decode_headers)) {
+            $conv = @iconv($charset, $this->_decode_headers, $input);
+            $input = ($conv === false) ? $input : $conv;
+        }
+        
         return $input;
     }
 
@@ -646,7 +839,13 @@ class Mail_mimeDecode extends PEAR
         $input = preg_replace("/=\r?\n/", '', $input);
 
         // Replace encoded characters
-       $input = preg_replace_callback('/=([a-f0-9]{2})/i',
+        //
+        // https://www.php.net/manual/en/function.create-function.php 
+        // This function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. Relying on this function is highly discouraged.
+        //
+        // $cb = create_function('$matches',  ' return chr(hexdec($matches[0]));');
+        // $input = preg_replace_callback( '/=([a-f0-9]{2})/i', $cb, $input);
+        $input = preg_replace_callback('/=([a-f0-9]{2})/i',
                function ($matches) {
                    return chr(hexdec($matches[0]));
                },
@@ -732,7 +931,7 @@ class Mail_mimeDecode extends PEAR
 
     /**
      * getSendArray() returns the arguments required for Mail::send()
-     * used to build the arguments for a mail::send() call
+     * used to build the arguments for a mail::send() call 
      *
      * Usage:
      * $mailtext = Full email (for example generated by a template)
@@ -755,7 +954,6 @@ class Mail_mimeDecode extends PEAR
         $this->_decode_headers = FALSE;
         $headerlist =$this->_parseHeaders($this->_header);
         $to = "";
-        $header = array();
         if (!$headerlist) {
             return $this->raiseError("Message did not contain headers");
         }
@@ -765,7 +963,7 @@ class Mail_mimeDecode extends PEAR
                 case "to":
                 case "cc":
                 case "bcc":
-                    $to = ",".$item['value'];
+                    $to .= ",".$item['value'];
                 default:
                    break;
             }
@@ -775,7 +973,7 @@ class Mail_mimeDecode extends PEAR
         }
         $to = substr($to,1);
         return array($to,$header,$this->_body);
-    }
+    } 
 
     /**
      * Returns a xml copy of the output of
@@ -797,7 +995,7 @@ class Mail_mimeDecode extends PEAR
     function getXML($input)
     {
         $crlf    =  "\r\n";
-        $output  = '<?xml version=\'1.0\' ?>' . $crlf .
+        $output  = '<?xml version=\'1.0\'?>' . $crlf .
                    '<!DOCTYPE email SYSTEM "http://www.phpguru.org/xmail/xmail.dtd">' . $crlf .
                    '<email>' . $crlf .
                    Mail_mimeDecode::_getXML($input) .
@@ -893,51 +1091,3 @@ class Mail_mimeDecode extends PEAR
     }
 
 } // End of class
-
-class StringView {
-    var $string;
-    var $start;
-    var $end;
-
-    function __construct(&$string, $start=0, $end=false) {
-        $this->string = &$string;
-        $this->start = $start;
-        $this->end = $end;
-    }
-
-    function __toString() {
-        return $this->end
-            ? substr($this->string, $this->start, $this->end - $this->start)
-            : substr($this->string, $this->start);
-    }
-
-    function substr($start, $end=false) {
-        return new StringView($this->string, $this->start + $start,
-            $end ? min($this->start + $end, $this->end ?: PHP_INT_MAX) : $this->end);
-    }
-
-    function split($token) {
-        $ltoken = strlen($token);
-        $windows = array();
-        $offset = $this->start;
-        for ($i = 0;; $i++) {
-            $windows[$i] = array('start' => $offset);
-            $offset = strpos($this->string, $token, $offset);
-            if (!$offset || ($this->end && $offset >= $this->end))
-                break;
-
-            // Enforce local window
-            $windows[$i]['stop'] = min($this->end ?: $offset, $offset);
-            $offset += $ltoken;
-            if ($this->end && $offset > $this->end)
-                break;
-        }
-
-        $parts = array();
-        foreach ($windows as $w) {
-            $parts[] = new static($this->string, $w['start'], @$w['stop'] ?: false);
-        }
-        return $parts;
-
-    }
-}


### PR DESCRIPTION
Update the mimeDecode.php file, which was originally version 1.48 from 2006/12/03 and has been maintained up to now. Currently, we are directly using version 1.5.6. Adjustments were made to the syntax while retaining the original getHeader() function.

This is to fix #6680 issue.