### PR TITLE
issue: Excessive Fetching Errors

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1355,7 +1355,7 @@ class DynamicFormEntry extends VerySimpleModel {
                     //use getChanges if getClean returns an empty array
                     $fieldClean = $field->getClean() ?: $field->getChanges();
                     if (is_array($fieldClean) && $fieldClean[0])
-                        $fieldClean = json_decode($fieldClean[0], true);
+                        $fieldClean = is_string($fieldClean[0]) ? json_decode($fieldClean[0], true) : $fieldClean[0];
                 } else
                     $fieldClean = $field->getClean();
 


### PR DESCRIPTION
This addresses issue #6647 where in certain scenarios/setups the system throws the infamous `Excessive errors processing emails for` error. As per the information from the referenced issue the main cause is a fatal error where `json_decode()` is receiving an array instead of the expected string. This adds a check on `$fieldClean[0]` to see if it's a string and if so uses the `json_decode()` otherwise it uses itself.