### PR TITLE
issue: Client ACL Staff File Download

### DIFF
--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -367,7 +367,8 @@ class Validator {
         $aclbk = $cfg->getACLBackend();
         switch($backend) {
             case 'client':
-                if (in_array($aclbk, array(0,3)))
+                if (in_array($aclbk, array(0,3))
+                        || ($aclbk == 2 && StaffAuthenticationBackend::getUser()))
                     return true;
                 break;
             case 'staff':


### PR DESCRIPTION
This addresses #6758 where enabling the ACL for Clients and attempting to download a file as an Agent throws an Access Denied error. This adds a check in the `check_acl` function to see if the backend is set to Client Portal and if the current authenticated person is an Agent. If so, it will skip the ACL check; otherwise it will enforce the check.