### PR TITLE
Ignore VS Code Workspace Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ setup/cli/modules/importer
 .vagrant
 ._.DS_Store
 Vagrantfile
+# VS Code workspace files
+*.code-workspace
 
 # Staging directory used for packaging script
 stage


### PR DESCRIPTION
This PR simply adds `*.code-workspace` to `.gitignore` file