### PR TITLE
issue: Safari Response Content Disposition

### DIFF
--- a/include/class.http.php
+++ b/include/class.http.php
@@ -113,10 +113,6 @@ class Http {
         if (false !== strpos($user_agent,'msie')
                 && false !== strpos($user_agent,'win'))
             return 'filename='.rawurlencode($filename);
-        elseif (false !== strpos($user_agent, 'safari')
-                && false === strpos($user_agent, 'chrome'))
-            // Safari and Safari only can handle the filename as is
-            return 'filename='.str_replace(',', '', $filename);
         else
             // Use RFC5987
             return "filename*=UTF-8''".rawurlencode($filename);


### PR DESCRIPTION
This addresses an issue where Safari is now refusing to load inline images stored in S3. Upon investigation it was found the code had an old check for Safari browser when generating the content disposition filename string. If Safari was being used it left the filename alone as "Safari and only Safari can handle the filename as is". Well this may be true for Safari however S3 cannot handle this. This removes the Safari specific check and forces even Safari to UTF8 encode the filename for the content disposition string. This allows Safari to load inline images from S3 again. Safari still loads other images, etc. just fine as well.