### PR TITLE
api: DueDate and Other Errors

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -43,15 +43,22 @@ class TicketApiController extends ApiController {
             foreach ($form->getFields() as $field)
                 $supported[] = $field->get('name');
 
-        if(!strcasecmp($format, 'email')) {
-            $supported = array_merge($supported, array('header', 'mid',
-                'emailId', 'to-email-id', 'ticketId', 'reply-to', 'reply-to-name',
-                'in-reply-to', 'references', 'thread-type', 'system_emails',
-                'mailflags' => array('bounce', 'auto-reply', 'spam', 'viral'),
-                'recipients' => array('*' => array('name', 'email', 'source'))
-                ));
-
-            $supported['attachments']['*'][] = 'cid';
+        switch ($format) {
+            case 'email':
+                $supported = array_merge($supported, [
+                    'header', 'mid', 'emailId', 'to-email-id', 'ticketId', 'reply-to',
+                    'reply-to-name', 'in-reply-to', 'references', 'thread-type', 'system_emails',
+                    'mailflags' => ['bounce', 'auto-reply', 'spam', 'viral'],
+                    'recipients' => ['*' => ['name', 'email', 'source']]
+                ]);
+                $supported['attachments']['*'][] = 'cid';
+                break;
+            case 'json':
+            case 'xml':
+                $supported = array_merge($supported, [
+                    'duedate', 'slaId', 'staffId'
+                ]);
+                break;
         }
 
         return $supported;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -4370,7 +4370,7 @@ implements RestrictedAccess, Threadable, Searchable {
             $ticket->email_id = $vars['emailId'];
 
         //Make sure the origin is staff - avoid firebug hack!
-        if ($vars['duedate'] && !strcasecmp($origin,'staff'))
+        if ($vars['duedate'] && in_array(strtolower($origin), ['staff', 'api']))
             $ticket->duedate = date('Y-m-d G:i',
                 Misc::dbtime($vars['duedate']));
 


### PR DESCRIPTION
This addresses an issue where adding a `duedate` to API request payloads the system simply ignores it. This is due to an _old_ bit of code (1.7 - circa 2013) that refuses the `duedate` from any source other than `staff`. This updates the check from `strcasecmp()` to `in_array()` so it can check for both `staff` and `api`. This will allow a `duedate` to manually be set from Staff created Tickets as well as API created Tickets.

In addition, this updates the `getRequestStructure()` function to change the single `strcasecmp()` for `email` to a `switch {}`. This is so we can check multiple types other than `email`. This adds the previous `email` format as a case and adds two new cases for `json` and `xml` formats. Within these two new cases `duedate`, `slaId`, and `staffId` are added as available fields. This is so the system doesn’t throw an `Unexpected data received in API request` error even though these fields are valid and accepted with JSON and XML payloads.