### PR TITLE
issue: User Lookup Umlaut

### DIFF
--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -323,7 +323,7 @@ class UsersAjaxAPI extends AjaxController {
         elseif (!$bk || !$id)
             Http::response(422, 'Backend and user id required');
         elseif (!($backend = AuthenticationBackend::getSearchDirectoryBackend($bk))
-                || !($user_info = $backend->lookup($id)))
+                || !($user_info = $backend->lookup(html_entity_decode($id))))
             Http::response(404, 'User not found');
 
         $form = UserForm::getUserForm()->getForm($user_info);


### PR DESCRIPTION
This addresses osTicket/osTicket-plugins#293 where attempting to lookup and select a User from an external source like LDAP with an umlaut in their name causes an error of "User not found". This is because the URL is encoded with `htmlentities()` which makes the umlaut character unrecognizable. This wraps the lookup string with `html_entity_decode()` so that the umlaut is preserved and lookup succeeds.