### PR TITLE
issue: Content Management Errors

### DIFF
--- a/include/ajax.content.php
+++ b/include/ajax.content.php
@@ -185,7 +185,7 @@ class ContentAjaxAPI extends AjaxController {
     }
 
     function updateContent($id) {
-        global $thisstaff;
+        global $thisstaff, $cfg;
 
         if (!$thisstaff || !$thisstaff->isAdmin())
             Http::response(403, 'Access Denied');
@@ -206,6 +206,7 @@ class ContentAjaxAPI extends AjaxController {
         }
         if (!$errors['err'])
             $errors['err'] = __('Correct any errors below and try again.');
+        $langs = Internationalization::getConfiguredSystemLanguages();
         $info = $_POST;
         $errors = Format::htmlchars($errors);
         include STAFFINC_DIR . 'templates/content-manage.tmpl.php';


### PR DESCRIPTION
This addresses an issue where if you update the User Account Confirmation Email template for example and it has validation errors the system will throw a fatal error. This is due to a missing `$langs` variable and a missing `$cfg` global. This adds the missing variable and global back to avoid fatal errors.