### PR TITLE
fields: Variable Name Validation

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -914,7 +914,7 @@ class DynamicFormField extends VerySimpleModel {
                 /* `variable` is used for automation. Internally it's called `name` */
                 ), "name");
         }
-        if ($this->get('name') && !preg_match('/^(?!\d)([[:alnum:]]|_|-)+$/u', $this->get('name')))
+        if ($this->get('name') && !preg_match('/^(?!\d)([[:alnum:]]|_)+$/u', $this->get('name')))
             $this->addError(__(
                 'Invalid character in variable name. Please use letters and numbers only.'
             ), 'name');


### PR DESCRIPTION
This addresses an issue where `-` characters are allowed in Field Variable Names when they shouldn't be. Reason being is dashes are not allowed in MySQL Column names. Since we use the Field Variable Name as the Column name in the respective CDATA table we cannot allow the dashes in the Variable Names.