### PR TITLE
issue: iFrame Logins

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -250,13 +250,19 @@ class osTicketSession {
     }
 
     static function renewCookie($baseTime=false, $window=false) {
+        global $ost;
+
         $ttl = $window ?: SESSION_TTL;
         $expire = ($baseTime ?: time()) + $ttl;
-        setcookie(session_name(), session_id(), $expire,
-            ini_get('session.cookie_path'),
-            ini_get('session.cookie_domain'),
-            ini_get('session.cookie_secure'),
-            ini_get('session.cookie_httponly'));
+        $opts = [
+            'expires' => $expire,
+            'path' => ini_get('session.cookie_path'),
+            'domain' => ini_get('session.cookie_domain'),
+            'secure' => ini_get('session.cookie_secure'),
+            'httponly' => ini_get('session.cookie_httponly'),
+            'samesite' => !empty($ost->getConfig()->getAllowIframes()) ? 'None' : 'Strict'
+        ];
+        setcookie(session_name(), session_id(), $opts);
         // Trigger expire update - neeed for secondary handlers that only
         // log new sessions
          self::expire(session_id(), $ttl);


### PR DESCRIPTION
This addresses an issue with iFrame logins where the site simply would refuse to honor cross site cookies. This adds a new check to see if the system allows iFrames. If so, it will set the `samesite` for the cookie to `None` which allows the cookie to be sent in all contexts. If the site does not allow iFrames it will default to `Strict` for security reasons.