### PR TITLE
issue: Regex OR Operator

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -538,7 +538,7 @@ class Format {
                 '/[\x{2310}-\x{231F}]/u',   # Hourglass/Watch
                 '/[\x{1000B6}]/u',          # Private Use Area (Plane 16)
                 '/[\x{2322}-\x{232F}]/u',   # Keyboard
-                '/[\x{00B0}|\x{00A9}]/u'    # Degrees/Copyright
+                '/\x{00B0}|\x{00BA}/u'      # Degree Symbol
             ), '', $text);
     }
 


### PR DESCRIPTION
This addresses issue #6817 where when using an OR operator in the Regular Expression validation textbox for a Short Answer field it gets removed without warning. This is due to a malformed Regex statement within the `Format::strip_emoticons()` function. This simply removes the brackets from the OR comparison as brackets are only used for range comparisons (eg. `/[\x{2310}-\x{231F}]/u`).