### PR TITLE
Plugin: functions enable(), disable(), uninstall() of a plugin will not called by enable, disable, uninstall a plugin

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -895,8 +895,14 @@ class Plugin extends VerySimpleModel {
         return true;
     }
 
+    function disable() {
+        $errors = [];
+        $this->update(['isactive' => 0], $errors);
+    }
+
     function enable() {
-        return true;
+        $errors = [];
+        $this->update(['isactive' => 1], $errors);
     }
 
     /**

--- a/scp/plugins.php
+++ b/scp/plugins.php
@@ -92,17 +92,19 @@ if ($_POST) {
         } else {
             $plugins = Plugin::objects()->filter([
                     'id__in' => array_values($_POST['ids'])]);
-            switch(strtolower($_POST['a'])) {
-            case 'enable':
-                $plugins->update(['isactive' => 1]);
-                break;
-            case 'disable':
-                 $plugins->update(['isactive' => 0]);
-                break;
-            case 'delete':
-                foreach ($plugins as $p)
-                    $p->uninstall($errors);
-                break;
+            foreach ($plugins as $p) {
+                $impl = $p->getImpl() ?: $p;
+                switch(strtolower($_POST['a'])) {
+                case 'enable':
+                    $impl->enable();
+                    break;
+                case 'disable':
+                     $impl->disable();
+                    break;
+                case 'delete':
+                    $impl->uninstall($errors);
+                    break;
+                }
             }
             // reset cached list
             PluginManager::clearCache();


### PR DESCRIPTION
see https://forum.osticket.com/d/103659-functions-not-working-enable-function-only-executed-on-install

This happens, because on these actions only functions from plugins core class will called, not from the plugin itself.
To solve this behavior, call the implementation of selected plugin in ./scp/plugins.php

this pull request will call modified functions Plugin::enable() and Plugin::disable() to trigger plugin functions, too.