### PR TITLE
issue: Basic Search Selector

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -269,7 +269,7 @@ var scp_prep = function() {
 
     /* Typeahead tickets lookup */
     var last_req;
-    $('input.basic-search').typeahead({
+    $('input.basic-search:not([id])').typeahead({
         source: function (typeahead, query) {
             if (last_req) last_req.abort();
             var $el = this.$element;


### PR DESCRIPTION
This addresses an issue where if you load the User Directory, click the Organization tab, go back to the User Directory tab, and attempt a user lookup via basic-search it attempts to hit the url `undefined?q=xxx` which is obviously not valid and fails to return results. After investigation it was found that when clicking through the tabs vs directly loading them causes the Javascript/jQuery to load in reverse sequence. This means core `scp/js/scp.js` code was taking precedence over the inline-jQuery within the Users Staff Template. In most cases this shouldn't matter however in this particular case the input selector in the core `scp/js/scp.js` was looking for a generic `input.basic-search` class. We use this class for all basic searches however the ones for user lookup and organization lookpup respectively have their own unique ID in addition that the inline-jQuery is supposed to select. Since the core is loading after the inline in this case that means the core takes precedence over the inline code causing wrong URL, etc. This simply updates the core selector to have `:not([id])` so that it doesn't try to match an iput with class of `input.basic-search` with an ID. Tested and working with User/Org lookups and all other basic-searches.