### PR TITLE
Remove regex bug that deletes pipe characters "|" from all thread entries

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -538,7 +538,7 @@ class Format {
                 '/[\x{2310}-\x{231F}]/u',   # Hourglass/Watch
                 '/[\x{1000B6}]/u',          # Private Use Area (Plane 16)
                 '/[\x{2322}-\x{232F}]/u',   # Keyboard
-                '/[\x{00B0}|\x{00A9}]/u'    # Degrees/Copyright
+                '/[\x{00B0}]/u'             # Degrees
             ), '', $text);
     }
 


### PR DESCRIPTION
In JediKev's b843fb15030c2566af415cda049be30a25ab4eb2 the regex was '/[\x{00B0}|\x{00A9}]/u' was added, with the intention of removing degrees -or -copyright.  But this bracketed section is a character class, not a sub-expression. So what it actually does is remove any of: degrees, |, or copyright.

Since an earlier line already removes copyright (A9) I just updated the new expression to be a character class of one. 

This could be even more concise as just: /\x{00B0}/u