### PR TITLE
issue: Referred Tickets Incorrect Queue Counts

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -738,7 +738,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
     }
 
     function applyVisibility($query, $exclude_archived=false) {
-        return $query->filter($this->getTicketsVisibility($exclude_archived));
+        return $query->filter($this->getTicketsVisibility($exclude_archived))->distinct('ticket_id');
     }
 
     function applyDeptVisibility($qs) {


### PR DESCRIPTION
This addresses an issue where having a Ticket Referred to you and one of your Departments increases the Queue count erroneously. In the `getTicketsVisibility()` function the system adds criteria to find Tickets referred to the Agent and then later adds separate criteria to find Tickets referred to the Agent’s Department(s). The problem is the two separate criteria will make the same Ticket appear twice in the results. To fix the issue we simply need to make the results distinct via `ticket_id`. Since `getTicketsVisibility()` is essentially generating an array of criteria we can’t add the distinction there. Plus, it could be used for things other than counts. So we move on to `applyVisibility()` where we use the criteria and add the distinction there. To note, this function is only used in `SavedQueue::counts()` and `SavedQueue::getTotal()` which would only affect counts; just what we want.