### PR TITLE
issue: Plain-text Base64

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -106,7 +106,7 @@ namespace osTicket\Mail {
             $part = new MimePart($text);
             $part->type = Mime::TYPE_TEXT;
             $part->charset = $this->charset;
-            $part->encoding = $encoding ?: Mime::ENCODING_BASE64;
+            $part->encoding = $encoding;
             $this->addMimeContent($part);
         }
 


### PR DESCRIPTION
This addresses an issue where Base64 encoding plain-text content leads to raw encoded data being displayed in the mail client. This removes the Base64 encoding from plain-text emails so the content displays properly. To note, when you look at providers like Gmail, etc. they do not Base64 encode Plain-text nor HTML content.