### PR TITLE
Update plugin installation info

### DIFF
--- a/include/class.plugin.php
+++ b/include/class.plugin.php
@@ -360,6 +360,44 @@ class PluginManager {
         return $p->getImpl() ?: $p;
     }
 
+    /**
+     * Find alternative installation path for a plugin
+     *
+     * Checks if the plugin exists in filesystem with different installation type
+     * (phar vs directory) than what's stored in database.
+     *
+     * @param Plugin $plugin Plugin instance
+     * @return array{path: string, is_phar: bool, version: string, info: array<string,mixed> }|null
+     */
+    static function findAlternativePath($plugin): ?array {
+        $installPath = $plugin->getInstallPath();
+        if (!$installPath) {
+            return null;
+        }
+
+        $stemPath = INCLUDE_DIR . 'plugins/' . preg_replace('/\.phar$/i', '', basename($installPath));
+        $fullPaths = [
+                INCLUDE_DIR . $installPath => (substr($installPath, -5) === '.phar'),
+                $stemPath => false,
+                $stemPath.'.phar' => true,
+        ];
+
+        foreach ($fullPaths as $fullPath => $isPhar) {
+            if ($isPhar ? file_exists($fullPath) : (is_dir($fullPath) || file_exists($fullPath))) {
+                $info = static::getInfoForPath($fullPath, $isPhar);
+                if ($info) {
+                    return [
+                            'install_path' => str_replace(INCLUDE_DIR, '', $fullPath),
+                            'isphar' => (int)$isPhar,
+                            'version' => $info['version'] ?? '',
+                            'info' => $info,
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
 
     /**
      * install

--- a/include/staff/plugins.inc.php
+++ b/include/staff/plugins.inc.php
@@ -26,6 +26,12 @@
                             <?php echo __( 'Disable'); ?>
                         </a>
                     </li>
+                    <li>
+                        <a class="confirm" data-name="update-install-info" href="plugins.php?a=update-install-info">
+                            <i class="icon-refresh icon-fixed-width"></i>
+                            <?php echo __('Update installation info'); ?>
+                        </a>
+                    </li>
                     <li class="danger">
                         <a class="confirm" data-name="delete" href="plugins.php?a=delete">
                             <i class="icon-trash icon-fixed-width"></i>
@@ -78,9 +84,15 @@ foreach ($ost->plugins->allInstalled() as $p) {
                 $p->getNumInstances());
         ?>
         </a>
-        <?php if ($p->isDefunct())
-            echo sprintf('&nbsp;<span class="error">(%s)</span>',
-                    __('defunct — missing')); ?>
+        <?php if ($p->isDefunct()) {
+            $message = __('defunct — missing');
+            $alternative = PluginManager::findAlternativePath($p);
+            if ($alternative) {
+                $message .= sprintf(', %s', __('update installation info'));
+            }
+
+            echo sprintf('&nbsp;<span class="error">(%s)</span>', $message);
+        } ?>
 
         </td>
         <td><?php echo $p->getVersion(); ?></td>
@@ -133,6 +145,13 @@ if ($count) //Show options..
         <font color="red"><?php echo sprintf(
         __('Are you sure you want to <b>disable</b> %s?'),
         _N('selected plugin', 'selected plugins', 2)); ?></font>
+    </p>
+    <p class="confirm-action" style="display:none;" id="update-install-info-confirm">
+        <font color="blue"><?php echo sprintf(
+        __('Are you sure you want to <b>update installation info</b> for %s?'),
+        _N('selected plugin', 'selected plugins', 2)); ?></font>
+        <br><br><?php echo __(
+        'This will update the plugin path, installation type, and version based on the filesystem.'); ?>
     </p>
     <div><?php echo __('Please confirm to continue.'); ?></div>
     <hr style="margin-top:1em"/>

--- a/scp/plugins.php
+++ b/scp/plugins.php
@@ -103,6 +103,27 @@ if ($_POST) {
                 foreach ($plugins as $p)
                     $p->uninstall($errors);
                 break;
+            case 'update-install-info':
+                $updated = 0;
+                foreach ($plugins as /** @var Plugin $p */ $p) {
+                    $installPath = $p->getInstallPath();
+                    if (!$installPath) {
+                        continue;
+                    }
+                    
+                    $info = PluginManager::findAlternativePath($p);
+                    if (!$info) {
+                        continue;
+                    }
+                    
+                    $newPath = $info['install_path'];
+                    $newIsPhar = $info['isphar'];
+                    $newVersion = $info['version'];
+                    if ($newPath !== (int) $p->isPhar() || $newIsPhar !== $p->isPhar() || $newVersion !== $p->getVersion()) {
+                        $plugins->update(['install_path' => $newPath, 'isphar' => $newIsPhar, 'version' => $newVersion]);
+                    }
+                }
+                break;
             }
             // reset cached list
             PluginManager::clearCache();


### PR DESCRIPTION
## Solved problems: 
1. plugin has 2 types of installation (single `phar` file or directory with files). This information have to be sync with database. If uploaded plugin with different type of installation when information database have to be updated.
2. Updating of metadata of installed plugins (version, name).

Additionally, it highlights plugins whose path of installation must be updated.

## Using
1. Select plugins to be updated
2. Click action 'Update installation info'

<img width="1004" height="517" alt="image" src="https://github.com/user-attachments/assets/9a2ee1cb-fa86-483c-8620-6f692b76a196" />
