### PR TITLE
OAuth2: Show Scopes and Enforce Strict Mode

### DIFF
--- a/include/class.oauth2.php
+++ b/include/class.oauth2.php
@@ -23,6 +23,7 @@ namespace osTicket\OAuth2 {
         protected $expires;
         protected $refreshToken;
         protected $resourceOwnerId;
+        protected $scope;
         // osTicket specific
         protected $resourceOwnerEmail;
         protected $configSignature;
@@ -49,6 +50,9 @@ namespace osTicket\OAuth2 {
 
             if (!empty($options['resource_owner_email']))
                 $this->resourceOwnerEmail = $options['resource_owner_email'];
+
+            if (!empty($options['scope']))
+                $this->scope = $options['scope'];
         }
 
         public function getToken() {
@@ -77,6 +81,10 @@ namespace osTicket\OAuth2 {
 
         public function getResourceOwner() {
             return $this->getResourceOwnerEmail();
+        }
+
+        public function getScope() {
+            return $this->scope;
         }
 
         public function getConfigSignature() {

--- a/include/staff/templates/email-oauth2auth.tmpl.php
+++ b/include/staff/templates/email-oauth2auth.tmpl.php
@@ -156,12 +156,28 @@ if (isset($errors['err'])) {
                         40); ?></td>
             </tr>
             <tr>
-                <td><?php echo __('Resource Owner'); ?>:</td>
-                <td><?php echo $token->getResourceOwner(); ?></td>
+                <td><?php echo __('Resource Owner Id'); ?>:</td>
+                <td><?php echo $token->getResourceOwnerId(); ?></td>
+            </tr>
+            <tr>
+                <td><?php echo __('Resource Owner Email'); ?>:</td>
+                <td><?php echo $token->getResourceOwnerEmail(); ?></td>
             </tr>
             <tr>
                 <td><?php echo __('Config Signature'); ?>:</td>
                 <td><?php echo  $token->getConfigSignature(); ?></td>
+            </tr>
+          </tbody>
+          <thead>
+            <tr>
+                <th colspan="2">
+                    <em><?php echo __('Token Scopes'); ?></em>
+                </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+                <td colspan=2><?php echo str_replace(' ', '<br />', $token->getScope()); ?></td>
             </tr>
         </tbody>
         </table>


### PR DESCRIPTION
Misc. updates to:
* [Token: Show Authorized Scopes](https://github.com/osTicket/osTicket/commit/a77cf535ed6bed2859ecffcec1c7efbb0a429fb3)
* [OAuth2: Add Resource Ownership Strict Mode Check](https://github.com/osTicket/osTicket/commit/390555db367c7d8a780381c431371dfba31e6bd4)

Showing scopes requires the upcoming version of OAuth2 plugin - [PR is here](https://github.com/osTicket/osTicket-plugins/pull/292). 