### PR TITLE
Users directory: Add configuration option to show different user fields in users list view

### DIFF
--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -53,6 +53,22 @@ define('DBPASS','%CONFIG-DBPASS');
 # Table prefix
 define('TABLE_PREFIX','%CONFIG-PREFIX');
 
+# Option: USERS_COLUMS
+#
+# Values: string of column-separated field|title from the ost_user__cdata
+#         table that we want to display additional to the default fields
+#         in the users directory list view.
+#         Check the columns in your ost_user__cdata table and use the
+#         field name 'cdata__'+columnname in the list below.
+#         If a language term is available (see
+#         include/i18n/[language_code]/LC_MESSAGES/messages.mo.php)
+#         you can use it after the field name with a | separator, like;
+#           'cdata__firstname|First Name:cdata__email2|Email'
+#         If no language term is available, just leave empty or put a
+#         term that should work for most of your agents.
+#
+# define('USERS_COLUMNS', 'cdata__firstname|First Name:cdata__mobilephone|Mobile Number');
+
 #
 # SSL Options
 # ---------------------------------------------------

--- a/include/staff/users.inc.php
+++ b/include/staff/users.inc.php
@@ -59,6 +59,23 @@ $_SESSION[':Q:users'] = $users;
 
 $users->values('id', 'name', 'default_email__address', 'account__id',
     'account__status', 'created', 'updated');
+
+$users_columns = preg_split('/:/', USERS_COLUMNS);
+$users_columns_term = [];
+$users_column_name = [];
+foreach ($users_columns as $extra_column) {
+    if (preg_match('/\|/', $extra_column)) {
+        list($field, $term) = preg_split('/\|/', $extra_column);
+        $users_columns_name[] = $field;
+        $users_columns_term[$field] = $term;
+        $extra_column = $field;
+    } else {
+        $users_columns_name[] = $extra_column;
+        $users_columns_term[$extra_column] = '';
+    }
+    $users->values($extra_column);
+}
+
 $users->order_by($order . $order_column);
 ?>
 <div id="basic_search">
@@ -163,13 +180,22 @@ else
                 echo $qstr; ?>&sort=create"><?php echo __('Created'); ?></a></th>
             <th width="20%"><a <?php echo $update_sort; ?> href="users.php?<?php
                 echo $qstr; ?>&sort=update"><?php echo __('Updated'); ?></a></th>
+            <?php
+            foreach ($users_columns_name as $extra_column) {
+                if (!empty($users_columns_term[$extra_column])) {
+                    echo '            <th>'.__($users_columns_term[$extra_column]).'</th>';
+                } else {
+                    echo '            <th>'.$extra_column.'</th>';
+                }
+            }
+            ?>
         </tr>
     </thead>
     <tbody>
     <?php
         $ids=($errors && is_array($_POST['ids']))?$_POST['ids']:null;
         foreach ($users as $U) {
-                // Default to email address mailbox if no name specified
+                // Defaults to email address mailbox if no name specified
                 if (!$U['name'])
                     list($name) = explode('@', $U['default_email__address']);
                 else
@@ -204,6 +230,11 @@ else
                 <td><?php echo $status; ?></td>
                 <td><?php echo Format::date($U['created']); ?></td>
                 <td><?php echo Format::datetime($U['updated']); ?>&nbsp;</td>
+               <?php
+               foreach ($users_columns_name as $extra_column) {
+                   echo '<td>'.$U[$extra_column].'</td>';
+               }
+               ?>
                </tr>
 <?php   } //end of foreach. ?>
     </tbody>


### PR DESCRIPTION
Allows for greater customization if the usage type does not match the typical OSTicket usage type.

Defining `define('USERS_COLUMNS', 'cdata__firstname|First Name:cdata__mobilephone|Mobile Number');` will automatically add the "First Name" and "Mobile Number" columns to the users repository list view (scp/users.php) and make it much easier to distinguish between homonymous users.

This PR does *not* provide search or sorting support for the added columns.

I tried to match the coding style of the existing code as much as possible.

There are possible optimisations in the way the user__cdata is loaded (currently one `$users->values($extra_column);` call for each additional field), but looking into it, I saw I would have had to either use the otherwise-apparently-unused-UserCdata class, or develop a new method for the User class which would provide a new way to query, and that seemed like a bad idea to go that far for a first contrib.