### PR TITLE
Add support for WEBP-files for Login / Login Backdrop pictures

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -366,6 +366,7 @@ class AttachmentFile extends VerySimpleModel
                 case IMAGETYPE_GIF:
                 case IMAGETYPE_JPEG:
                 case IMAGETYPE_PNG:
+                case IMAGETYPE_WEBP:
                     break;
                 default:
                     $error = __('Invalid image file type');
@@ -387,6 +388,7 @@ class AttachmentFile extends VerySimpleModel
                 case IMAGETYPE_GIF:
                 case IMAGETYPE_JPEG:
                 case IMAGETYPE_PNG:
+                case IMAGETYPE_WEBP:
                     break;
                 default:
                     $error = __('Invalid image file type');


### PR DESCRIPTION
As the WEBP-format slowly becomes standard in all browsers and offers way smaller filesizes with excellent picture quality, I think it is time to allow this also as supported filetype in osTicket.

This PR adds IMAGETYPE_WEBP to the supported type in class.file.php.