### PR TITLE
patches: Latest 11/18/2024

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -27,9 +27,8 @@ class osTicketSession {
         // session name/ssid
         if ($name && strcmp($this->name, $name))
             $this->name = $name;
-        // Session ttl cannot exceed php.ini maxlifetime setting
         $maxlife =  ini_get('session.gc_maxlifetime');
-        $this->ttl = min($ttl ?: ($maxlife ?: SESSION_TTL), $maxlife);
+        $this->ttl = $ttl ?: ($maxlife ?: SESSION_TTL);
         // Set osTicket specific session name/sessid
         session_name($this->name);
         // Set Default cookie Params before we start the session

--- a/scp/emailtest.php
+++ b/scp/emailtest.php
@@ -81,7 +81,6 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                     $emails = Email::objects()->values_flat('email_id',
                             'email', 'name', 'smtp__active')
                     ->order_by('name');
-                    print $emails;
                     foreach ($emails as $row) {
                         list($id,$email,$name,$smtp) = $row;
                         $selected = ($info['email_id'] && $id == $info['email_id']) ? 'selected="selected"' : '';


### PR DESCRIPTION
This includes patches for multiple things including:
- Addressing an issue where Guest User sessions would quickly timeout even though the User session was configured for say 24 hours.
- Removing a random `print $emails` from the `emailtest.php` page.