### PR TITLE
Use DOMDocument->documentElement

### DIFF
--- a/include/html2text.php
+++ b/include/html2text.php
@@ -91,9 +91,10 @@ function identify_node($node, $parent=null) {
     if ($node instanceof DOMText)
         return $node;
     if ($node instanceof DOMDocument)
-        return identify_node($node->childNodes->item(1), $parent);
+        return identify_node($node->documentElement, $parent);
     if ($node instanceof DOMDocumentType
-            || $node instanceof DOMComment)
+            || $node instanceof DOMComment
+            || $node == null)
         // ignore
         return "";
 


### PR DESCRIPTION
Do not assume second DOMDocument child is the first document element. Instead use the dedicated documentElement property.

e.g. in recent libxml 2.14 running `<?xml encoding="utf-8"?><h3>` via DOMDocument::loadHTML (without any options) changed from returning `[DOMProcessingInstruction, DOMElement]` to `[DOMDocumentType, DOMComment, DOMElement]`