### PR TITLE
issue: Department Field User Import

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3336,7 +3336,7 @@ class DepartmentField extends ChoiceField {
 
     function getValue() {
          if (($value = parent::getValue()) && ($id=$this->getClean()))
-            return $value[$id];
+            return is_array($value) ? $value[$id] : $value;
      }
 
     function to_php($value, $id=false) {


### PR DESCRIPTION
This addresses an issue where if you are importing Users via CSV, one of the Users already exists in the system, their profile has a Department Field with a current value set, and the CSV row for their account has a Department Field value the system will fail with an error of `Cannot access offset of type string on string`. This is due to blindly assuming the `$value` is an array. This adds a check to see if the value is an array, if so it will use the `$id` otherwise it defaults to the `$value`.