### PR TITLE
Fixing missing filename in filedrop value attribte when using canned reply

### DIFF
--- a/js/filedrop.field.js
+++ b/js/filedrop.field.js
@@ -174,7 +174,7 @@
             .attr({'aria-valuemin':0,'aria-valuemax':100})
             .hide())
           .append($('<input type="hidden"/>').attr('name', this.options.name)
-            .val(file.id))
+            .val(''+file.id+','+file.name))
       if (this.options.deletable) {
         filenode.prepend($('<span><i class="icon-trash"></i></span>')
           .addClass('trash pull-right')


### PR DESCRIPTION
Possible fix for #6665 

This could (and probably should) also be handled server-side, but this solution was faster to implement for me.

The problem stems from omiting the name of the uploaded file when using a canned reply.
It seems like the server script does not parse the uploaded file correctly when only using the attachment id only and just completely drops the attachment:

<img width="257" height="44" alt="Screenshot 2025-08-12 at 16 13 30" src="https://github.com/user-attachments/assets/c8f589b7-819f-4d66-9121-1b565a993f3d" />

vs

<img width="392" height="45" alt="Screenshot 2025-08-12 at 16 14 25" src="https://github.com/user-attachments/assets/9b92f387-be5e-4caf-89fa-7465a91fd709" />
