### PR TITLE
issue: Latest SQL Warnings

### DIFF
--- a/include/ajax.draft.php
+++ b/include/ajax.draft.php
@@ -242,6 +242,7 @@ class DraftAjaxAPI extends AjaxController {
 
         $draft = Draft::create(array(
             'namespace' => $namespace,
+            'body' => ''
         ));
         if (!$draft->save())
             Http::response(500, 'Unable to create draft');
@@ -312,7 +313,8 @@ class DraftAjaxAPI extends AjaxController {
             Http::response(403, "Login required for image upload");
 
         $draft = Draft::create(array(
-            'namespace' => $namespace
+            'namespace' => $namespace,
+            'body' => ''
         ));
         if (!$draft->save())
             Http::response(500, 'Unable to create draft');

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -320,7 +320,8 @@ class osTicket {
             .',title='.db_input(Format::sanitize($title, true))
             .',log_type='.db_input($loglevel[$level])
             .',log='.db_input(Format::sanitize($message, false))
-            .',ip_address='.db_input($_SERVER['REMOTE_ADDR']);
+            .',ip_address='.db_input($_SERVER['REMOTE_ADDR'])
+            .',logger=""';
 
         db_query($sql, false);
 

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1665,6 +1665,7 @@ implements TemplateVariable {
 
         $entry = new static(array(
             'created' => SqlFunction::NOW(),
+            'updated' => SqlFunction::NOW(),
             'type' => $vars['type'],
             'thread_id' => $vars['threadId'],
             'title' => Format::strip_emoticons(Format::sanitize($vars['title'], true)),
@@ -2201,8 +2202,8 @@ class ThreadEvent extends VerySimpleModel {
 
         $inst = self::create(array(
             'thread_type' => ObjectModel::OBJECT_TYPE_TICKET,
-            'staff_id' => $staff,
-            'team_id' => $ticket->getTeamId(),
+            'staff_id' => $staff ?: 0,
+            'team_id' => $ticket->getTeamId() ?: 0,
             'dept_id' => $ticket->getDeptId(),
             'topic_id' => $ticket->getTopicId(),
         ), $user);
@@ -2212,8 +2213,8 @@ class ThreadEvent extends VerySimpleModel {
     static function forTask($task, $state, $user=false) {
         $inst = self::create(array(
             'thread_type' => ObjectModel::OBJECT_TYPE_TASK,
-            'staff_id' => $task->getStaffId(),
-            'team_id' => $task->getTeamId(),
+            'staff_id' => $task->getStaffId() ?: 0,
+            'team_id' => $task->getTeamId() ?: 0,
             'dept_id' => $task->getDeptId(),
         ), $user);
         return $inst;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -715,7 +715,7 @@ implements RestrictedAccess, Threadable, Searchable {
         if (!$lock->delete())
             return false;
 
-        $this->lock = null;
+        $this->lock = 0;
         return $this->save();
     }
 


### PR DESCRIPTION
This temporarily addresses #6661 where there are a few MariaDB warnings after `sql_mode` changes. This only includes temporary changes via code until we enforce defaults via SQL in the next major release. This accomplishes the following:
- Ensures a `body` is set when creating Drafts
- Ensures a `logger` is set when adding system logs
- Ensures `updated` has a date-time set when creating a new ThreadEntry
- Ensures `staff_id`|`team_id` defaults to `0` if no object ID available
- Ensures the `lock_id` is set to `0` instead of `NULL`