### PR TITLE
issue: SVG MIME Type

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -3997,7 +3997,8 @@ class FileUploadField extends FormField {
         // Check invalid image hacks
         if ($file['tmp_name']
                 && stripos($file['type'], 'image/') === 0
-                && !exif_imagetype($file['tmp_name']))
+                && !(exif_imagetype($file['tmp_name'])
+                    || mime_content_type($file['tmp_name']) === 'image/svg+xml'))
             return false;
 
         return true;


### PR DESCRIPTION
This addresses #6873 where SVG Image uploads are failing even with strict MIME checking disabled. This is due to the `exif_imagetype()` call that checks an image MIME type. This method does not work well with SVGs as it only checks the first few bytes. This adds a specific SVG check using `mime_content_type()` that can handle SVG MIME type checks.