### PR TITLE
issue: Image Annotation

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -485,7 +485,7 @@ class Format {
         $exclude = !$cfg->allowExternalImages();
         $local = false;
 
-        $input = preg_replace_callback('/<img ([^>]*)(src="([^"]+)")([^>]*)\/?>/',
+        $input = preg_replace_callback('/<img ([^>]*?)(src="([^"]+)")([^>]*)\/?>/',
             function($match) use ($local, $allowed, $exclude, $display) {
                 if (strpos($match[3], 'cid:') !== false)
                     $local = true;


### PR DESCRIPTION
This addresses an issue where when annotating an image and sending it, it disappears from the final reply. This is due to REGEX that attempts to detect inline images and determines if it should strip them or not. This REGEX statement is greedy which means it will find as many matches as possible. This is a problem for image annotation as one of the classes that gets added to the image is `data-orig-annotated-image-src`. This gets picked up by the REGEX and as a result causes the image to be rejected since it contains a file URL instead of the expected `cid`. This pull simply changes the first matching group to "lazy" so that it stops on the first match. This causes the real `src` value to be picked up and parsed which contains the expected `cid`.