### PR TITLE
update: PHP Deprecations & Warnings

### DIFF
--- a/include/class.attachment.php
+++ b/include/class.attachment.php
@@ -192,7 +192,7 @@ extends InstrumentedList {
     function getInlines($lang=false) { return $this->_getList(false, true, $lang); }
     function getSeparates($lang=false) { return $this->_getList(true, false, $lang); }
     function getAll($lang=false) { return $this->_getList(true, true, $lang); }
-    function count($lang=false) { return count($this->getSeparates($lang)); }
+    function count($lang=false): int { return count($this->getSeparates($lang)); }
 
     function _getList($separates=false, $inlines=false, $lang=false) {
         $base = $this;

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -195,7 +195,7 @@ extends VerySimpleModel {
             ))->delete();
     }
 
-    static function getConfigsByNamespace(?string $namespace=null, $key, $value=false) {
+    static function getConfigsByNamespace(string $namespace=null, $key, $value=false) {
         $filter = array();
 
          $filter['key'] = $key;

--- a/include/class.message.php
+++ b/include/class.message.php
@@ -183,7 +183,7 @@ abstract class BaseMessageStorage implements MessageStorageBackend {
         return $messages;
     }
 
-    function getIterator() {
+    function getIterator(): Traversable {
         $this->used = true;
         $messages = $this->load();
         if ($this->queued) {

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -233,16 +233,16 @@ class ModelMeta implements ArrayAccess {
         return $root;
     }
 
-    function offsetGet($field) {
+    function offsetGet($field): mixed {
         return $this->meta[$field];
     }
-    function offsetSet($field, $what) {
+    function offsetSet($field, $what): void {
         $this->meta[$field] = $what;
     }
-    function offsetExists($field) {
+    function offsetExists($field): bool {
         return isset($this->meta[$field]);
     }
-    function offsetUnset($field) {
+    function offsetUnset($field): void {
         throw new Exception('Model MetaData is immutable');
     }
 
@@ -1368,7 +1368,7 @@ class QuerySet implements IteratorAggregate, ArrayAccess, Serializable, Countabl
         return $list[0];
     }
 
-    function count() {
+    function count(): int {
         // Defer to the iterator if fetching already started
         if (isset($this->_iterator)) {
             return $this->_iterator->count();
@@ -1562,7 +1562,7 @@ class QuerySet implements IteratorAggregate, ArrayAccess, Serializable, Countabl
     }
 
     // IteratorAggregate interface
-    function getIterator($iterator=false) {
+    function getIterator($iterator=false): Traversable {
         if (!isset($this->_iterator)) {
             $class = $iterator ?: $this->getIteratorClass();
             $it = new $class($this);
@@ -1593,16 +1593,16 @@ class QuerySet implements IteratorAggregate, ArrayAccess, Serializable, Countabl
     }
 
     // ArrayAccess interface
-    function offsetExists($offset) {
+    function offsetExists($offset): bool {
         return $this->getIterator()->offsetExists($offset);
     }
-    function offsetGet($offset) {
+    function offsetGet($offset): mixed {
         return $this->getIterator()->offsetGet($offset);
     }
-    function offsetUnset($a) {
+    function offsetUnset($a): void {
         throw new Exception(__('QuerySet is read-only'));
     }
-    function offsetSet($a, $b) {
+    function offsetSet($a, $b): void {
         throw new Exception(__('QuerySet is read-only'));
     }
 
@@ -1735,27 +1735,27 @@ implements ArrayAccess {
         $this->inner->rewind();
     }
 
-    function getIterator() {
+    function getIterator(): Traversable {
         $this->asArray();
         return new ArrayIterator($this->storage);
     }
 
-    function offsetExists($offset) {
+    function offsetExists($offset): bool {
         $this->fillTo($offset+1);
         return count($this->storage) > $offset;
     }
-    function offsetGet($offset) {
+    function offsetGet($offset): mixed {
         $this->fillTo($offset+1);
         return $this->storage[$offset];
     }
-    function offsetUnset($a) {
+    function offsetUnset($a): void {
         throw new Exception(__('QuerySet is read-only'));
     }
-    function offsetSet($a, $b) {
+    function offsetSet($a, $b): void {
         throw new Exception(__('QuerySet is read-only'));
     }
 
-    function count($mode=COUNT_NORMAL) {
+    function count($mode=COUNT_NORMAL): int {
         $this->asArray();
         return count($this->storage);
     }
@@ -1999,7 +1999,7 @@ implements IteratorAggregate {
         return $model;
     }
 
-    function getIterator() {
+    function getIterator(): Traversable {
         $func = ($this->map) ? 'getRow' : 'getArray';
         $func = array($this->resource, $func);
         $cache = true;
@@ -2028,27 +2028,27 @@ implements Iterator {
         $this->callback = $callback;
     }
 
-    function rewind() {
+    function rewind(): void {
         $this->eoi = false;
         $this->next();
     }
 
-    function key() {
+    function key(): mixed {
         return $this->key;
     }
 
-    function valid() {
+    function valid(): bool {
         if (!isset($this->eoi))
             $this->rewind();
         return !$this->eoi;
     }
 
-    function current() {
+    function current(): mixed {
         if ($this->eoi) return false;
         return $this->current;
     }
 
-    function next() {
+    function next(): void {
         try {
             $cbk = $this->callback;
             $this->current = $cbk();
@@ -2073,7 +2073,7 @@ implements IteratorAggregate {
         $this->queryset = $queryset;
     }
 
-    function getIterator() {
+    function getIterator(): Traversable {
         $this->resource = $this->queryset->getQuery();
         return new CallbackSimpleIterator(function() {
             global $StopIteration;
@@ -2096,7 +2096,7 @@ implements IteratorAggregate {
         $this->queryset = $queryset;
     }
 
-    function getIterator() {
+    function getIterator(): Traversable {
         $this->resource = $this->queryset->getQuery();
         return new CallbackSimpleIterator(function() {
             global $StopIteration;
@@ -2171,7 +2171,7 @@ extends ModelResultSet {
      * Slight edit to the standard iteration method which will skip deleted
      * items.
      */
-    function getIterator() {
+    function getIterator(): Traversable {
         return new CallbackFilterIterator(parent::getIterator(),
             function($i) { return !$i->__deleted__; }
         );
@@ -2244,11 +2244,11 @@ extends ModelResultSet {
         return clone $this->queryset;
     }
 
-    function offsetUnset($a) {
+    function offsetUnset($a): void {
         $this->fillTo($a);
         $this->storage[$a]->delete();
     }
-    function offsetSet($a, $b) {
+    function offsetSet($a, $b): void {
         $this->fillTo($a);
         if ($obj = $this->storage[$a])
             $obj->delete();

--- a/include/class.util.php
+++ b/include/class.util.php
@@ -98,12 +98,12 @@ implements IteratorAggregate, Countable {
     }
 
     // IteratorAggregate
-    function getIterator() {
+    function getIterator(): Traversable {
         return new ArrayIterator($this->storage);
     }
 
     // Countable
-    function count($mode=COUNT_NORMAL) {
+    function count($mode=COUNT_NORMAL): int {
         return count($this->storage, $mode);
     }
 
@@ -195,7 +195,7 @@ implements ArrayAccess, Serializable {
     }
 
     // ArrayAccess
-    function offsetGet($offset) {
+    function offsetGet($offset): mixed {
         if (!is_int($offset))
             throw new InvalidArgumentException('List indices should be integers');
         elseif ($offset < 0)
@@ -204,10 +204,11 @@ implements ArrayAccess, Serializable {
             throw new OutOfBoundsException('List index out of range');
         return $this->storage[$offset];
     }
-    function offsetSet($offset, $value) {
-        if ($offset === null)
-            return $this->storage[] = $value;
-        elseif (!is_int($offset))
+    function offsetSet($offset, $value): void {
+        if ($offset === null) {
+            $this->storage[] = $value;
+            return;
+        } elseif (!is_int($offset))
             throw new InvalidArgumentException('List indices should be integers');
         elseif ($offset < 0)
             $offset += count($this->storage);
@@ -217,14 +218,14 @@ implements ArrayAccess, Serializable {
 
         $this->storage[$offset] = $value;
     }
-    function offsetExists($offset) {
+    function offsetExists($offset): bool {
         if (!is_int($offset))
             throw new InvalidArgumentException('List indices should be integers');
         elseif ($offset < 0)
             $offset += count($this->storage);
         return isset($this->storage[$offset]);
     }
-    function offsetUnset($offset) {
+    function offsetUnset($offset): void {
         if (!is_int($offset))
             throw new InvalidArgumentException('List indices should be integers');
         elseif ($offset < 0)


### PR DESCRIPTION
This addresses #6574/#6590 and other deprecations and warnings encountered during testing with `error_reporting` set to `E_ALL` and both `display_errors` and `display_startup_errors` enabled. This includes defining optional parameters before required parameters and function return types not matching their parent.