### PR TITLE
Fix force_https auto-enabling on settings page

### DIFF
--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -65,7 +65,7 @@ $gmtime = Misc::gmtime();
             <td><?php echo __('Force HTTPS'); ?>:</td>
             <td>
                 <input type="checkbox" name="force_https" <?php
-                echo $config['force_https'] ? 'checked="checked"' : ''; ?>>
+                echo ($config['force_https'] == "on") ? 'checked="checked"' : ''; ?>>
                 <?php echo __('Force all requests through HTTPS.'); ?>
                 <font class="error"><?php echo $errors['force_https']; ?></font>
                 <i class="help-tip icon-question-sign" href="#force_https"></i>


### PR DESCRIPTION
If `force_https` is `off`, the checkbox on the settings page still shows up checked, and the settings will be enabled when you save the settings. Even if you haven't touched it.

This causes infinite redirect loops if using a reverse proxy to terminate TLS.