### PR TITLE
user: List Import

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1593,7 +1593,7 @@ class SelectionField extends FormField {
         $selection = array();
 
         if ($value && !is_array($value))
-            $value = array($value);
+            $value = JsonDataParser::parse($value) ?: array($value);
 
         if ($value && is_array($value)) {
             foreach ($value as $k=>$v) {


### PR DESCRIPTION
This addresses an issue where attempting to import a User with a value for a Custom List fails to import the list item. This is due to the parsed (JSON) value (which comes from `SelectionField::to_database()`) being passed to `SelectionField::parse()` which doesn't know how to parse it. This pull updates the `if()` statement that checks if the given value is not an array and adds `JsonDataParser::parse($value) ?:` before the `array($value)` to see if we can successfully parse the string. If so, it will use the parsed array. If not, it falls back to manually converting the value into an array.