### PR TITLE
Add WhatsApp ConvoChat Notifications Plugin

### DIFF
--- a/include/plugins/whatsapp-convo/README.md
+++ b/include/plugins/whatsapp-convo/README.md
@@ -1,0 +1,258 @@
+# Plugin WhatsApp ConvoChat para osTicket
+
+Plugin profesional para osTicket que envía notificaciones de WhatsApp a través de la API de ConvoChat cuando se crean tickets o se reciben mensajes.
+
+## 🌟 Características
+
+- ✅ Notificaciones automáticas de WhatsApp al crear tickets
+- ✅ Notificaciones automáticas al recibir mensajes/respuestas en tickets
+- ✅ Plantillas de mensajes personalizables
+- ✅ Soporte para variables dinámicas en plantillas
+- ✅ Modo debug para facilitar troubleshooting
+- ✅ Validación de configuración
+- ✅ Logs de errores automáticos
+
+## 📋 Requisitos
+
+- osTicket v1.10 o superior
+- PHP 7.0 o superior
+- Extensión cURL habilitada en PHP
+- Cuenta activa en ConvoChat
+- Cuenta de WhatsApp vinculada en ConvoChat
+- API Key de ConvoChat
+
+## 🔧 Instalación
+
+1. **Copiar archivos del plugin**
+
+   Los archivos del plugin ya deben estar en:
+   ```
+   include/plugins/whatsapp-convo/
+   ```
+
+2. **Acceder al panel de administración de osTicket**
+
+   Ir a: `Manage` → `Plugins`
+
+3. **Instalar el plugin**
+
+   - Buscar "WhatsApp ConvoChat Notifications" en la lista de plugins disponibles
+   - Hacer clic en "Install" o "Add New Instance"
+
+4. **Configurar el plugin**
+
+   Completar los siguientes campos obligatorios:
+
+## ⚙️ Configuración
+
+### Campos Obligatorios
+
+| Campo | Descripción | Ejemplo |
+|-------|-------------|---------|
+| **API Secret** | Clave API de ConvoChat (desde Tools → API Keys) | `abc123def456...` |
+| **WhatsApp Account ID** | ID único de su cuenta de WhatsApp en ConvoChat | `+522221234567` |
+| **Número de teléfono destinatario** | Número en formato E.164 que recibirá notificaciones | `+522221234567` |
+
+### Campos Opcionales
+
+| Campo | Descripción | Valor por defecto |
+|-------|-------------|-------------------|
+| **Notificar al crear ticket** | Activar/desactivar notificación de nuevos tickets | ✅ Activado |
+| **Notificar al recibir mensaje** | Activar/desactivar notificación de nuevos mensajes | ✅ Activado |
+| **API Base URL** | URL base de la API de ConvoChat | `https://sms.convo.chat/api` |
+| **Modo debug** | Guardar logs detallados en el sistema | ❌ Desactivado |
+
+### Plantillas de Mensajes
+
+#### Plantilla para Nuevo Ticket
+
+Variables disponibles:
+- `{{ticket_number}}` - Número del ticket
+- `{{subject}}` - Asunto del ticket
+- `{{name}}` - Nombre del usuario
+- `{{email}}` - Email del usuario
+- `{{message}}` - Contenido del primer mensaje
+
+**Plantilla por defecto:**
+```
+🎫 *Nuevo Ticket Creado*
+
+Ticket #{{ticket_number}}
+Asunto: {{subject}}
+De: {{name}} ({{email}})
+
+Mensaje:
+{{message}}
+```
+
+#### Plantilla para Nueva Respuesta
+
+Variables disponibles:
+- `{{ticket_number}}` - Número del ticket
+- `{{subject}}` - Asunto del ticket
+- `{{name}}` - Nombre de quien respondió
+- `{{message}}` - Contenido de la respuesta
+
+**Plantilla por defecto:**
+```
+💬 *Nueva Respuesta en Ticket*
+
+Ticket #{{ticket_number}}
+Asunto: {{subject}}
+De: {{name}}
+
+Respuesta:
+{{message}}
+```
+
+## 🚀 Cómo Obtener las Credenciales de ConvoChat
+
+### 1. Obtener API Secret
+
+1. Ingresar a su cuenta de ConvoChat
+2. Ir a `Tools` → `API Keys`
+3. Crear una nueva API Key o copiar una existente
+4. Copiar el `secret` generado
+
+### 2. Vincular Cuenta de WhatsApp
+
+Si aún no tiene una cuenta de WhatsApp vinculada:
+
+```bash
+# Endpoint para crear un nuevo QR
+GET https://sms.convo.chat/api/create/wa.link?secret=YOUR_API_SECRET
+
+# Respuesta incluirá:
+# - qrstring: String del código QR
+# - qrimageLink: URL de la imagen del QR para escanear
+# - infoLink: URL para verificar el estado de la vinculación
+```
+
+Pasos:
+1. Llamar al endpoint `create/wa.link` con su API Secret
+2. Escanear el código QR con WhatsApp
+3. Obtener el `WhatsApp Account ID` (número de teléfono vinculado)
+
+### 3. Obtener WhatsApp Account ID
+
+Si ya tiene una cuenta vinculada:
+
+```bash
+# Listar cuentas de WhatsApp
+GET https://sms.convo.chat/api/get/wa.accounts?secret=YOUR_API_SECRET
+```
+
+El `WhatsApp Account ID` es el número de teléfono de la cuenta (ej: `+522221234567`)
+
+## 🧪 Pruebas
+
+1. **Activar modo debug**
+   - En la configuración del plugin, activar "Modo debug"
+   - Los logs se guardarán en el log de errores de PHP
+
+2. **Crear un ticket de prueba**
+   - Crear un nuevo ticket desde el panel de cliente
+   - Verificar que llegue la notificación de WhatsApp
+   - Revisar los logs en caso de error
+
+3. **Enviar una respuesta**
+   - Responder a un ticket existente
+   - Verificar que llegue la notificación de nueva respuesta
+
+## 🐛 Troubleshooting
+
+### No llegan notificaciones
+
+1. **Verificar que el plugin esté activo**
+   - `Manage` → `Plugins` → verificar que esté "Active"
+
+2. **Verificar configuración**
+   - API Secret correcto
+   - WhatsApp Account ID válido
+   - Número de teléfono en formato E.164 (con +)
+
+3. **Revisar logs**
+   - Activar "Modo debug"
+   - Revisar el log de errores de PHP
+   - Buscar líneas que contengan `[WhatsAppConvo]`
+
+4. **Verificar conectividad**
+   - El servidor debe poder hacer peticiones HTTPS a `sms.convo.chat`
+   - cURL debe estar habilitado
+
+### Error: "cURL no está disponible"
+
+Instalar/habilitar la extensión cURL de PHP:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install php-curl
+sudo service apache2 restart
+
+# CentOS/RHEL
+sudo yum install php-curl
+sudo service httpd restart
+```
+
+### Error: "Configuración incompleta"
+
+Verificar que todos los campos obligatorios estén completos:
+- API Secret
+- WhatsApp Account ID
+- Número de teléfono destinatario
+
+## 📝 Formato de Número de Teléfono
+
+El número de teléfono debe estar en formato **E.164**:
+
+✅ **Correcto:**
+- `+522221234567` (México)
+- `+13051234567` (USA)
+- `+34912345678` (España)
+
+❌ **Incorrecto:**
+- `522221234567` (falta el +)
+- `2221234567` (falta código de país)
+- `+52 222 123 4567` (tiene espacios)
+- `+52-222-123-4567` (tiene guiones)
+
+## 🔐 Seguridad
+
+- El API Secret se almacena en la base de datos de osTicket
+- Todas las peticiones se hacen sobre HTTPS
+- Se valida el certificado SSL de ConvoChat
+- No se almacenan logs de mensajes por defecto (solo en modo debug)
+
+## 📚 API de ConvoChat Utilizada
+
+El plugin utiliza el endpoint:
+```
+POST https://sms.convo.chat/api/send/whatsapp
+```
+
+Parámetros enviados:
+- `secret`: API Secret
+- `account`: WhatsApp Account ID
+- `recipient`: Número de teléfono destinatario
+- `type`: "text"
+- `message`: Contenido del mensaje
+- `priority`: 1 (alta prioridad)
+
+## 📄 Licencia
+
+Este plugin se distribuye bajo la misma licencia que osTicket (GPL).
+
+## 👨‍💻 Soporte
+
+Para reportar problemas o sugerencias:
+- Revisar los logs con modo debug activado
+- Verificar la configuración de ConvoChat
+- Contactar al administrador del sistema
+
+## 🔄 Versión
+
+**v1.0.0** - Versión inicial
+- Soporte para notificaciones de tickets creados
+- Soporte para notificaciones de mensajes/respuestas
+- Plantillas personalizables
+- Modo debug

--- a/include/plugins/whatsapp-convo/config.php
+++ b/include/plugins/whatsapp-convo/config.php
@@ -1,0 +1,116 @@
+<?php
+
+require_once INCLUDE_DIR . 'class.plugin.php';
+require_once INCLUDE_DIR . 'class.forms.php';
+
+class WhatsAppConvoPluginConfig extends PluginConfig {
+
+    function getOptions() {
+        return array(
+            'api_secret' => new TextboxField(array(
+                'label' => __('API Secret'),
+                'required' => true,
+                'configuration' => array(
+                    'size' => 60,
+                    'length' => 100,
+                ),
+                'hint' => __('Su clave API de ConvoChat (desde Tools → API Keys)'),
+            )),
+            'whatsapp_account' => new TextboxField(array(
+                'label' => __('WhatsApp Account ID'),
+                'required' => true,
+                'configuration' => array(
+                    'size' => 60,
+                    'length' => 100,
+                ),
+                'hint' => __('ID único de su cuenta de WhatsApp vinculada en ConvoChat'),
+            )),
+            'notify_on_ticket_create' => new BooleanField(array(
+                'label' => __('Notificar al crear ticket'),
+                'default' => true,
+                'configuration' => array(
+                    'desc' => __('Enviar notificación de WhatsApp cuando se crea un nuevo ticket'),
+                ),
+            )),
+            'notify_on_message' => new BooleanField(array(
+                'label' => __('Notificar al recibir mensaje'),
+                'default' => true,
+                'configuration' => array(
+                    'desc' => __('Enviar notificación de WhatsApp cuando se añade un mensaje al ticket'),
+                ),
+            )),
+            'recipient_phone' => new TextboxField(array(
+                'label' => __('Número de teléfono destinatario'),
+                'required' => true,
+                'configuration' => array(
+                    'size' => 60,
+                    'length' => 20,
+                ),
+                'hint' => __('Número de teléfono en formato E.164 (ej: +522221234567) para recibir notificaciones'),
+            )),
+            'api_base_url' => new TextboxField(array(
+                'label' => __('API Base URL'),
+                'default' => 'https://sms.convo.chat/api',
+                'required' => true,
+                'configuration' => array(
+                    'size' => 60,
+                    'length' => 100,
+                ),
+                'hint' => __('URL base de la API de ConvoChat'),
+            )),
+            'message_template_new_ticket' => new TextareaField(array(
+                'label' => __('Plantilla mensaje nuevo ticket'),
+                'default' => "🎫 *Nuevo Ticket Creado*\n\nTicket #{{ticket_number}}\nAsunto: {{subject}}\nDe: {{name}} ({{email}})\n\nMensaje:\n{{message}}",
+                'required' => true,
+                'configuration' => array(
+                    'rows' => 6,
+                    'cols' => 60,
+                ),
+                'hint' => __('Variables disponibles: {{ticket_number}}, {{subject}}, {{name}}, {{email}}, {{message}}'),
+            )),
+            'message_template_new_message' => new TextareaField(array(
+                'label' => __('Plantilla mensaje nueva respuesta'),
+                'default' => "💬 *Nueva Respuesta en Ticket*\n\nTicket #{{ticket_number}}\nAsunto: {{subject}}\nDe: {{name}}\n\nRespuesta:\n{{message}}",
+                'required' => true,
+                'configuration' => array(
+                    'rows' => 6,
+                    'cols' => 60,
+                ),
+                'hint' => __('Variables disponibles: {{ticket_number}}, {{subject}}, {{name}}, {{message}}'),
+            )),
+            'debug_mode' => new BooleanField(array(
+                'label' => __('Modo debug'),
+                'default' => false,
+                'configuration' => array(
+                    'desc' => __('Guardar logs de depuración en el log del sistema'),
+                ),
+            )),
+        );
+    }
+
+    function pre_save(&$config, &$errors) {
+        // Validar formato de número de teléfono
+        if (isset($config['recipient_phone'])) {
+            $phone = trim($config['recipient_phone']);
+            // Verificar que el número empiece con +
+            if (!preg_match('/^\+\d{10,15}$/', $phone)) {
+                $errors['recipient_phone'] = __('El número de teléfono debe estar en formato E.164 (ej: +522221234567)');
+                return false;
+            }
+        }
+
+        // Validar API Secret
+        if (isset($config['api_secret']) && empty(trim($config['api_secret']))) {
+            $errors['api_secret'] = __('La API Secret es requerida');
+            return false;
+        }
+
+        // Validar WhatsApp Account ID
+        if (isset($config['whatsapp_account']) && empty(trim($config['whatsapp_account']))) {
+            $errors['whatsapp_account'] = __('El WhatsApp Account ID es requerido');
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/include/plugins/whatsapp-convo/plugin.php
+++ b/include/plugins/whatsapp-convo/plugin.php
@@ -1,0 +1,11 @@
+<?php
+
+return array(
+    'id' =>             'osticket:whatsapp-convo',
+    'version' =>        '1.0.0',
+    'name' =>           'WhatsApp ConvoChat Notifications',
+    'author' =>         'osTicket',
+    'description' =>    'Envía notificaciones de WhatsApp a través de ConvoChat cuando se crean tickets o se reciben mensajes',
+    'url' =>            'https://www.osticket.com',
+    'plugin' =>         'whatsapp.php:WhatsAppConvoPlugin',
+);

--- a/include/plugins/whatsapp-convo/whatsapp.php
+++ b/include/plugins/whatsapp-convo/whatsapp.php
@@ -1,0 +1,262 @@
+<?php
+
+require_once(INCLUDE_DIR . 'class.signal.php');
+require_once(INCLUDE_DIR . 'class.plugin.php');
+require_once('config.php');
+
+class WhatsAppConvoPlugin extends Plugin {
+    var $config_class = 'WhatsAppConvoPluginConfig';
+
+    /**
+     * Bootstrap del plugin - se ejecuta cuando el plugin está activo
+     */
+    function bootstrap() {
+        // Obtener la configuración
+        $config = $this->getConfig();
+
+        // Conectar señales solo si están habilitadas
+        if ($config->get('notify_on_ticket_create')) {
+            Signal::connect('ticket.created', array($this, 'onTicketCreated'));
+        }
+
+        if ($config->get('notify_on_message')) {
+            Signal::connect('threadentry.created', array($this, 'onThreadEntryCreated'));
+        }
+    }
+
+    /**
+     * Manejador de evento: ticket creado
+     */
+    function onTicketCreated($ticket, $data = null) {
+        $config = $this->getConfig();
+
+        if (!$config->get('notify_on_ticket_create')) {
+            return;
+        }
+
+        try {
+            $this->log('Ticket creado: #' . $ticket->getNumber());
+
+            // Obtener información del ticket
+            $ticketInfo = array(
+                'ticket_number' => $ticket->getNumber(),
+                'subject' => $ticket->getSubject(),
+                'name' => $ticket->getName(),
+                'email' => $ticket->getEmail(),
+                'message' => $this->getTicketMessage($ticket),
+            );
+
+            // Generar mensaje usando la plantilla
+            $message = $this->renderTemplate(
+                $config->get('message_template_new_ticket'),
+                $ticketInfo
+            );
+
+            // Enviar mensaje de WhatsApp
+            $this->sendWhatsAppMessage($message);
+
+        } catch (Exception $e) {
+            $this->logError('Error al procesar ticket creado: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Manejador de evento: entrada de hilo creada (mensaje/respuesta)
+     */
+    function onThreadEntryCreated($entry, $data = null) {
+        $config = $this->getConfig();
+
+        if (!$config->get('notify_on_message')) {
+            return;
+        }
+
+        try {
+            // Obtener el ticket asociado
+            $thread = $entry->getThread();
+            if (!$thread) {
+                return;
+            }
+
+            $ticket = $thread->getObject();
+            if (!$ticket || !($ticket instanceof Ticket)) {
+                return;
+            }
+
+            $this->log('Nueva entrada en ticket: #' . $ticket->getNumber());
+
+            // Obtener información de la entrada
+            $poster = $entry->getPoster();
+            $name = is_object($poster) ? $poster->getName() : $entry->getName();
+
+            $entryInfo = array(
+                'ticket_number' => $ticket->getNumber(),
+                'subject' => $ticket->getSubject(),
+                'name' => $name,
+                'message' => $this->cleanMessage($entry->getBody()),
+            );
+
+            // Generar mensaje usando la plantilla
+            $message = $this->renderTemplate(
+                $config->get('message_template_new_message'),
+                $entryInfo
+            );
+
+            // Enviar mensaje de WhatsApp
+            $this->sendWhatsAppMessage($message);
+
+        } catch (Exception $e) {
+            $this->logError('Error al procesar entrada de hilo: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Obtener el primer mensaje del ticket
+     */
+    private function getTicketMessage($ticket) {
+        try {
+            $thread = $ticket->getThread();
+            if ($thread) {
+                $entries = $thread->getEntries();
+                if ($entries && count($entries) > 0) {
+                    $firstEntry = $entries[0];
+                    return $this->cleanMessage($firstEntry->getBody());
+                }
+            }
+        } catch (Exception $e) {
+            $this->logError('Error al obtener mensaje del ticket: ' . $e->getMessage());
+        }
+        return '';
+    }
+
+    /**
+     * Limpiar el mensaje de HTML y formatear
+     */
+    private function cleanMessage($message) {
+        // Eliminar tags HTML
+        $message = strip_tags($message);
+        // Decodificar entidades HTML
+        $message = html_entity_decode($message, ENT_QUOTES, 'UTF-8');
+        // Limitar longitud
+        if (strlen($message) > 500) {
+            $message = substr($message, 0, 497) . '...';
+        }
+        return trim($message);
+    }
+
+    /**
+     * Renderizar plantilla con variables
+     */
+    private function renderTemplate($template, $variables) {
+        $message = $template;
+        foreach ($variables as $key => $value) {
+            $message = str_replace('{{' . $key . '}}', $value, $message);
+        }
+        return $message;
+    }
+
+    /**
+     * Enviar mensaje de WhatsApp usando la API de ConvoChat
+     */
+    private function sendWhatsAppMessage($message) {
+        $config = $this->getConfig();
+
+        $apiSecret = $config->get('api_secret');
+        $whatsappAccount = $config->get('whatsapp_account');
+        $recipientPhone = $config->get('recipient_phone');
+        $apiBaseUrl = rtrim($config->get('api_base_url'), '/');
+
+        if (empty($apiSecret) || empty($whatsappAccount) || empty($recipientPhone)) {
+            $this->logError('Configuración incompleta: API Secret, WhatsApp Account o Recipient Phone faltantes');
+            return false;
+        }
+
+        $url = $apiBaseUrl . '/send/whatsapp';
+
+        // Preparar datos para enviar
+        $postData = array(
+            'secret' => $apiSecret,
+            'account' => $whatsappAccount,
+            'recipient' => $recipientPhone,
+            'type' => 'text',
+            'message' => $message,
+            'priority' => 1, // Alta prioridad
+        );
+
+        $this->log('Enviando WhatsApp a: ' . $recipientPhone);
+
+        // Enviar petición HTTP
+        $response = $this->sendHttpRequest($url, $postData);
+
+        if ($response) {
+            $responseData = json_decode($response, true);
+
+            if (isset($responseData['status']) && $responseData['status'] == 200) {
+                $this->log('WhatsApp enviado exitosamente. Message ID: ' .
+                    (isset($responseData['data']['messageId']) ? $responseData['data']['messageId'] : 'N/A'));
+                return true;
+            } else {
+                $errorMsg = isset($responseData['message']) ? $responseData['message'] : 'Error desconocido';
+                $this->logError('Error al enviar WhatsApp: ' . $errorMsg);
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Enviar petición HTTP usando cURL
+     */
+    private function sendHttpRequest($url, $postData) {
+        if (!function_exists('curl_init')) {
+            $this->logError('cURL no está disponible en el servidor');
+            return false;
+        }
+
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($postData));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            'Content-Type: application/x-www-form-urlencoded',
+        ));
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+
+        curl_close($ch);
+
+        if ($curlError) {
+            $this->logError('cURL Error: ' . $curlError);
+            return false;
+        }
+
+        if ($httpCode != 200) {
+            $this->logError('HTTP Error ' . $httpCode . ': ' . $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Log de mensajes (si debug está habilitado)
+     */
+    private function log($message) {
+        $config = $this->getConfig();
+        if ($config->get('debug_mode')) {
+            error_log('[WhatsAppConvo] ' . $message);
+        }
+    }
+
+    /**
+     * Log de errores (siempre se registra)
+     */
+    private function logError($message) {
+        error_log('[WhatsAppConvo ERROR] ' . $message);
+    }
+}


### PR DESCRIPTION
Implementación completa de plugin para osTicket que envía notificaciones de WhatsApp a través de la API de ConvoChat.

Características principales:
- Notificaciones automáticas al crear tickets
- Notificaciones automáticas al recibir mensajes/respuestas
- Plantillas de mensajes personalizables con variables dinámicas
- Configuración completa desde el panel de admin de osTicket
- Soporte para formato E.164 en números de teléfono
- Modo debug para troubleshooting
- Validación de configuración
- Logs automáticos de errores
- Integración con sistema de señales de osTicket

Archivos incluidos:
- plugin.php: Descriptor del plugin
- config.php: Clase de configuración con todos los campos necesarios
- whatsapp.php: Lógica principal del plugin
- README.md: Documentación completa de instalación y uso

El plugin se conecta a las señales:
- ticket.created: Para notificar cuando se crea un ticket
- threadentry.created: Para notificar cuando se añade un mensaje

Usa el endpoint POST /send/whatsapp de la API de ConvoChat para enviar mensajes de WhatsApp con prioridad alta.