### PR TITLE
issue: Transfer Empty Comments Var

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2725,7 +2725,7 @@ implements RestrictedAccess, Threadable, Searchable {
              && ($msg=$tpl->getTransferAlertMsgTemplate())
          ) {
             $msg = $this->replaceVars($msg->asArray(),
-                array('comments' => $note, 'staff' => $thisstaff));
+                array('comments' => $note ?: '', 'staff' => $thisstaff));
             // Recipients
             $recipients = array();
             // Assigned staff or team... if any


### PR DESCRIPTION
This addresses an issue where the `comments` variable is not replaced in the Ticket Transfer Alert if there is no comment provided. This adds a ternary operator to the `comments` variable assignment to see if there is a value. If so it will use the value if not it will default to an empty string. This is so the variable can be replaced with nothing which is the intended end result.