### PR TITLE
issue: Canned Response Access

### DIFF
--- a/include/class.canned.php
+++ b/include/class.canned.php
@@ -311,6 +311,12 @@ extends VerySimpleModel {
 
         return true;
     }
+
+    function staffCanAccess($staff) {
+        if (!$staff instanceof Staff)
+            return false;
+        return (!$this->dept || (($role = $staff->getRole($this->dept)) && $role->hasPerm(Canned::PERM_MANAGE)));
+    }
 }
 RolePermission::register( /* @trans */ 'Knowledgebase', Canned::getPermissions());
 

--- a/scp/canned.php
+++ b/scp/canned.php
@@ -37,6 +37,10 @@ if(!$thisstaff
 $canned=null;
 if($_REQUEST['id'] && !($canned=Canned::lookup($_REQUEST['id'])))
     $errors['err']=sprintf(__('%s: Unknown or invalid ID.'), __('Canned Response'));
+if ($canned && !$canned->staffCanAccess($thisstaff)) {
+    header('Location: canned.php');
+    exit;
+}
 
 $canned_form = new SimpleForm(array(
     'attachments' => new FileUploadField(array('id'=>'attach',


### PR DESCRIPTION
This addresses issue #6772 where you can access a Canned Response with a Department set even if you don’t have the Premade Role Permission for the Canned Response's Department. This is due to not checking access before displaying the Canned Response. This adds a new function called `staffCanAccess()` to class Canned that checks to see if the Canned Response has a Department and if so ensures the Agent has a Role in that Department and that the Role contains the Premade Permission. This adds a new `if()` statement that calls `staffCanAccess()` if a Canned Response is found.