### PR TITLE
issue: mimeDecode .eml Attachments

### DIFF
--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -369,6 +369,8 @@ class Mail_mimeDecode extends PEAR
 						$return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding) : $body);
 					}
                     $obj = new Mail_mimeDecode($body);
+                    if (!isset($return->body))
+                        $return->body = $body;
                     $return->parts[] = $obj->decode(array('include_bodies' => $this->_include_bodies,
 					                                      'decode_bodies'  => $this->_decode_bodies,
 														  'decode_headers' => $this->_decode_headers));


### PR DESCRIPTION
This reapplies a missing patch `af1c4a6` that added `message/rfc822` attachment support.