### PR TITLE
issue: Multiselect List Export

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1633,6 +1633,7 @@ class SelectionField extends FormField {
             $values = array();
             $choices = $this->getChoices();
             foreach (explode(',', $value) as $V) {
+                $V = trim($V);
                 if (isset($choices[$V]))
                     $values[$V] = $choices[$V];
             }


### PR DESCRIPTION
This addresses an issue where attempting to export a multiselection List Field with multiple selected items only shows the first selected item. This is due to the Item IDs containing spaces (due to the earlier `explode()` call) so the IDs do not match the available IDs. This adds a `trim()` around the Item IDs so that they match appropriately.