### PR TITLE
Patch PEAR DNS2 to fix Implicitly marking parameters as nullable

### DIFF
--- a/include/pear/Net/DNS2.php
+++ b/include/pear/Net/DNS2.php
@@ -254,7 +254,7 @@ class Net_DNS2
      * @access public
      *
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         //
         // check for the sockets extension

--- a/include/pear/Net/DNS2/Exception.php
+++ b/include/pear/Net/DNS2/Exception.php
@@ -80,8 +80,8 @@ class Net_DNS2_Exception extends Exception
         $message = '', 
         $code = 0, 
         $previous = null, 
-        Net_DNS2_Packet_Request $request = null,
-        Net_DNS2_Packet_Response $response = null
+        ?Net_DNS2_Packet_Request $request = null,
+        ?Net_DNS2_Packet_Response $response = null
     ) {
         //
         // store the request/response objects (if passed)

--- a/include/pear/Net/DNS2/RR.php
+++ b/include/pear/Net/DNS2/RR.php
@@ -178,7 +178,7 @@ abstract class Net_DNS2_RR
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, ?array $rr = null)
     {
         if ( (!is_null($packet)) && (!is_null($rr)) ) {
 

--- a/include/pear/Net/DNS2/RR/CERT.php
+++ b/include/pear/Net/DNS2/RR/CERT.php
@@ -132,7 +132,7 @@ class Net_DNS2_RR_CERT extends Net_DNS2_RR
      * @return
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, ?array $rr = null)
     {
         parent::__construct($packet, $rr);
     

--- a/include/pear/Net/DNS2/RR/OPT.php
+++ b/include/pear/Net/DNS2/RR/OPT.php
@@ -120,7 +120,7 @@ class Net_DNS2_RR_OPT extends Net_DNS2_RR
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, ?array $rr = null)
     {
         //
         // this is for when we're manually building an OPT RR object; we aren't

--- a/include/pear/Net/DNS2/Resolver.php
+++ b/include/pear/Net/DNS2/Resolver.php
@@ -70,7 +70,7 @@ class Net_DNS2_Resolver extends Net_DNS2
      * @access public
      *
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         parent::__construct($options);
     }

--- a/include/pear/Net/DNS2/Updater.php
+++ b/include/pear/Net/DNS2/Updater.php
@@ -87,7 +87,7 @@ class Net_DNS2_Updater extends Net_DNS2
      * @access public
      *
      */
-    public function __construct($zone, array $options = null)
+    public function __construct($zone, ?array $options = null)
     {
         parent::__construct($options);
 


### PR DESCRIPTION
Fixes https://github.com/osTicket/osTicket/issues/6870