### PR TITLE
issue: POP OAuth2 Error REGEX

### DIFF
--- a/include/class.mail.php
+++ b/include/class.mail.php
@@ -412,7 +412,7 @@ namespace osTicket\Mail {
                     return true;
                 } elseif (preg_match('/^-ERR (.*+)$/i',
                             $response, $matches)) {
-                    throw new Exception($matches[2]);
+                    throw new Exception($matches[1]);
                 } else {
                     break;
                 }


### PR DESCRIPTION
This addresses an issue with POP OAuth2 error parsing where errors are blank on screen. This is due to using `$matches[2]` (which doesn't exist) vs `$matches[1]`. This updates the code to use the correct match so that errors are correctly shown on screen.