### PR TITLE
update: Composer symfony/process

### DIFF
--- a/include/laminas-mail/composer.json
+++ b/include/laminas-mail/composer.json
@@ -24,7 +24,7 @@
         "laminas/laminas-db": "^2.18",
         "phpunit/phpunit": "^10.4.2",
         "psalm/plugin-phpunit": "^0.18.4",
-        "symfony/process": "^6.3.4",
+        "symfony/process": "^6.4",
         "vimeo/psalm": "^5.15"
     },
     "suggest": {

--- a/include/laminas-mail/composer.lock
+++ b/include/laminas-mail/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8818c0fe2b1beaaa3eaec91f5a86791c",
+    "content-hash": "7dcf165a4abadafbc7a79cc71dc1b62c",
     "packages": [
         {
             "name": "laminas/laminas-loader",
@@ -4224,16 +4224,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.8",
+            "version": "v6.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5"
+                "reference": "25214adbb0996d18112548de20c281be9f27279f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8d92dd79149f29e89ee0f480254db595f6a6a2c5",
-                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/25214adbb0996d18112548de20c281be9f27279f",
+                "reference": "25214adbb0996d18112548de20c281be9f27279f",
                 "shasum": ""
             },
             "require": {
@@ -4265,7 +4265,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.8"
+                "source": "https://github.com/symfony/process/tree/v6.4.14"
             },
             "funding": [
                 {
@@ -4281,7 +4281,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-11-14T15:35:54+00:00"
         },
         {
             "name": "symfony/service-contracts",


### PR DESCRIPTION
This is a rewrite of #6757 that updates the `symfony/process` package to address a recent security advisory (11/2024). Both osTicket and laminas-mail do not use this package in production (only in dev mode) so this only updates the `require-dev` section of the main `composer.json` file as well as the `composer.lock` file. This is so that if anyone uses it in dev mode they will be using the latest patched version of `symfony/process`.

Since this package is not in-use below are the specific instructions used to update it without installing it:
```
cd include/laminas-mail/
composer require --dev --no-update symfony/process
vim composer.lock
  -- Update symfony/process version to latest (v6.4.14)
  -- Update the `reference` for the source and distribution to commit hash
  -- Update the `time`
composer update --no-install --lock
```