### PR TITLE
issue: Email Remote Backend Name

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -1350,7 +1350,7 @@ class SmtpAccount extends EmailAccount {
         // matching.
         if ($vars['smtp_active'] == 1
                 && ($vars['smtp_auth_bk'] === 'mailbox')
-                && (strpos($vars['auth_bk'], 'oauth2') === 0)
+                && (strpos($vars['mailbox_auth_bk'], 'oauth2') === 0)
                 && !$this->checkStrictMatching())
             $_errors['smtp_auth_bk'] = sprintf('%s and %s', __('Resource Owner'), __('Email Mismatch'));
 


### PR DESCRIPTION
This addresses an issue reported by @JensEB where the wrong remote backend name was used in a strpos check. This updates the name from `auth_bk` to the correct `mailbox_auth_bk`.