### PR TITLE
Add docker containerezation 

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -106,6 +106,12 @@ COPY --from=plugins-build /tmp/osticket-plugins/ /var/www/html/include/plugins/
 COPY . /var/www/html
 COPY include/ost-sampleconfig.php include/ost-config.php
 
+ARG OSTINSTALLED=0
+RUN set -eux; \
+    if [ 1 = $OSTINSTALLED ]; then \
+       rm -r ./setup; \
+    fi
+
 # Set proper permissions (will be set on mounted volume at runtime)
 # Note: We keep root user for proper file permissions in container
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,114 @@
+FROM php:8.2-fpm AS system
+
+# Install necessary components
+RUN set -eux; \
+    echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        curl \
+        libc-client2007e-dev \
+        libkrb5-dev \
+        libxml2-dev \
+        libzip-dev \
+        unzip; \
+    rm -f /etc/apt/sources.list.d/bookworm.list; \
+    rm -rf /var/lib/apt/lists/*
+
+# Build stage for system plugins
+FROM system AS plugins-build
+
+ARG INSTALL_SYS_PLUGINS=audit,auth-2fa,auth-cas,auth-ldap,auth-oauth2,auth-passthru,storage-fs,storage-s3
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install git for cloning
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git; \
+    rm -f /etc/apt/sources.list.d/bookworm.list; \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone osTicket-plugins repository and build plugins
+RUN set -eux; \
+    mkdir -p "/tmp"; \
+    cd "/tmp"; \
+    git clone --depth 1 https://github.com/osTicket/osTicket-plugins.git osticket-plugins; \
+    cd "/tmp/osticket-plugins"; \
+    rm -rf .git; \
+    php make.php hydrate; \
+    IFS=','; \
+    for plugin in $INSTALL_SYS_PLUGINS; do \
+        plugin=$(echo "$plugin" | xargs); \
+        php -dphar.readonly=0 make.php build "$plugin"; \
+    done; \
+    find . ! -name . -type d -print0 -maxdepth 1 | xargs -0 rm -r --; \
+    find . -type f -not -name '*.phar' -print0 | xargs -0 rm -- ; \
+    rm composer.phar
+
+# Main application stage
+FROM system AS app
+
+ENV TZ Europe/Kiev
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install system dependencies and IMAP requirements in a single layer
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        antiword \
+        catdoc \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg62-turbo-dev \
+        libonig-dev \
+        libpng-dev \
+        nginx \
+        poppler-utils; \
+    rm -f /etc/apt/sources.list.d/bookworm.list; \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure and install PHP extensions
+# Note: xml, dom, phar, fileinfo, opcache are built-in in PHP 8.2
+RUN set -eux; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-install -j"$(nproc)" \
+        mysqli \
+        gd \
+        gettext \
+        mbstring \
+        intl \
+        zip
+
+# Configure and install IMAP extension
+RUN set -eux; \
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+    docker-php-ext-install -j"$(nproc)" imap
+
+# Install APCu extension
+RUN set -eux; \
+    pecl install apcu; \
+    docker-php-ext-enable apcu; \
+    rm -rf /tmp/pear
+
+# Copy PHP configuration
+COPY .docker/php/php.ini /usr/local/etc/php/conf.d/osticket.ini
+
+# Remove default nginx configuration and copy project-specific config
+RUN rm -f /etc/nginx/conf.d/default.conf && rm -f /etc/nginx/sites-enabled/default
+COPY .docker/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Copy built phar plugins from plugins-build stage
+COPY --from=plugins-build /tmp/osticket-plugins/ /var/www/html/include/plugins/
+
+COPY . /var/www/html
+COPY include/ost-sampleconfig.php include/ost-config.php
+
+# Set proper permissions (will be set on mounted volume at runtime)
+# Note: We keep root user for proper file permissions in container
+
+EXPOSE 80
+
+CMD ["bash", "-c", "php-fpm -D && nginx -g 'daemon off;'"]

--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80 default;
+    listen [::]:80 default;
+
+    root /var/www/html;
+    index index.php;
+
+    client_max_body_size 50M;
+
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        if (!-f $document_root$fastcgi_script_name) {
+            return 404;
+        }
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        include fastcgi_params;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Block direct access to include files (security)
+    location ~ ^/include/.*\.php$ {
+        deny all;
+    }
+
+    location ~* \.(jpg|jpeg|gif|png|css|js|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+}

--- a/.docker/php/php.ini
+++ b/.docker/php/php.ini
@@ -1,0 +1,62 @@
+; osTicket PHP Configuration
+
+; Memory and execution limits
+memory_limit = 256M
+max_execution_time = 300
+max_input_time = 300
+
+; File uploads
+upload_max_filesize = 50M
+post_max_size = 50M
+max_file_uploads = 20
+
+; Error reporting (development)
+display_errors = On
+display_startup_errors = On
+error_reporting = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT
+log_errors = On
+error_log = /var/log/php_errors.log
+
+; Session settings
+session.save_handler = files
+session.save_path = "/tmp"
+session.gc_maxlifetime = 86400
+session.cookie_httponly = 1
+session.use_strict_mode = 1
+
+; Security
+allow_url_fopen = Off
+allow_url_include = Off
+expose_php = Off
+
+; Date and timezone
+date.timezone = UTC
+
+; OPcache settings
+opcache.enable = 1
+opcache.enable_cli = 0
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 8
+opcache.max_accelerated_files = 10000
+opcache.revalidate_freq = 2
+opcache.fast_shutdown = 1
+
+; APCu settings
+apc.enabled = 1
+apc.shm_size = 64M
+apc.ttl = 7200
+apc.enable_cli = 0
+
+; Default charset
+default_charset = "UTF-8"
+
+; mbstring settings
+mbstring.language = Neutral
+mbstring.internal_encoding = UTF-8
+mbstring.http_input = UTF-8
+mbstring.http_output = UTF-8
+mbstring.encoding_translation = Off
+mbstring.detect_order = auto
+mbstring.substitute_character = none
+
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.docker/mysql/init-auth.sql

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Database credentials
+MYSQL_ROOT_PASSWORD=rootpassword
+MYSQL_DATABASE=osticket
+MYSQL_USER=osticket
+MYSQL_PASSWORD=osticket
+MYSQL_PORT=3306
+
+# Web server port
+NGINX_PORT=80
+
+# Mail testing service (MailHog) ports
+MAILHOG_SMTP_PORT=1025
+MAILHOG_WEB_PORT=8025
+
+###> osTicket runtime configuration ###
+ADMIN_EMAIL=admin@example.local
+# Application mail defaults (used by osTicket configuration)
+MAIL_HOST=mailhog
+MAIL_PORT=1025
+MAIL_FROM=osticket@example.local
+# Path to local ost-config.php for mounting into the container
+OST_CONFIG_PATH=./include/ost-config.php
+# Leave SECRET_SALT empty to auto-generate on first container start
+SECRET_SALT=
+TABLE_PREFIX=ost_
+###< osTicket runtime configuration ###

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .htaccess
 php53.cgi
 include/ost-config.php
@@ -20,3 +21,7 @@ stage
 include/mpdf/ttfontdata
 include/mpdf/tmp
 nbproject/
+
+/.env
+/.docker/mysql/init-auth.sql
+/compose.override.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+## Local Development Setup with Docker
+
+To get started, ensure that installed required tools:
+1. [docker](https://docs.docker.com/engine/install/)
+2. [docker-compose](https://docs.docker.com/compose/install/)
+
+### Run locally
+
+1. (Optional) Copy [compose.override.example.yaml](compose.override.example.yaml) 
+   to [compose.override.yaml](compose.override.yaml) and update if necessary. 
+2. Build & run
+   ```shell
+   docker compose up --build
+   ```
+3. (Optional) Importing of database dump
+   ```shell
+   docker exec -i $(docker compose ps -q mysql) mysql -u${MYSQL_USER} -p${MYSQL_PASSWORD} ${MYSQL_DATABASE} < dump.sql
+   ```
+   where "dump.sql" is the path to the database dump
+   You should request the database dump from your mentor.
+
+You can now access osTicket at http://localhost.
+
+## Removing of outdated local branches
+
+To speed up removing of outdated local branches after the code review just execute command:
+```shell
+git branch --format='%(refname:short)' \
+   | grep -v "$(git rev-parse --abbrev-ref HEAD)" \
+   | xargs -n 1 git branch -D
+```
+This script deletes all local branches except the current one.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Create your own fork of the project and use
 the feature is published in your fork, send a pull request to begin the
 conversation of integrating your new feature into osTicket.
 
+Read [CONTRIBUTING.md](CONTRIBUTING.md) to find more instructions.
+
 ### Localization
 [![Crowdin](https://badges.crowdin.net/osticket-official/localized.svg)](https://crowdin.com/project/osticket-official)
 

--- a/compose.override.example.yaml
+++ b/compose.override.example.yaml
@@ -4,7 +4,6 @@ services:
     volumes:
       - .:/var/www/html
 
-
   # Catching of outgoing emails
   mailhog:
     image: mailhog/mailhog:latest
@@ -18,3 +17,6 @@ services:
       - mailhog_data:/mailhog/data
     networks:
       - osticket
+
+volumes:
+  mailhog_data:

--- a/compose.override.example.yaml
+++ b/compose.override.example.yaml
@@ -1,0 +1,20 @@
+# copy to compose.override.yaml and update as you wish for native using
+services:
+  app:
+    volumes:
+      - .:/var/www/html
+
+
+  # Catching of outgoing emails
+  mailhog:
+    image: mailhog/mailhog:latest
+    environment:
+      - MH_STORAGE=maildir
+      - MH_MAILDIR_PATH=/mailhog/data
+    ports:
+      - "${MAILHOG_SMTP_PORT:-1025}:1025"
+      - "${MAILHOG_WEB_PORT:-8025}:8025"
+    volumes:
+      - mailhog_data:/mailhog/data
+    networks:
+      - osticket

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,5 +50,4 @@ services:
       - mysql_data:/var/lib/mysql
 
 volumes:
-  mailhog_data:
   mysql_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,54 @@
+networks:
+  osticket:
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile
+      args:
+        INSTALL_SYS_PLUGINS: ${INSTALL_SYS_PLUGINS:-audit,auth-2fa,auth-cas,auth-ldap,auth-oauth2,auth-passthru,storage-fs,storage-s3}
+        OSTICKET_USER_IDENTIFIER_TOKEN: ${OSTICKET_USER_IDENTIFIER_TOKEN:-}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      # create file compose.override.yaml to extend passing of variables
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
+      - DBHOST=mysql
+      - DBNAME=${MYSQL_DATABASE:-osticket}
+      - DBPASS=${MYSQL_PASSWORD:-osticket}
+      - DBUSER=${MYSQL_USER:-osticket}
+      - SECRET_SALT=${SECRET_SALT:-}
+      - TABLE_PREFIX=${TABLE_PREFIX:-ost_}
+    networks:
+      - osticket
+    ports:
+      - "${NGINX_PORT:-80}:80"
+    # create file compose.override.yaml to pass local context
+    # volumes:
+    #  - .:/var/www/html
+
+  mysql:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-osticket}
+      MYSQL_USER: ${MYSQL_USER:-osticket}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-osticket}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - osticket
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mailhog_data:
+  mysql_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
       args:
         INSTALL_SYS_PLUGINS: ${INSTALL_SYS_PLUGINS:-audit,auth-2fa,auth-cas,auth-ldap,auth-oauth2,auth-passthru,storage-fs,storage-s3}
         OSTICKET_USER_IDENTIFIER_TOKEN: ${OSTICKET_USER_IDENTIFIER_TOKEN:-}
+        OSTINSTALLED: ${OSTINSTALLED:-0}
     depends_on:
       mysql:
         condition: service_healthy

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -30,10 +30,10 @@ if(OSTINSTALLED!=TRUE){
 }
 
 # Encrypt/Decrypt secret key - randomly generated during installation.
-define('SECRET_SALT','%CONFIG-SIRI');
+define('SECRET_SALT', $_SERVER['SECRET_SALT'] ?? $_ENV['SECRET_SALT'] ?? '%CONFIG-SIRI');
 
 #Default admin email. Used only on db connection issues and related alerts.
-define('ADMIN_EMAIL','%ADMIN-EMAIL');
+define('ADMIN_EMAIL', $_SERVER['ADMIN_EMAIL'] ?? $_ENV['ADMIN_EMAIL'] ?? '%ADMIN-EMAIL');
 
 # Database Options
 # ====================================================
@@ -41,17 +41,17 @@ define('ADMIN_EMAIL','%ADMIN-EMAIL');
 #
 define('DBTYPE','mysql');
 #  DBHOST can have comma separated hosts (e.g db1:6033,db2:6033)
-define('DBHOST','%CONFIG-DBHOST');
-define('DBNAME','%CONFIG-DBNAME');
-define('DBUSER','%CONFIG-DBUSER');
-define('DBPASS','%CONFIG-DBPASS');
+define('DBHOST', $_SERVER['DBHOST'] ?? $_ENV['DBHOST'] ?? '%CONFIG-DBHOST');
+define('DBNAME', $_SERVER['DBNAME'] ?? $_ENV['DBNAME'] ?? '%CONFIG-DBNAME');
+define('DBUSER', $_SERVER['DBUSER'] ?? $_ENV['DBUSER'] ?? '%CONFIG-DBUSER');
+define('DBPASS', $_SERVER['DBPASS'] ?? $_ENV['DBPASS'] ?? '%CONFIG-DBPASS');
 
 # Database TCP/IP Connect Timeout (default: 3 seconds)
 # Timeout is important when DBHOST has multiple proxies to try
 # define('DBCONNECT_TIMEOUT', 3);
 
 # Table prefix
-define('TABLE_PREFIX','%CONFIG-PREFIX');
+define('TABLE_PREFIX', $_SERVER['TABLE_PREFIX'] ?? $_ENV['TABLE_PREFIX'] ?? '%CONFIG-PREFIX');
 
 #
 # SSL Options
@@ -133,7 +133,7 @@ define('TABLE_PREFIX','%CONFIG-PREFIX');
 # http://en.wikipedia.org/wiki/X-Forwarded-For
 #
 
-define('TRUSTED_PROXIES', '');
+define('TRUSTED_PROXIES', $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? '');
 
 
 # Option: LOCAL_NETWORKS (default: 127.0.0.0/24)

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -21,7 +21,7 @@ if(!strcasecmp(basename($_SERVER['SCRIPT_NAME']),basename(__FILE__)) || !defined
     die('kwaheri rafiki!');
 
 #Install flag
-define('OSTINSTALLED',FALSE);
+define('OSTINSTALLED', (bool) ($_SERVER['OSTINSTALLED'] ?? $_ENV['OSTINSTALLED'] ?? FALSE));
 if(OSTINSTALLED!=TRUE){
     if(!file_exists(ROOT_DIR.'setup/install.php')) die('Error: Contact system admin.'); //Something is really wrong!
     //Invoke the installer.

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -288,7 +288,7 @@ class Installer extends SetupWizard {
 
         //Rewrite the config file - MUST be done last to allow for installer recovery.
         $configFile = strtr($configFile, array(
-            "define('OSTINSTALLED',FALSE);" => "define('OSTINSTALLED',TRUE);",
+            'define(\'OSTINSTALLED\', (bool) ($_SERVER[\'OSTINSTALLED\'] ?? $_ENV[\'OSTINSTALLED\'] ?? FALSE));' => 'define(\'OSTINSTALLED\', (bool) ($_SERVER[\'OSTINSTALLED\'] ?? $_ENV[\'OSTINSTALLED\'] ?? FALSE));',
             '%ADMIN-EMAIL' => $vars['admin_email'],
             '%CONFIG-DBHOST' => $vars['dbhost'],
             '%CONFIG-DBNAME' => $vars['dbname'],

--- a/setup/inc/ost-sampleconfig.php
+++ b/setup/inc/ost-sampleconfig.php
@@ -20,7 +20,7 @@
 if(!strcasecmp(basename($_SERVER['SCRIPT_NAME']),basename(__FILE__)) || !defined('ROOT_PATH')) die('kwaheri rafiki!');
 
 #Install flag
-define('OSTINSTALLED',FALSE);
+define('OSTINSTALLED', (bool) ($_SERVER['OSTINSTALLED'] ?? $_ENV['OSTINSTALLED'] ?? FALSE));
 if(OSTINSTALLED!=TRUE){
     if(!file_exists(ROOT_PATH.'setup/install.php')) die('Error: Contact system admin.'); //Something is really wrong!
     //Invoke the installer.


### PR DESCRIPTION
**What is done:**
- Added building & running with `docker compose up`.
- Flexible configuration of docker services both via environment variables and native override-file (`compose.override.yaml`).
- Added example of `compose.override.yaml` with mailhog for the catching of outgoing emails during local development.
- Added easy installation of [system plugins](https://github.com/osTicket/osTicket-plugins) by one environment variable `INSTALL_SYS_PLUGINS`.
- Added native support of environment variables by config.
- Added instructions for local development with docker.