### PR TITLE
php: iconv Recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Requirements
   * MySQL database version 5.5 (or greater)
 
 ### Recommendations
-  * ctype, fileinfo, gd, gettext, imap, intl, json, mbstring, Zend OPcache, phar,
-    xml, xml-dom, and zip extensions for PHP
+  * ctype, fileinfo, gd, gettext, iconv, imap, intl, json, mbstring,
+    Zend OPcache, phar, xml, xml-dom, and zip extensions for PHP
   * APCu module enabled and configured for PHP
 
 Deployment

--- a/include/staff/system.inc.php
+++ b/include/staff/system.inc.php
@@ -9,6 +9,10 @@ $extensions = array(
             'name' => 'gdlib',
             'desc' => __('Used for image manipulation and PDF printing')
             ),
+        'iconv' => array(
+            'name' => 'iconv',
+            'desc' => __('Useful for email processing')
+            ),
         'imap' => array(
             'name' => 'imap',
             'desc' => __('Useful for email processing')

--- a/setup/inc/install-prereq.inc.php
+++ b/setup/inc/install-prereq.inc.php
@@ -24,6 +24,8 @@ if(!defined('SETUPINC')) die('Kwaheri!');
             <?php echo __('You can use osTicket without these, but you may not be able to use all features.');?>
             <ul class="progress">
                 <li class="<?php echo extension_loaded('gd')?'yes':'no'; ?>">Gdlib <?php echo __('Extension');?></li>
+                <li class="<?php echo extension_loaded('iconv')?'yes':'no'; ?>">PHP ICONV <?php echo __('Extension');?> &mdash; <em><?php
+                    echo __('Useful for email processing');?></em></li>
                 <li class="<?php echo extension_loaded('imap')?'yes':'no'; ?>">PHP IMAP <?php echo __('Extension');?> &mdash; <em><?php
                     echo __('Useful for email processing');?></em></li>
                 <li class="<?php echo extension_loaded('ctype')?'yes':'no'; ?>">PHP CTYPE <?php echo __('Extension');?> &mdash; <em><?php


### PR DESCRIPTION
This updates the PHP Prerequisites to include the `iconv` extension. Iconv methods are used for email parsing (in the pear/Mail_mimeDecode package) as well as other places internally. This adds the extension to the installer prerequisites as well as the system information page and the `README.md`.