### PR TITLE
issue: Ticket Relations

### DIFF
--- a/include/staff/ticket-relations.inc.php
+++ b/include/staff/ticket-relations.inc.php
@@ -19,7 +19,7 @@ if (count($children ?: array()) != 0 || $ticket->isChild()) { ?>
                  <th width="200"><?php echo __('Create Date'); ?></th>
              </tr>
          </thead>
-         <tbody class="tasks">
+         <tbody class="relations">
          <?php
          if ($children) {
              foreach($children as $child) {


### PR DESCRIPTION
This addresses an issue where when viewing a Parent/Child Ticket that also has Tasks and you first click the Tasks tab, then the Related Tickets tab, then finally click a Related Ticket the browser redirects to `/scp/ickets.php?=xxx` with URL Not Supported error. This is due to reusing the class name `tasks` for the related Tickets table. This changes the `tasks` class to `relations` so that it's unique.