### PR TITLE
queue: getTotal Incorrect Counts

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -905,7 +905,10 @@ class SavedQueue extends CustomQueue {
         $query = $this->getQuery();
         if ($agent)
             $query = $agent->applyVisibility($query);
-        $query->limit(false)->offset(false)->order_by(false);
+        $query->filter(Q::any([
+                'ticket_pid__isnull' => true,
+                'flags__hasbit' => Ticket::FLAG_LINKED
+            ]))->limit(false)->offset(false)->order_by(false);
         try {
             return $query->count();
         } catch (Exception $e) {


### PR DESCRIPTION
This addresses an issue where when using `getTotal()` to get the total counts for a Queue it mistakenly includes Children Tickets. This causes a discrepancy between the number of Tickets shown within the Queue vs the total shown for the count. Since we ignore Children Tickets within the Queues themselves (due to them being merged into a Parent) we should also ignore Children within the Queue Counts. This adds a new filter to the `$query` in `getTotal()` that filters Tickets with `ticket_pid` equal to `NULL` or Tickets with `flags` containing `Ticket::FLAG_LINKED` (ie. it is a Link not Merge).