### PR TITLE
issue: hide delete link for advanced search queues

### DIFF
--- a/include/staff/templates/queue-tickets.tmpl.php
+++ b/include/staff/templates/queue-tickets.tmpl.php
@@ -197,7 +197,7 @@ return false;">
                         </li>
 <?php
 
-if ($queue->id > 0 && $queue->isOwner($thisstaff)) { ?>
+if (intval($queue->id) > 0 && $queue->isOwner($thisstaff)) { ?>
                         <li class="danger">
                             <a class="no-pjax confirm-action" href="#"
                                 data-dialog="ajax.php/queue/<?php


### PR DESCRIPTION
This hides the delete link for advanced search queues that have not yet been saved.
To reproduce the error, try performing an advanced search and afterwards try deleting the queue by clicking on the Delete item in the dropdown that appears to the right of the queue title