### PR TITLE
Fix Banlist permission check

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -252,8 +252,7 @@ if($ticket->isOverdue())
                 } ?>
 
 
-<?php           if ($thisstaff->hasPerm(Email::PERM_BANLIST)
-                    && $role->hasPerm(Ticket::PERM_REPLY)) {
+<?php           if ($thisstaff->hasPerm(Email::PERM_BANLIST)) {
                      if(!$emailBanned) {?>
                         <li><a class="confirm-action" id="ticket-banemail"
                             href="#banemail"><i class="icon-ban-circle"></i> <?php echo sprintf(


### PR DESCRIPTION
This fixes a minor issue where, even if you have permission _Banlist_, you cannot see link _Ban/Unban Email_ unless you have a role with _ticket.reply_ enabled