### PR TITLE
Add database schema and business logic documentation

### DIFF
--- a/FX.md
+++ b/FX.md
@@ -1,0 +1,1264 @@
+# osTicket Business Logic & Operations
+
+This document describes the business logic, operations, and invariants of the osTicket help desk system.
+
+## Overview
+
+osTicket is a PHP-based help desk ticketing system with the following core capabilities:
+- Multi-channel ticket ingestion (Web, Email, Phone, API)
+- Department and team-based routing
+- SLA management with business hours support
+- Role-based access control
+- Dynamic forms and custom fields
+- Knowledge base (FAQ)
+- Email notifications and auto-responses
+
+---
+
+## Core Business Entities
+
+### Ticket
+The central entity representing a support request.
+
+**Key Properties**:
+- `number`: Human-readable ticket identifier (customizable format)
+- `status`: Current state (open, closed, archived, deleted)
+- `source`: Origin channel (Web, Email, Phone, API, Other)
+- `isoverdue`: SLA violation flag
+- `isanswered`: Response status flag
+
+**Relationships**:
+| Entity | Cardinality | Description |
+|--------|-------------|-------------|
+| User | N:1 | Ticket owner/requester |
+| Staff | N:1 | Assigned agent (nullable) |
+| Team | N:1 | Assigned team (nullable) |
+| Department | N:1 | Owning department |
+| Topic | N:1 | Help topic/category |
+| Status | N:1 | Current status definition |
+| Priority | N:1 | Priority level |
+| SLA | N:1 | Service level agreement |
+| Thread | 1:1 | Communication thread |
+| Lock | 1:1 | Edit lock (when being edited) |
+
+**Source File**: `include/class.ticket.php` (~4800 lines)
+
+---
+
+### User
+End-user/client who creates or is associated with tickets.
+
+**Key Properties**:
+- `name`: Display name
+- `status`: Account status flags
+- `default_email_id`: Primary email address
+
+**Relationships**:
+| Entity | Cardinality | Description |
+|--------|-------------|-------------|
+| UserEmail | 1:N | Email addresses |
+| UserAccount | 1:1 | Portal login (optional) |
+| Organization | N:1 | Parent organization |
+| Ticket | 1:N | Owned tickets |
+
+**Source File**: `include/class.user.php`
+
+---
+
+### Staff
+Internal support agent/administrator.
+
+**Key Properties**:
+- `username`: Login username
+- `isactive`: Active status
+- `isadmin`: Administrator flag
+- `onvacation`: Vacation mode (excludes from assignment)
+- `assigned_only`: View only assigned tickets
+
+**Relationships**:
+| Entity | Cardinality | Description |
+|--------|-------------|-------------|
+| Department | N:1 | Primary department |
+| Role | N:1 | Primary role |
+| StaffDeptAccess | 1:N | Extended department access |
+| Team | N:M | Team memberships |
+
+**Source File**: `include/class.staff.php`
+
+---
+
+### Organization
+Company or group that users belong to.
+
+**Key Properties**:
+- `name`: Organization name
+- `domain`: Email domain for auto-assignment
+- `manager`: Account manager (Staff or Team)
+
+**Features**:
+- Shared ticket visibility for organization members
+- Domain-based auto-association for new users
+- Custom data via dynamic forms
+
+**Source File**: `include/class.organization.php`
+
+---
+
+### Department
+Organizational unit for ticket routing and management.
+
+**Key Properties**:
+- `name`: Department name
+- `path`: Hierarchical path (supports nesting)
+- `ispublic`: Visibility to end users
+
+**Flags**:
+| Flag | Description |
+|------|-------------|
+| `FLAG_ACTIVE` | Department is active |
+| `FLAG_ARCHIVED` | Department is archived (hidden) |
+| `FLAG_ASSIGN_MEMBERS_ONLY` | Only primary members can be assigned |
+| `FLAG_ASSIGN_PRIMARY_ONLY` | Only primary member assignments |
+| `FLAG_DISABLE_AUTO_CLAIM` | Prevent claim-on-reply |
+| `FLAG_DISABLE_REOPEN_AUTO_ASSIGN` | Prevent auto-assign on reopen |
+
+**Source File**: `include/class.dept.php`
+
+---
+
+### Team
+Group of staff members for collective assignment.
+
+**Key Properties**:
+- `name`: Team name
+- `lead_id`: Team lead staff member
+- `flags`: Team configuration flags
+
+**Relationships**:
+| Entity | Cardinality | Description |
+|--------|-------------|-------------|
+| Staff | N:M | Team members |
+| Staff (lead) | N:1 | Team lead |
+
+**Source File**: `include/class.team.php`
+
+---
+
+### Role
+Permission set for staff access control.
+
+**Key Properties**:
+- `name`: Role name
+- `permissions`: JSON-encoded permission set
+
+**Source File**: `include/class.role.php`
+
+---
+
+### Thread
+Communication container for ticket/task entries.
+
+**Key Properties**:
+- `object_id`: Parent object ID
+- `object_type`: Parent type (T=Ticket, A=Task)
+- `lastresponse`: Last staff response time
+- `lastmessage`: Last user message time
+
+**Relationships**:
+| Entity | Cardinality | Description |
+|--------|-------------|-------------|
+| ThreadEntry | 1:N | Messages/responses/notes |
+| ThreadEvent | 1:N | Activity audit log |
+| ThreadCollaborator | 1:N | CC'd users |
+| ThreadReferral | 1:N | Cross-references |
+
+**Source File**: `include/class.thread.php` (~2500 lines)
+
+---
+
+### ThreadEntry
+Individual message within a thread.
+
+**Entry Types**:
+| Type | Code | Description |
+|------|------|-------------|
+| Message | `M` | From user/client |
+| Response | `R` | From staff |
+| Note | `N` | Internal only |
+
+**Source File**: `include/class.thread.php`
+
+---
+
+### Task
+Internal work item, optionally linked to a ticket.
+
+**Key Properties**:
+- Similar structure to tickets
+- Own threading system
+- Can be standalone or attached to ticket
+
+**Relationships**:
+| Entity | Cardinality | Description |
+|--------|-------------|-------------|
+| Ticket | N:1 | Parent ticket (optional) |
+| Staff | N:1 | Assigned agent |
+| Team | N:1 | Assigned team |
+| Department | N:1 | Owning department |
+| Thread | 1:1 | Communication thread |
+
+**Source File**: `include/class.task.php`
+
+---
+
+### SLA (Service Level Agreement)
+Defines response time expectations.
+
+**Key Properties**:
+- `grace_period`: Hours until overdue (business or calendar)
+- `flags`: SLA behavior flags
+
+**Flags**:
+| Flag | Value | Description |
+|------|-------|-------------|
+| `FLAG_ACTIVE` | 1 | SLA is active |
+| `FLAG_ESCALATE` | 2 | Enable priority escalation |
+| `FLAG_NOALERTS` | 4 | Suppress overdue alerts |
+| `FLAG_TRANSIENT` | 8 | Temporary SLA |
+
+**Source File**: `include/class.sla.php`
+
+---
+
+### HelpTopic
+Ticket categorization and routing configuration.
+
+**Key Properties**:
+- `topic`: Topic name
+- `topic_pid`: Parent topic (hierarchical)
+- `ispublic`: Visibility to users
+
+**Routing Configuration**:
+- Default department
+- Default priority
+- Default SLA
+- Default assignee (staff or team)
+- Associated forms
+
+**Source File**: `include/class.topic.php`
+
+---
+
+### Filter
+Email/ticket routing rules.
+
+**Key Properties**:
+- `execorder`: Execution priority
+- `match_all_rules`: Match mode (AND/OR)
+- `stop_onmatch`: Stop processing on match
+- `target`: Apply to (Any, Web, Email, API)
+
+**Rule Operators**:
+| Operator | Description |
+|----------|-------------|
+| `equal` | Exact match |
+| `not_equal` | Not equal |
+| `contains` | Contains substring |
+| `dn_contain` | Does not contain |
+| `starts` | Starts with |
+| `ends` | Ends with |
+| `match` | Regex match |
+| `not_match` | Regex not match |
+
+**Source File**: `include/class.filter.php`
+
+---
+
+## Core Operations
+
+### Ticket Lifecycle
+
+#### 1. Ticket Creation
+
+**Method**: `Ticket::create($vars, &$errors, $origin, $autorespond, $alert)`
+
+**Flow**:
+```
+1. Validate input data
+   ├── Check required fields
+   ├── Validate user email (not banned)
+   └── Process help topic forms
+
+2. Apply ticket filters (TicketFilter)
+   ├── Match against filter rules
+   ├── Execute filter actions
+   └── Stop on match (if configured)
+
+3. Create ticket record
+   ├── Generate ticket number
+   ├── Set department, status, priority
+   ├── Calculate SLA due date
+   └── Create thread
+
+4. Create user if needed
+   ├── Find by email or create
+   ├── Associate with organization
+   └── Set as ticket owner
+
+5. Post initial message
+   └── Create thread entry (type=M)
+
+6. Send notifications
+   ├── Auto-response to user (if enabled)
+   └── Alert to staff (if enabled)
+
+7. Log event
+   └── Record creation in thread_event
+```
+
+**Origins**:
+| Origin | Description | Auto-response | Alert |
+|--------|-------------|---------------|-------|
+| `Web` | Client portal | Yes | Yes |
+| `Email` | Email fetcher | Configurable | Yes |
+| `Phone` | Staff-entered | No | Configurable |
+| `API` | API request | Configurable | Configurable |
+| `Staff` | Staff on behalf | No | Configurable |
+
+**Invariants**:
+- Email address must not be banned
+- Department must be active
+- User must have valid email
+- Filter rejection halts creation
+
+---
+
+#### 2. Ticket Assignment
+
+**Methods**:
+- `Ticket::assignToStaff($staff, $note, $alert)`
+- `Ticket::assignToTeam($team, $note, $alert)`
+- `Ticket::assign($form)` - Form-based assignment
+
+**Flow**:
+```
+1. Validate assignment
+   ├── Staff must be active
+   ├── Staff must have department access
+   └── Team must be active
+
+2. Clear existing assignment
+   ├── Clear referrals (if assigned)
+   └── Update staff_id/team_id
+
+3. Log assignment
+   └── Create thread event
+
+4. Notify (if alert=true)
+   └── Send assignment notification
+```
+
+**Department Assignment Rules**:
+| Flag | Behavior |
+|------|----------|
+| `FLAG_ASSIGN_MEMBERS_ONLY` | Only primary department members |
+| `FLAG_ASSIGN_PRIMARY_ONLY` | Excludes extended access members |
+
+**Invariants**:
+- Staff must have access to ticket's department
+- Staff on vacation cannot be assigned (unless forced)
+- Unassignment clears both staff and team
+
+---
+
+#### 3. Ticket Transfer
+
+**Method**: `Ticket::transfer($dept_id, $comments, $alert)`
+
+**Flow**:
+```
+1. Validate transfer
+   ├── Target department exists
+   └── Target department is active
+
+2. Update department
+   └── Set new dept_id
+
+3. Re-evaluate SLA
+   ├── Use department default SLA
+   └── Recalculate due date
+
+4. Handle staff assignment
+   ├── Clear if staff not in new dept
+   └── Keep if staff has access
+
+5. Reopen if closed
+   └── Set status to open
+
+6. Post internal note
+   └── Document transfer reason
+
+7. Clear referrals
+   └── Remove department referrals
+
+8. Log event
+   └── Record transfer
+```
+
+**Invariants**:
+- Closed tickets are reopened on transfer
+- Staff assignment cleared if no access to new department
+- SLA recalculated based on new department
+
+---
+
+#### 4. Ticket Status Changes
+
+**Method**: `Ticket::setStatus($status, $comments, &$errors, $set_closing_agent)`
+
+**States**:
+| State | Description | Transitions |
+|-------|-------------|-------------|
+| `open` | Active ticket | → closed |
+| `closed` | Resolved | → open (reopen) |
+| `archived` | Archived | Read-only |
+| `deleted` | Marked for deletion | Hard delete |
+
+**Close Flow**:
+```
+1. Check closeable
+   └── isCloseable() validation
+
+2. Set status
+   └── Update status_id
+
+3. Record closing agent
+   └── staff_id = closing staff
+
+4. Clear flags
+   ├── Clear overdue flag
+   └── Clear due dates
+
+5. Set closed timestamp
+   └── closed = NOW()
+
+6. Log event
+   └── Record closure
+```
+
+**Reopen Flow**:
+```
+1. Check reopenable
+   └── isReopenable() validation
+
+2. Set status to open
+   └── Update status_id
+
+3. Re-assign (if enabled)
+   └── Assign to closing agent
+
+4. Set reopen timestamp
+   └── reopened = NOW()
+
+5. Log event
+   └── Record reopen
+```
+
+**Invariants**:
+- Only staff with PERM_CLOSE can close tickets
+- Deleted status triggers permanent deletion
+- Reopened tickets may auto-assign to closing agent
+
+---
+
+#### 5. Ticket Merging
+
+**Method**: `Ticket::merge($tickets, $form)`
+
+**Flow**:
+```
+1. Validate merge
+   ├── Target tickets exist
+   └── Staff has permission
+
+2. For each source ticket:
+   ├── Set parent (ticket_pid)
+   ├── Migrate collaborators
+   ├── Migrate tasks (optional)
+   ├── Preserve thread entries
+   └── Update status (per config)
+
+3. Update parent ticket
+   ├── Consolidate thread data
+   └── Update timestamps
+
+4. Log events
+   └── Record merge on all tickets
+```
+
+**Options**:
+- Merge tasks to parent
+- Set child ticket status
+- Preserve original data in extra field
+
+**Invariants**:
+- Merged tickets maintain parent reference
+- Access to parent grants access to children
+- Thread entries preserved with merge metadata
+
+---
+
+#### 6. Reply Posting
+
+**Method**: `Ticket::postReply($vars, &$errors, $alert, $claim)`
+
+**Flow**:
+```
+1. Validate reply
+   ├── Body content required
+   └── Staff has permission
+
+2. Create thread entry
+   ├── Type = 'R' (response)
+   ├── Set staff author
+   └── Store recipients
+
+3. Process recipients
+   ├── To: User email
+   ├── CC: Collaborators
+   └── BCC: Additional
+
+4. Auto-claim (if enabled)
+   └── Assign to replying staff
+
+5. Update ticket
+   ├── Set answered flag
+   ├── Update lastupdate
+   └── Update status (optional)
+
+6. Inject signature
+   └── Department or staff signature
+
+7. Send notification
+   └── Email to recipients
+
+8. Log event
+   └── Record response
+```
+
+**Invariants**:
+- Reply requires PERM_REPLY permission
+- Auto-claim only if department allows
+- Signature determined by staff preference
+
+---
+
+### User Operations
+
+#### User Creation
+
+**Methods**:
+- `UserModel::create($vars)` - Direct creation
+- `User::fromVars($vars)` - From form data
+- `User::fromEmail($email)` - From email lookup
+
+**Flow**:
+```
+1. Validate input
+   ├── Email required
+   ├── Email not banned
+   └── Email unique
+
+2. Create user record
+   ├── Set name
+   └── Set status
+
+3. Create user email
+   ├── Create UserEmail record
+   └── Set as default
+
+4. Organization association
+   ├── Match by domain (if configured)
+   └── Or explicit assignment
+
+5. Process custom data
+   └── Save form entries
+```
+
+**Invariants**:
+- Email addresses must be unique
+- Banned emails prevent creation
+- Organization auto-association by domain
+
+---
+
+#### User Account Management
+
+**Features**:
+- Portal login credentials
+- Password reset flow
+- Backend authentication (LDAP, OAuth)
+- Two-factor authentication
+
+**Account States**:
+| Status | Description |
+|--------|-------------|
+| Active | Can login |
+| Locked | Temporarily blocked |
+| Disabled | Permanently disabled |
+
+---
+
+### Staff Operations
+
+#### Staff Authentication
+
+**Flow**:
+```
+1. Lookup by username/email
+2. Validate backend
+   ├── Local password check
+   ├── LDAP authentication
+   └── OAuth/SSO
+3. Check 2FA (if enabled)
+4. Validate account status
+   ├── Must be active
+   └── Check password expiry
+5. Create session
+6. Log login event
+```
+
+**Invariants**:
+- Staff must be active
+- Force password change if flagged
+- Session bound to IP (if configured)
+
+---
+
+#### Department Access
+
+**Access Types**:
+| Type | Description |
+|------|-------------|
+| Primary | Default department assignment |
+| Extended | Additional department access via StaffDeptAccess |
+
+**Permission Resolution**:
+```
+1. Check primary department
+   └── Use primary role permissions
+
+2. Check extended access
+   └── Use role from StaffDeptAccess
+
+3. Check assignment
+   └── Assigned tickets visible
+
+4. Check referrals
+   └── Referred tickets visible
+```
+
+---
+
+### Email Operations
+
+#### Inbound Email Processing
+
+**Components**:
+- `MailFetcher`: Polls configured mailboxes
+- `MailParser`: Parses MIME messages
+- `TicketFilter`: Routes messages
+
+**Flow**:
+```
+1. Connect to mailbox
+   ├── IMAP/POP3 protocol
+   └── OAuth2 or password auth
+
+2. Fetch messages
+   ├── Limit by fetchmax setting
+   └── Check folder configuration
+
+3. Parse message
+   ├── Extract headers
+   ├── Parse MIME body
+   ├── Extract attachments
+   └── Detect charset
+
+4. Identify thread
+   ├── Match by Message-ID
+   ├── Match by References header
+   └── Match by ticket number in subject
+
+5. Process message
+   ├── New ticket: Create ticket
+   └── Reply: Add to thread
+
+6. Post-fetch action
+   ├── Delete from server
+   ├── Archive to folder
+   └── Leave on server
+```
+
+**Bounce Detection**:
+- Auto-reply headers detected
+- Bounce patterns matched
+- System email flagging
+
+**Invariants**:
+- Banned emails rejected
+- System emails tracked to prevent loops
+- Thread matching by multiple criteria
+
+---
+
+#### Outbound Email
+
+**Methods**:
+- `Mailer::send()` - Standard email
+- `Ticket::sendAutoReply()` - Acknowledgment
+- `Ticket::sendAlert()` - Staff notification
+
+**Template Variables**:
+| Variable | Description |
+|----------|-------------|
+| `%ticket` | Ticket object |
+| `%user` | User object |
+| `%staff` | Staff object |
+| `%message` | Thread entry |
+| `%signature` | Signature text |
+
+**Invariants**:
+- From address per department
+- Auto-response respects noautoresp flag
+- System emails tracked for loop prevention
+
+---
+
+### SLA Processing
+
+#### Due Date Calculation
+
+**Method**: `SLA::addGracePeriod($datetime, $format)`
+
+**Flow**:
+```
+1. Get grace period hours
+2. Check for schedule
+   ├── If schedule: Use business hours
+   └── If no schedule: Calendar hours
+3. Add hours to start time
+4. Return calculated due date
+```
+
+**Business Hours Calculation**:
+```
+For each hour to add:
+  1. Check if current time in schedule
+  2. If in schedule: Add hour
+  3. If not: Skip to next scheduled period
+  4. Handle holidays and exceptions
+```
+
+**Invariants**:
+- Grace period always in hours
+- Business hours exclude non-working periods
+- Timezone from schedule or system default
+
+---
+
+#### Overdue Processing
+
+**Method**: `Ticket::checkOverdue()` (static, via cron)
+
+**Flow**:
+```
+1. Query open tickets where:
+   ├── isoverdue = 0
+   └── duedate <= NOW() OR est_duedate <= NOW()
+
+2. For each ticket:
+   ├── Set isoverdue = 1
+   └── Update timestamp
+
+3. Send alerts (if enabled)
+   └── Per SLA FLAG_NOALERTS setting
+```
+
+**Invariants**:
+- Only open tickets checked
+- Either duedate or est_duedate triggers overdue
+- SLA can suppress alerts
+
+---
+
+### Filter System
+
+#### Filter Execution
+
+**Method**: `TicketFilter::apply($ticket)`
+
+**Flow**:
+```
+1. Load active filters (ordered by execorder)
+
+2. For each filter:
+   ├── Check target (Web/Email/API/Any)
+   └── Evaluate rules
+
+3. Rule evaluation:
+   ├── If match_all_rules: AND logic
+   └── If !match_all_rules: OR logic
+
+4. On match:
+   ├── Execute filter actions
+   └── If stop_onmatch: Break
+
+5. Return matched filter or null
+```
+
+**Filter Actions**:
+| Action | Description |
+|--------|-------------|
+| `assign` | Assign to staff/team |
+| `dept` | Route to department |
+| `priority` | Set priority |
+| `status` | Set status |
+| `sla` | Set SLA |
+| `topic` | Set help topic |
+| `reject` | Reject ticket |
+| `email` | Send email |
+
+**Invariants**:
+- Filters execute in order
+- Stop on match halts processing
+- Reject action prevents ticket creation
+
+---
+
+### Dynamic Forms
+
+#### Form Processing
+
+**Flow**:
+```
+1. Load form definition
+   └── DynamicForm::lookup($id)
+
+2. Render form fields
+   ├── Text, textarea, select
+   ├── Date, datetime
+   ├── Checkbox, radio
+   └── Custom types
+
+3. Validate submission
+   ├── Required field check
+   ├── Type validation
+   └── Custom validators
+
+4. Save form entry
+   ├── Create FormEntry
+   └── Create FormEntryValues
+```
+
+**Form Types**:
+| Type | Code | Usage |
+|------|------|-------|
+| Ticket | `T` | Ticket custom fields |
+| User | `U` | User profile fields |
+| Organization | `O` | Organization fields |
+| Task | `A` | Task custom fields |
+| Generic | `G` | Reusable forms |
+
+**Custom Data Storage**:
+- Form entries linked by object_type + object_id
+- Values stored in form_entry_values
+- Aggregated data in *__cdata tables
+
+---
+
+## Access Control
+
+### Permission Model
+
+#### Ticket Permissions
+
+| Permission | Constant | Description |
+|------------|----------|-------------|
+| Create | `PERM_CREATE` | Create tickets on behalf of users |
+| Edit | `PERM_EDIT` | Edit ticket information |
+| Assign | `PERM_ASSIGN` | Assign to agents/teams |
+| Release | `PERM_RELEASE` | Release assignment |
+| Transfer | `PERM_TRANSFER` | Transfer between departments |
+| Refer | `PERM_REFER` | Manage referrals |
+| Merge | `PERM_MERGE` | Merge tickets |
+| Link | `PERM_LINK` | Link related tickets |
+| Reply | `PERM_REPLY` | Post replies |
+| Mark Answered | `PERM_MARKANSWERED` | Toggle answered status |
+| Close | `PERM_CLOSE` | Close/resolve tickets |
+| Delete | `PERM_DELETE` | Delete tickets |
+
+---
+
+#### User Permissions
+
+| Permission | Constant | Description |
+|------------|----------|-------------|
+| Create | `PERM_CREATE` | Create users |
+| Edit | `PERM_EDIT` | Manage user info |
+| Delete | `PERM_DELETE` | Delete users |
+| Manage | `PERM_MANAGE` | Manage accounts |
+| Directory | `PERM_DIRECTORY` | Access user directory |
+
+---
+
+#### Organization Permissions
+
+| Permission | Constant | Description |
+|------------|----------|-------------|
+| Create | `PERM_CREATE` | Create organizations |
+| Edit | `PERM_EDIT` | Manage organizations |
+| Delete | `PERM_DELETE` | Delete organizations |
+
+---
+
+#### Task Permissions
+
+| Permission | Constant | Description |
+|------------|----------|-------------|
+| Create | `PERM_CREATE` | Create tasks |
+| Edit | `PERM_EDIT` | Edit tasks |
+| Assign | `PERM_ASSIGN` | Assign tasks |
+| Transfer | `PERM_TRANSFER` | Transfer tasks |
+| Reply | `PERM_REPLY` | Post to task thread |
+| Close | `PERM_CLOSE` | Close tasks |
+| Delete | `PERM_DELETE` | Delete tasks |
+
+---
+
+### Permission Resolution
+
+**Method**: `Ticket::checkStaffPerm($staff, $perm)`
+
+**Resolution Order**:
+```
+1. Check department access
+   └── Staff has primary or extended access?
+
+2. Check assignment
+   └── Staff assigned to ticket?
+
+3. Check referral
+   └── Ticket referred to staff/dept?
+
+4. Check role permission
+   └── Role contains permission?
+
+5. Return result
+```
+
+---
+
+### User Access Control
+
+**Method**: `Ticket::checkUserAccess($user)`
+
+**Access Levels**:
+```
+1. Ticket owner
+   └── user_id matches
+
+2. Organization member
+   ├── Same organization
+   └── Org ticket visibility enabled
+
+3. Active collaborator
+   └── In thread_collaborator (active)
+
+4. CC collaborator
+   └── In thread_collaborator (CC flag)
+
+5. Merged ticket access
+   └── Access to parent/child grants access
+```
+
+---
+
+## Scheduled Tasks (Cron)
+
+### Task Registry
+
+| Task | Frequency | Description |
+|------|-----------|-------------|
+| MailFetcher | 5 min | Fetch and process incoming emails |
+| TicketMonitor | 5 min | Check overdue tickets, cleanup locks |
+| PurgeLogs | Daily (probabilistic) | Clean old system logs |
+| PurgeDrafts | Each run | Remove stale drafts |
+| CleanOrphanedFiles | 1/10 runs | Delete unlinked attachments |
+| CleanExpiredSessions | Each run | Remove expired sessions |
+| CleanPwResets | Each run | Remove expired password tokens |
+| MaybeOptimizeTables | Weekly (probabilistic) | Database table optimization |
+
+### Cron Execution
+
+**Methods**:
+- API endpoint with authentication (`api/cron.php`)
+- CLI execution (`LocalCronApiController::call()`)
+
+**Requirements**:
+- Valid API key with `can_exec_cron` permission
+- Or command-line access
+
+---
+
+## API
+
+### Ticket API
+
+**Endpoint**: `api/http.php/tickets.json`
+
+**Operations**:
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | /tickets.json | Create ticket |
+| POST | /tickets.xml | Create ticket (XML) |
+| POST | /tickets.email | Create from email |
+
+**Request Format** (JSON):
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name",
+  "subject": "Ticket Subject",
+  "message": "Ticket body content",
+  "topicId": 1,
+  "attachments": [
+    {
+      "name": "file.pdf",
+      "type": "application/pdf",
+      "data": "base64encoded..."
+    }
+  ]
+}
+```
+
+**Authentication**:
+- API key in `X-API-Key` header
+- IP whitelist validation
+
+**Invariants**:
+- API key must be active
+- IP must match configured address
+- `can_create_tickets` permission required
+
+---
+
+## Concurrency Control
+
+### Ticket Locking
+
+**Mechanism**: Pessimistic locking via `lock` table
+
+**Flow**:
+```
+1. Staff views ticket
+   └── Create lock record
+
+2. Lock contains:
+   ├── staff_id
+   ├── expire time
+   └── lock code
+
+3. Other staff sees lock warning
+   └── Can break lock if expired
+
+4. Lock cleanup via cron
+   └── Remove expired locks
+```
+
+**Invariants**:
+- Only one active lock per ticket
+- Lock expires after configured period
+- Breaking lock requires permission
+
+---
+
+## Audit Trail
+
+### Thread Events
+
+All significant actions are logged to `thread_event`:
+
+| Event | Description |
+|-------|-------------|
+| created | Ticket/task created |
+| closed | Ticket closed |
+| reopened | Ticket reopened |
+| assigned | Assignment changed |
+| transferred | Department changed |
+| overdue | Marked overdue |
+| edited | Ticket edited |
+| merged | Tickets merged |
+| linked | Tickets linked |
+| referred | Ticket referred |
+| claimed | Ticket claimed |
+| released | Assignment released |
+
+**Event Data**:
+- Actor (staff/user/system)
+- Timestamp
+- Event-specific data (JSON)
+- Annulment flag (for corrections)
+
+---
+
+## Invariants Summary
+
+### Ticket Invariants
+
+1. **Creation**
+   - Email must not be banned
+   - Department must be active
+   - Topic must be active (if public)
+   - Required form fields must be filled
+
+2. **Assignment**
+   - Staff must be active and not on vacation
+   - Staff must have department access
+   - Team must be active
+
+3. **Status**
+   - Only open → closed allowed (unless reopen)
+   - Deleted state triggers permanent deletion
+   - Closing agent recorded for reopen
+
+4. **SLA**
+   - Due date calculated from creation time
+   - Business hours from schedule
+   - Overdue flag set via cron
+
+5. **Access**
+   - Department access required for staff
+   - Organization visibility optional for users
+   - Collaborators have limited access
+
+### User Invariants
+
+1. Email address must be unique
+2. Primary email required
+3. Banned emails prevent all operations
+
+### Staff Invariants
+
+1. Username must be unique
+2. Primary department required
+3. Primary role required
+4. Vacation mode excludes from assignment
+
+### Organization Invariants
+
+1. Name must be unique (if enforced)
+2. Domain used for auto-association
+3. Account manager can be Staff or Team
+
+---
+
+## Extension Points
+
+### Signals (Events)
+
+osTicket uses a signal system for extensibility:
+
+| Signal | Description |
+|--------|-------------|
+| `cron` | Cron job execution |
+| `ticket.created` | Ticket created |
+| `ticket.closed` | Ticket closed |
+| `ticket.assigned` | Ticket assigned |
+| `mail.received` | Email received |
+| `model.created` | Any model created |
+| `model.updated` | Any model updated |
+| `model.deleted` | Any model deleted |
+
+**Usage**:
+```php
+Signal::connect('ticket.created', function($ticket) {
+    // Custom logic
+});
+```
+
+### Plugins
+
+Plugins can extend functionality via:
+- Custom filter actions
+- Custom form field types
+- Custom authentication backends
+- Custom storage backends
+- Signal handlers
+
+**Source**: `include/class.plugin.php`
+
+---
+
+## Configuration
+
+### System Configuration
+
+Key configuration items in `config` table:
+
+| Key | Namespace | Description |
+|-----|-----------|-------------|
+| `helpdesk_url` | core | Base URL |
+| `helpdesk_title` | core | Site title |
+| `default_dept_id` | core | Default department |
+| `default_sla_id` | core | Default SLA |
+| `default_priority_id` | core | Default priority |
+| `default_template_id` | core | Default email template |
+| `enable_kb` | core | Knowledge base enabled |
+| `enable_captcha` | core | CAPTCHA enabled |
+| `auto_claim_tickets` | core | Auto-claim on reply |
+| `collaborator_ticket_visibility` | core | Collaborator access |
+| `require_topic_to_close` | core | Require topic for closure |
+
+### Department Configuration
+
+Each department has:
+- Email templates
+- Default SLA
+- Business hours schedule
+- Auto-response settings
+- Assignment policies
+
+### Email Configuration
+
+Each email account has:
+- IMAP/POP3 settings
+- SMTP settings
+- Fetch frequency
+- Post-fetch actions
+- Authentication credentials
+
+---
+
+## Error Handling
+
+### Validation Errors
+
+Form and operation errors returned via `$errors` array:
+- Field-specific errors by field name
+- General errors in `err` key
+
+### System Errors
+
+Logged to `syslog` table:
+- Debug, Warning, Error levels
+- Logger identification
+- IP address tracking
+
+### Email Errors
+
+Email account errors tracked:
+- Error count
+- Last error message
+- Last error timestamp
+- Auto-disable after threshold

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,1496 @@
+# osTicket Database Schema
+
+This document provides a comprehensive reference for the osTicket database schema.
+
+## Overview
+
+- **Database Engine**: MySQL (primary supported database)
+- **Default Charset**: UTF-8
+- **Table Prefix**: Configurable via `%TABLE_PREFIX%` (default: `ost_`)
+- **Total Tables**: 66
+- **Schema Location**: `setup/inc/streams/core/install-mysql.sql`
+- **Migrations**: `include/upgrader/streams/core/` (99 migration files)
+
+## Database Variants
+
+> **Note**: osTicket currently supports **MySQL only**. The schema uses MySQL-specific syntax including:
+> - `AUTO_INCREMENT` for auto-incrementing columns
+> - `ENGINE=MyISAM` / `ENGINE=InnoDB` specifications
+> - MySQL-specific collations (`utf8_unicode_ci`, `ascii_general_ci`, `ascii_bin`)
+
+### Engine Selection
+
+| Engine | Tables | Use Case |
+|--------|--------|----------|
+| MyISAM | Most tables | Default, optimized for reads |
+| InnoDB | `sequence`, `thread_referral`, `event` | Transaction support, row-level locking |
+
+---
+
+## Table Reference
+
+### Configuration & System Tables
+
+#### `config`
+System configuration key-value store.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `namespace` | VARCHAR(64) | NOT NULL | Configuration namespace |
+| `key` | VARCHAR(64) | NOT NULL | Configuration key |
+| `value` | TEXT | NOT NULL | Configuration value |
+| `updated` | TIMESTAMP | | Last update time |
+
+**Indexes**: UNIQUE(`namespace`, `key`)
+
+---
+
+#### `sequence`
+Auto-increment sequence management for ticket numbers.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(64) | | Sequence name |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | |
+| `next` | BIGINT(20) UNSIGNED | NOT NULL, DEFAULT 1 | Next value |
+| `increment` | INT(11) | DEFAULT 1 | Increment step |
+| `padding` | CHAR(1) | DEFAULT '0' | Padding character |
+| `updated` | DATETIME | | Last update |
+
+**Engine**: InnoDB (required for row-level locking)
+
+---
+
+#### `syslog`
+System logs and audit trails.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `log_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `log_type` | ENUM('Debug','Warning','Error') | NOT NULL | Log level |
+| `title` | VARCHAR(255) | NOT NULL | Log title |
+| `log` | TEXT | NOT NULL | Log message |
+| `logger` | VARCHAR(64) | NOT NULL | Logger identifier |
+| `ip_address` | VARCHAR(64) | NOT NULL | Client IP |
+| `created` | DATETIME | NOT NULL | Creation time |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `log_type`, `created`
+
+---
+
+#### `session`
+User session management.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `session_id` | VARCHAR(255) | PK, ascii_general_ci | Session identifier |
+| `session_data` | BLOB | | Serialized session data |
+| `session_expire` | DATETIME | | Expiration time |
+| `session_updated` | DATETIME | | Last activity |
+| `user_id` | VARCHAR(16) | | Associated user/staff |
+| `user_ip` | VARCHAR(64) | | Client IP |
+| `user_agent` | VARCHAR(255) | utf8_unicode_ci | Browser user agent |
+
+**Indexes**: `updated` (`session_updated`, `session_id`)
+
+---
+
+#### `event`
+Event definitions and triggers.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(60) | NOT NULL | Event name |
+| `description` | VARCHAR(60) | | Event description |
+
+**Engine**: InnoDB
+
+---
+
+### User & Account Tables
+
+#### `user`
+End user/client profiles.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `org_id` | INT(11) UNSIGNED | DEFAULT 0 | Organization FK |
+| `default_email_id` | INT(10) UNSIGNED | NOT NULL | Primary email FK |
+| `status` | INT(11) UNSIGNED | DEFAULT 0 | Account status flags |
+| `name` | VARCHAR(128) | NOT NULL | Display name |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `org_id`, `default_email_id`, `name`
+
+---
+
+#### `user_email`
+User email addresses (supports multiple per user).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `user_id` | INT(10) UNSIGNED | NOT NULL | User FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Email flags |
+| `address` | VARCHAR(255) | NOT NULL | Email address |
+
+**Indexes**: UNIQUE(`address`), `user_id`
+
+---
+
+#### `user_account`
+User portal login credentials.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `user_id` | INT(10) UNSIGNED | NOT NULL | User FK |
+| `status` | INT(11) UNSIGNED | DEFAULT 0 | Account status |
+| `timezone` | VARCHAR(64) | | User timezone |
+| `lang` | VARCHAR(16) | | Preferred language |
+| `username` | VARCHAR(64) | | Login username |
+| `passwd` | VARCHAR(128) | ascii_bin | Password hash |
+| `backend` | VARCHAR(32) | | Auth backend |
+| `extra` | TEXT | | Additional data (JSON) |
+| `registered` | DATETIME | | Registration date |
+
+**Indexes**: UNIQUE(`username`), `user_id`
+
+---
+
+#### `user__cdata`
+User custom data fields (dynamic form data).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `user_id` | INT(11) UNSIGNED | PK | User FK |
+| *dynamic* | *varies* | | Custom fields from forms |
+
+---
+
+#### `organization`
+Client organizations/companies.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(128) | NOT NULL | Organization name |
+| `manager` | VARCHAR(16) | | Account manager reference |
+| `status` | INT(11) UNSIGNED | DEFAULT 0 | Status flags |
+| `domain` | VARCHAR(256) | | Email domain for auto-add |
+| `extra` | TEXT | | Additional data (JSON) |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `name`
+
+---
+
+#### `organization__cdata`
+Organization custom data fields.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `org_id` | INT(11) UNSIGNED | PK | Organization FK |
+| *dynamic* | *varies* | | Custom fields from forms |
+
+---
+
+### Staff & Access Control Tables
+
+#### `staff`
+Help desk agents/support staff.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `staff_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `dept_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Primary department FK |
+| `role_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Primary role FK |
+| `username` | VARCHAR(32) | NOT NULL | Login username |
+| `firstname` | VARCHAR(32) | | First name |
+| `lastname` | VARCHAR(32) | | Last name |
+| `passwd` | VARCHAR(128) | | Password hash |
+| `backend` | VARCHAR(32) | | Auth backend |
+| `email` | VARCHAR(128) | | Staff email |
+| `phone` | VARCHAR(24) | | Phone number |
+| `phone_ext` | VARCHAR(6) | | Extension |
+| `mobile` | VARCHAR(24) | | Mobile number |
+| `signature` | TEXT | | Email signature |
+| `lang` | VARCHAR(16) | | Preferred language |
+| `timezone` | VARCHAR(64) | | Timezone |
+| `locale` | VARCHAR(16) | | Locale setting |
+| `notes` | TEXT | | Admin notes |
+| `isactive` | TINYINT(1) | DEFAULT 1 | Active status |
+| `isadmin` | TINYINT(1) | DEFAULT 0 | Admin flag |
+| `isvisible` | TINYINT(1) | DEFAULT 1 | Visibility in lists |
+| `onvacation` | TINYINT(1) | DEFAULT 0 | Vacation mode |
+| `assigned_only` | TINYINT(1) | DEFAULT 0 | See assigned only |
+| `show_assigned_tickets` | TINYINT(1) | DEFAULT 0 | UI preference |
+| `change_passwd` | TINYINT(1) | DEFAULT 0 | Force password change |
+| `max_page_size` | INT(11) UNSIGNED | DEFAULT 0 | Pagination preference |
+| `auto_refresh_rate` | INT(10) UNSIGNED | DEFAULT 0 | Auto-refresh rate |
+| `default_signature_type` | ENUM('none','mine','dept') | DEFAULT 'none' | Signature preference |
+| `default_paper_size` | ENUM('Letter','Legal','Ledger','A4','A3') | DEFAULT 'Letter' | PDF paper size |
+| `extra` | TEXT | | Additional data (JSON) |
+| `permissions` | TEXT | | Permission overrides |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `lastlogin` | DATETIME | | Last login time |
+| `passwdreset` | DATETIME | | Password reset time |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`username`), `dept_id`, `isadmin`, `isactive`, `onvacation`
+
+---
+
+#### `staff_dept_access`
+Extended department access for staff.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `staff_id` | INT(10) UNSIGNED | PK | Staff FK |
+| `dept_id` | INT(10) UNSIGNED | PK | Department FK |
+| `role_id` | INT(10) UNSIGNED | NOT NULL | Role for this dept |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Access flags |
+
+**Indexes**: `dept_id`
+
+---
+
+#### `role`
+Staff roles with permission sets.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Role flags |
+| `name` | VARCHAR(64) | NOT NULL | Role name |
+| `permissions` | TEXT | | Permission JSON |
+| `notes` | TEXT | | Role description |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`name`)
+
+---
+
+#### `group`
+Staff groups (legacy, maintained for compatibility).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `role_id` | INT(10) UNSIGNED | DEFAULT 0 | Default role FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Group flags |
+| `name` | VARCHAR(120) | NOT NULL | Group name |
+| `notes` | TEXT | | Group notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+---
+
+### Department & Team Tables
+
+#### `department`
+Support departments with routing configuration.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `pid` | INT(11) UNSIGNED | DEFAULT 0 | Parent department FK |
+| `tpl_id` | INT(10) UNSIGNED | DEFAULT 0 | Email template set FK |
+| `sla_id` | INT(10) UNSIGNED | DEFAULT 0 | Default SLA FK |
+| `schedule_id` | INT(10) UNSIGNED | DEFAULT 0 | Business hours FK |
+| `email_id` | INT(10) UNSIGNED | DEFAULT 0 | Outgoing email FK |
+| `autoresp_email_id` | INT(10) UNSIGNED | DEFAULT 0 | Auto-response email FK |
+| `manager_id` | INT(10) UNSIGNED | DEFAULT 0 | Department manager FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Department flags |
+| `name` | VARCHAR(128) | NOT NULL | Department name |
+| `signature` | TEXT | NOT NULL | Department signature |
+| `ispublic` | TINYINT(1) UNSIGNED | DEFAULT 1 | Public visibility |
+| `group_membership` | TINYINT(1) | DEFAULT 0 | Extended access mode |
+| `ticket_auto_response` | TINYINT(1) | DEFAULT 1 | Auto-response enabled |
+| `message_auto_response` | TINYINT(1) | DEFAULT 0 | Message auto-response |
+| `path` | VARCHAR(128) | NOT NULL | Hierarchical path |
+| `updated` | DATETIME | NOT NULL | Last update |
+| `created` | DATETIME | NOT NULL | Creation date |
+
+**Indexes**: UNIQUE(`name`, `pid`), `manager_id`, `autoresp_email_id`, `tpl_id`, `flags`
+
+---
+
+#### `team`
+Support teams for group assignment.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `team_id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `lead_id` | INT(10) UNSIGNED | DEFAULT 0 | Team lead staff FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Team flags |
+| `name` | VARCHAR(125) | NOT NULL | Team name |
+| `notes` | TEXT | | Team notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`name`), `lead_id`
+
+---
+
+#### `team_member`
+Team membership junction table.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `team_id` | INT(10) UNSIGNED | PK | Team FK |
+| `staff_id` | INT(10) UNSIGNED | PK | Staff FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Membership flags |
+
+**Indexes**: `staff_id`
+
+---
+
+### Ticket Tables
+
+#### `ticket`
+Core support tickets table.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `ticket_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `ticket_pid` | INT(11) UNSIGNED | DEFAULT 0 | Parent ticket (for merges) |
+| `number` | VARCHAR(20) | NOT NULL | Ticket number |
+| `user_id` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Ticket owner FK |
+| `user_email_id` | INT(11) UNSIGNED | DEFAULT NULL | Owner email FK |
+| `status_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Current status FK |
+| `dept_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Department FK |
+| `sla_id` | INT(10) UNSIGNED | DEFAULT 0 | SLA FK |
+| `topic_id` | INT(10) UNSIGNED | DEFAULT 0 | Help topic FK |
+| `staff_id` | INT(10) UNSIGNED | DEFAULT 0 | Assigned staff FK |
+| `team_id` | INT(10) UNSIGNED | DEFAULT 0 | Assigned team FK |
+| `email_id` | INT(11) UNSIGNED | DEFAULT 0 | Receiving email FK |
+| `lock_id` | INT(11) UNSIGNED | DEFAULT 0 | Edit lock FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Ticket flags |
+| `sort` | INT(11) UNSIGNED | DEFAULT 0 | Sort order |
+| `ip_address` | VARCHAR(64) | NOT NULL, DEFAULT '' | Creator IP |
+| `source` | ENUM('Web','Email','Phone','API','Other') | DEFAULT 'Other' | Ticket source |
+| `source_extra` | VARCHAR(40) | | Additional source info |
+| `isoverdue` | TINYINT(1) UNSIGNED | DEFAULT 0 | Overdue flag |
+| `isanswered` | TINYINT(1) UNSIGNED | DEFAULT 0 | Answered flag |
+| `duedate` | DATETIME | | User-set due date |
+| `est_duedate` | DATETIME | | SLA-calculated due date |
+| `reopened` | DATETIME | | Last reopen time |
+| `closed` | DATETIME | | Closure time |
+| `lastupdate` | DATETIME | | Last activity |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `user_id`, `dept_id`, `staff_id`, `team_id`, `status_id`, `created`, `closed`, `duedate`, `topic_id`, `sla_id`, `ticket_pid`
+
+---
+
+#### `ticket__cdata`
+Ticket custom data fields.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `ticket_id` | INT(11) UNSIGNED | PK | Ticket FK |
+| *dynamic* | *varies* | | Custom fields from forms |
+
+---
+
+#### `ticket_status`
+Ticket status definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(60) | NOT NULL | Status name |
+| `state` | VARCHAR(16) | NOT NULL | State: open, closed, archived, deleted |
+| `mode` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Status mode |
+| `flags` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Status flags |
+| `sort` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Sort order |
+| `properties` | TEXT | NOT NULL | JSON properties |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`name`), `state`
+
+---
+
+#### `ticket_priority`
+Priority level definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `priority_id` | TINYINT(4) UNSIGNED | PK, AUTO_INCREMENT | |
+| `priority` | VARCHAR(60) | NOT NULL | Priority name |
+| `priority_desc` | VARCHAR(30) | NOT NULL | Short description |
+| `priority_color` | VARCHAR(7) | NOT NULL | Hex color code |
+| `priority_urgency` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Urgency level (0-4) |
+| `ispublic` | TINYINT(1) | DEFAULT 1 | Public visibility |
+
+**Indexes**: UNIQUE(`priority`), `priority_urgency`, `ispublic`
+
+---
+
+#### `lock`
+Pessimistic edit locks for tickets.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `lock_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `staff_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Lock holder FK |
+| `expire` | DATETIME | | Lock expiration |
+| `code` | VARCHAR(20) | | Lock code |
+| `created` | DATETIME | NOT NULL | Creation time |
+
+---
+
+### Thread & Communication Tables
+
+#### `thread`
+Ticket/task communication threads.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `object_id` | INT(11) UNSIGNED | NOT NULL | Parent object ID |
+| `object_type` | CHAR(1) | NOT NULL | Object type code |
+| `extra` | TEXT | | Additional data (JSON) |
+| `lastresponse` | DATETIME | | Last response time |
+| `lastmessage` | DATETIME | | Last message time |
+| `created` | DATETIME | NOT NULL | Creation date |
+
+**Indexes**: `object_id`, `object_type`
+
+**Object Type Codes**:
+- `T` = Ticket
+- `A` = Task
+- `C` = Child Ticket (merged)
+
+---
+
+#### `thread_entry`
+Individual thread messages/responses.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `pid` | INT(11) UNSIGNED | DEFAULT 0 | Parent entry (for threading) |
+| `thread_id` | INT(11) UNSIGNED | NOT NULL | Thread FK |
+| `staff_id` | INT(11) UNSIGNED | DEFAULT 0 | Staff author FK |
+| `user_id` | INT(11) UNSIGNED | DEFAULT 0 | User author FK |
+| `type` | CHAR(1) | NOT NULL, DEFAULT '' | Entry type |
+| `flags` | INT(11) UNSIGNED | DEFAULT 0 | Entry flags |
+| `poster` | VARCHAR(128) | NOT NULL, DEFAULT '' | Poster name |
+| `editor` | INT(10) UNSIGNED | | Editor ID |
+| `editor_type` | CHAR(1) | | Editor type (S=Staff, U=User) |
+| `source` | VARCHAR(32) | NOT NULL, DEFAULT '' | Entry source |
+| `title` | VARCHAR(255) | | Entry title/subject |
+| `body` | TEXT | NOT NULL | Message body |
+| `format` | VARCHAR(16) | NOT NULL, DEFAULT 'html' | Body format |
+| `ip_address` | VARCHAR(64) | NOT NULL, DEFAULT '' | Author IP |
+| `extra` | TEXT | | Additional data (JSON) |
+| `recipients` | TEXT | | Recipient list |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL, DEFAULT '0000-00-00 00:00:00' | Last update |
+
+**Indexes**: `pid`, `thread_id`, `staff_id`, `type`
+
+**Entry Type Codes**:
+- `M` = Message (from user)
+- `R` = Response (from staff)
+- `N` = Note (internal)
+
+---
+
+#### `thread_entry_email`
+Email metadata for thread entries.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `thread_entry_id` | INT(11) UNSIGNED | NOT NULL | Thread entry FK |
+| `email_id` | INT(11) UNSIGNED | DEFAULT 0 | Receiving email FK |
+| `mid` | VARCHAR(255) | | Message-ID header |
+| `headers` | TEXT | | Raw email headers |
+
+**Indexes**: `thread_entry_id`, `mid`, `email_id`
+
+---
+
+#### `thread_entry_merge`
+Merged thread entry data preservation.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `thread_entry_id` | INT(11) UNSIGNED | NOT NULL | Thread entry FK |
+| `data` | TEXT | | Preserved merge data (JSON) |
+
+---
+
+#### `thread_event`
+Thread activity log/audit trail.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `thread_id` | INT(11) UNSIGNED | NOT NULL | Thread FK |
+| `thread_type` | CHAR(1) | DEFAULT '' | Thread object type |
+| `event_id` | INT(11) UNSIGNED | DEFAULT NULL | Event definition FK |
+| `staff_id` | INT(11) UNSIGNED | DEFAULT NULL | Acting staff FK |
+| `team_id` | INT(11) UNSIGNED | DEFAULT NULL | Acting team FK |
+| `dept_id` | INT(11) UNSIGNED | DEFAULT NULL | Related department FK |
+| `topic_id` | INT(11) UNSIGNED | DEFAULT NULL | Related topic FK |
+| `data` | TEXT | | Event data (JSON) |
+| `username` | VARCHAR(128) | NOT NULL, DEFAULT 'SYSTEM' | Actor username |
+| `uid` | INT(11) UNSIGNED | | Actor user ID |
+| `uid_type` | CHAR(1) | NOT NULL, DEFAULT 'S' | Actor type |
+| `annulled` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Event annulled |
+| `timestamp` | DATETIME | NOT NULL | Event time |
+
+**Indexes**:
+- `ticket_state` (`thread_id`, `event_id`, `timestamp`)
+- `ticket_stats` (`timestamp`, `event_id`)
+
+---
+
+#### `thread_referral`
+Inter-ticket cross-references/referrals.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `thread_id` | INT(11) UNSIGNED | NOT NULL | Source thread FK |
+| `object_id` | INT(11) UNSIGNED | NOT NULL | Target object ID |
+| `object_type` | CHAR(1) | NOT NULL | Target object type |
+| `created` | DATETIME | NOT NULL | Creation date |
+
+**Engine**: InnoDB
+**Indexes**: UNIQUE(`object_id`, `object_type`, `thread_id`), `thread_id`
+
+---
+
+#### `thread_collaborator`
+External collaborators on ticket threads.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Collaborator flags |
+| `thread_id` | INT(11) UNSIGNED | NOT NULL | Thread FK |
+| `user_id` | INT(11) UNSIGNED | NOT NULL | Collaborator user FK |
+| `role` | CHAR(1) | NOT NULL, DEFAULT 'M' | Role: M=Participant, C=CC |
+| `created` | DATETIME | NOT NULL | Addition date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`thread_id`, `user_id`), `user_id`
+
+---
+
+### Task Tables
+
+#### `task`
+Internal work items/sub-tickets.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `object_id` | INT(11) UNSIGNED | DEFAULT 0 | Parent object ID |
+| `object_type` | CHAR(1) | DEFAULT '' | Parent object type |
+| `number` | VARCHAR(20) | | Task number |
+| `dept_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Department FK |
+| `staff_id` | INT(10) UNSIGNED | DEFAULT 0 | Assigned staff FK |
+| `team_id` | INT(10) UNSIGNED | DEFAULT 0 | Assigned team FK |
+| `lock_id` | INT(11) UNSIGNED | DEFAULT 0 | Edit lock FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Task flags |
+| `duedate` | DATETIME | | Due date |
+| `closed` | DATETIME | | Closure date |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `dept_id`, `staff_id`, `team_id`, `created`, `object` (`object_id`, `object_type`), `flags`
+
+---
+
+#### `task__cdata`
+Task custom data fields.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `task_id` | INT(11) UNSIGNED | PK | Task FK |
+| *dynamic* | *varies* | | Custom fields from forms |
+
+---
+
+### Note & Draft Tables
+
+#### `note`
+Internal notes (non-ticket).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `pid` | INT(11) UNSIGNED | DEFAULT 0 | Parent note (for threading) |
+| `staff_id` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Author staff FK |
+| `ext_id` | VARCHAR(10) | | External reference ID |
+| `body` | TEXT | | Note content |
+| `status` | INT(11) UNSIGNED | DEFAULT 0 | Note status |
+| `sort` | INT(11) UNSIGNED | DEFAULT 0 | Sort order |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `ext_id`
+
+---
+
+#### `draft`
+Unsaved message drafts.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `staff_id` | INT(11) UNSIGNED | NOT NULL | Author staff FK |
+| `namespace` | VARCHAR(32) | NOT NULL | Draft context namespace |
+| `body` | TEXT | NOT NULL | Draft content |
+| `extra` | TEXT | | Additional data (JSON) |
+| `created` | TIMESTAMP | | Creation time |
+| `updated` | TIMESTAMP | ON UPDATE CURRENT_TIMESTAMP | Last update |
+
+**Indexes**: `staff_id`, `namespace`
+
+---
+
+### Email & Communication Tables
+
+#### `email`
+Email addresses and department associations.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `email_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `noautoresp` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Disable auto-response |
+| `priority_id` | TINYINT(4) UNSIGNED | DEFAULT 2 | Default priority FK |
+| `dept_id` | INT(10) UNSIGNED | DEFAULT 0 | Default department FK |
+| `topic_id` | INT(11) UNSIGNED | DEFAULT 0 | Default topic FK |
+| `email` | VARCHAR(255) | NOT NULL | Email address |
+| `name` | VARCHAR(255) | NOT NULL | Display name |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`email`), `priority_id`, `dept_id`
+
+---
+
+#### `email_account`
+Email account configurations (IMAP/SMTP).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `email_id` | INT(11) UNSIGNED | NOT NULL | Email FK |
+| `type` | ENUM('mailbox','smtp') | NOT NULL | Account type |
+| `auth_bk` | VARCHAR(64) | | Auth backend |
+| `auth_id` | TEXT | | Auth credentials |
+| `active` | TINYINT(1) | DEFAULT 1 | Active status |
+| `host` | VARCHAR(255) | | Server hostname |
+| `port` | INT(11) | | Server port |
+| `folder` | VARCHAR(255) | | IMAP folder |
+| `protocol` | ENUM('IMAP','POP','SMTP','OTHER') | | Protocol type |
+| `encryption` | ENUM('NONE','AUTO','SSL') | | Encryption type |
+| `fetchfreq` | TINYINT(3) | DEFAULT 5 | Fetch frequency (minutes) |
+| `fetchmax` | TINYINT(4) UNSIGNED | DEFAULT 30 | Max messages per fetch |
+| `postfetch` | ENUM('delete','nothing','archive') | DEFAULT 'nothing' | Post-fetch action |
+| `archivefolder` | VARCHAR(255) | | Archive folder path |
+| `allow_spoofing` | TINYINT(1) UNSIGNED | DEFAULT 0 | Allow from spoofing |
+| `num_errors` | TINYINT(3) UNSIGNED | DEFAULT 0 | Error count |
+| `last_error_msg` | VARCHAR(255) | | Last error message |
+| `last_error` | DATETIME | | Last error time |
+| `last_activity` | DATETIME | | Last activity time |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `email_id`, `type`
+
+---
+
+#### `email_template_group`
+Email template sets.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `tpl_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `isactive` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Active status |
+| `name` | VARCHAR(32) | NOT NULL | Template set name |
+| `lang` | VARCHAR(16) | DEFAULT 'en_US' | Language code |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+---
+
+#### `email_template`
+Individual email templates.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `tpl_id` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Template set FK |
+| `code_name` | VARCHAR(32) | NOT NULL | Template identifier |
+| `subject` | VARCHAR(255) | NOT NULL | Email subject template |
+| `body` | TEXT | NOT NULL | Email body template |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`tpl_id`, `code_name`)
+
+---
+
+#### `canned_response`
+Pre-written response templates.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `canned_id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `dept_id` | INT(10) UNSIGNED | DEFAULT 0 | Department FK (0=global) |
+| `isenabled` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 1 | Enabled status |
+| `title` | VARCHAR(255) | NOT NULL | Response title |
+| `response` | TEXT | NOT NULL | Response body |
+| `lang` | VARCHAR(16) | DEFAULT 'en_US' | Language code |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`title`), `dept_id`, `isenabled` (as 'active')
+
+---
+
+### Filter & Routing Tables
+
+#### `filter`
+Email/ticket routing rules.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `execorder` | INT(10) UNSIGNED | NOT NULL, DEFAULT 99 | Execution order |
+| `isactive` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 1 | Active status |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Filter flags |
+| `status` | INT(11) UNSIGNED | DEFAULT 0 | Filter status |
+| `match_all_rules` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Match mode (all/any) |
+| `stop_onmatch` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Stop on match |
+| `target` | ENUM('Any','Web','Email','API') | DEFAULT 'Any' | Filter target |
+| `email_id` | INT(10) UNSIGNED | DEFAULT 0 | Specific email FK |
+| `name` | VARCHAR(32) | NOT NULL | Filter name |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `target`, `email_id`
+
+---
+
+#### `filter_rule`
+Individual filter conditions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `filter_id` | INT(11) UNSIGNED | NOT NULL | Filter FK |
+| `what` | VARCHAR(32) | NOT NULL | Field to match |
+| `how` | ENUM('equal','not_equal','contains','dn_contain','starts','ends','match','not_match') | NOT NULL | Match operator |
+| `val` | VARCHAR(255) | NOT NULL | Match value |
+| `isactive` | TINYINT(1) UNSIGNED | DEFAULT 1 | Rule active |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`filter_id`, `what`, `how`, `val`), `filter_id`
+
+---
+
+#### `filter_action`
+Filter triggered actions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `filter_id` | INT(11) UNSIGNED | NOT NULL | Filter FK |
+| `sort` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Execution order |
+| `type` | VARCHAR(24) | NOT NULL | Action type |
+| `configuration` | TEXT | | Action config (JSON) |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `filter_id`
+
+---
+
+### Knowledge Base Tables
+
+#### `faq`
+FAQ articles.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `faq_id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `category_id` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Category FK |
+| `ispublished` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Published status |
+| `question` | VARCHAR(255) | NOT NULL | FAQ question |
+| `answer` | TEXT | NOT NULL | FAQ answer |
+| `keywords` | TINYTEXT | | Search keywords |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`question`), `category_id`, `ispublished`
+
+---
+
+#### `faq_category`
+Hierarchical FAQ categories.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `category_id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `category_pid` | INT(10) UNSIGNED | DEFAULT 0 | Parent category FK |
+| `ispublic` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Public visibility |
+| `name` | VARCHAR(125) | | Category name |
+| `description` | TEXT | NOT NULL | Category description |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `ispublic`
+
+---
+
+#### `faq_topic`
+FAQ to help topic associations.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `faq_id` | INT(10) UNSIGNED | PK | FAQ FK |
+| `topic_id` | INT(10) UNSIGNED | PK | Help topic FK |
+
+---
+
+#### `help_topic`
+Help topics for ticket categorization.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `topic_id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `topic_pid` | INT(10) UNSIGNED | DEFAULT 0 | Parent topic FK |
+| `ispublic` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 1 | Public visibility |
+| `noautoresp` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Disable auto-response |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Topic flags |
+| `status_id` | INT(10) UNSIGNED | DEFAULT 0 | Default status FK |
+| `priority_id` | TINYINT(4) UNSIGNED | DEFAULT 0 | Default priority FK |
+| `dept_id` | INT(10) UNSIGNED | DEFAULT 0 | Default department FK |
+| `staff_id` | INT(10) UNSIGNED | DEFAULT 0 | Default assignee FK |
+| `team_id` | INT(10) UNSIGNED | DEFAULT 0 | Default team FK |
+| `sla_id` | INT(10) UNSIGNED | DEFAULT 0 | Default SLA FK |
+| `page_id` | INT(10) UNSIGNED | DEFAULT 0 | Associated page FK |
+| `sequence_id` | INT(10) UNSIGNED | DEFAULT 0 | Number sequence FK |
+| `sort` | INT(10) UNSIGNED | DEFAULT 0 | Sort order |
+| `topic` | VARCHAR(128) | NOT NULL | Topic name |
+| `number_format` | VARCHAR(32) | | Ticket number format |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`topic`, `topic_pid`), `topic_pid`, `priority_id`, `dept_id`, (`staff_id`, `team_id`), `sla_id`, `page_id`
+
+---
+
+#### `help_topic_form`
+Topic-to-form assignments.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `topic_id` | INT(11) UNSIGNED | NOT NULL | Topic FK |
+| `form_id` | INT(10) UNSIGNED | NOT NULL | Form FK |
+| `sort` | INT(10) UNSIGNED | NOT NULL, DEFAULT 1 | Display order |
+| `extra` | TEXT | | Additional config (JSON) |
+
+**Indexes**: `topic-form` (`topic_id`, `form_id`)
+
+---
+
+### Dynamic Forms Tables
+
+#### `form`
+Dynamic form definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `pid` | INT(11) UNSIGNED | DEFAULT 0 | Parent form FK |
+| `type` | VARCHAR(8) | NOT NULL, DEFAULT 'G' | Form type code |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Form flags |
+| `title` | VARCHAR(255) | NOT NULL | Form title |
+| `instructions` | VARCHAR(512) | | Form instructions |
+| `name` | VARCHAR(64) | NOT NULL, DEFAULT '' | Internal name |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `type`
+
+**Form Type Codes**:
+- `G` = Generic
+- `U` = User
+- `T` = Ticket
+- `O` = Organization
+- `A` = Task
+- `C` = Company
+
+---
+
+#### `form_field`
+Form field definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `form_id` | INT(11) UNSIGNED | NOT NULL | Form FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 1 | Field flags |
+| `type` | VARCHAR(255) | NOT NULL, DEFAULT 'text' | Field type |
+| `label` | VARCHAR(255) | NOT NULL | Display label |
+| `name` | VARCHAR(64) | NOT NULL | Field name |
+| `configuration` | TEXT | | Field config (JSON) |
+| `sort` | INT(10) UNSIGNED | NOT NULL | Sort order |
+| `hint` | VARCHAR(512) | | Help text |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `form_id`, `sort`
+
+---
+
+#### `form_entry`
+Form submission instances.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `form_id` | INT(11) UNSIGNED | NOT NULL | Form FK |
+| `object_id` | INT(11) UNSIGNED | | Parent object ID |
+| `object_type` | CHAR(1) | NOT NULL, DEFAULT 'T' | Object type code |
+| `sort` | INT(11) UNSIGNED | NOT NULL, DEFAULT 1 | Sort order |
+| `extra` | TEXT | | Additional data (JSON) |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `entry_lookup` (`object_type`, `object_id`)
+
+---
+
+#### `form_entry_values`
+Form field values.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `entry_id` | INT(11) UNSIGNED | PK | Form entry FK |
+| `field_id` | INT(11) UNSIGNED | PK | Form field FK |
+| `value` | TEXT | | Field value |
+| `value_id` | INT(11) | | Reference value ID |
+
+---
+
+#### `list`
+Dropdown/select list definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(255) | NOT NULL | List name |
+| `name_plural` | VARCHAR(255) | | Plural form |
+| `sort_mode` | ENUM('Alpha','-Alpha','SortCol') | DEFAULT 'Alpha' | Sort mode |
+| `masks` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Property masks |
+| `type` | VARCHAR(16) | | List type |
+| `configuration` | TEXT | | List config (JSON) |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `type`
+
+---
+
+#### `list_items`
+List item values.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `list_id` | INT(11) UNSIGNED | NOT NULL | List FK |
+| `status` | INT(11) UNSIGNED | NOT NULL, DEFAULT 1 | Item status |
+| `value` | VARCHAR(255) | NOT NULL | Display value |
+| `extra` | TEXT | | Additional data (JSON) |
+| `sort` | INT(11) UNSIGNED | NOT NULL, DEFAULT 1 | Sort order |
+| `properties` | TEXT | | Item properties (JSON) |
+
+**Indexes**: `list_item_lookup` (`list_id`)
+
+---
+
+### File & Attachment Tables
+
+#### `file`
+File storage registry.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `ft` | CHAR(1) | NOT NULL, DEFAULT 'T' | File type code |
+| `bk` | CHAR(1) | NOT NULL, DEFAULT 'D' | Storage backend |
+| `type` | VARCHAR(255) | NOT NULL, DEFAULT '', ascii_general_ci | MIME type |
+| `size` | BIGINT(20) UNSIGNED | NOT NULL, DEFAULT 0 | File size (bytes) |
+| `key` | VARCHAR(86) | ascii_general_ci | File key/hash |
+| `signature` | VARCHAR(86) | ascii_bin | Content signature |
+| `name` | VARCHAR(255) | NOT NULL, DEFAULT '' | Original filename |
+| `attrs` | TEXT | | File attributes (JSON) |
+| `created` | DATETIME | NOT NULL | Creation date |
+
+**Indexes**: `ft`, `key`, `signature`, `type`, `created`, `size`
+
+**Storage Backends** (`bk`):
+- `D` = Database (file_chunk table)
+- `F` = Filesystem
+- `S` = S3/Object Storage
+
+---
+
+#### `file_chunk`
+File content chunks (database storage).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `file_id` | INT(11) UNSIGNED | PK | File FK |
+| `chunk_id` | INT(11) UNSIGNED | PK | Chunk sequence |
+| `filedata` | LONGBLOB | NOT NULL | Binary data |
+
+---
+
+#### `attachment`
+File-to-object associations.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `object_id` | INT(11) UNSIGNED | NOT NULL | Parent object ID |
+| `type` | CHAR(1) | NOT NULL | Object type code |
+| `file_id` | INT(11) UNSIGNED | NOT NULL | File FK |
+| `name` | VARCHAR(255) | | Display name override |
+| `inline` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Inline display |
+| `lang` | VARCHAR(16) | | Language code |
+
+**Indexes**: UNIQUE `file-type` (`object_id`, `file_id`, `type`), UNIQUE `file_object` (`file_id`, `object_id`)
+
+---
+
+### SLA Table
+
+#### `sla`
+Service Level Agreement definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `flags` | INT(10) UNSIGNED | DEFAULT 3 | SLA flags |
+| `grace_period` | INT(10) UNSIGNED | NOT NULL, DEFAULT 0 | Grace period (hours) |
+| `name` | VARCHAR(64) | NOT NULL, DEFAULT '' | SLA name |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`name`)
+
+**SLA Flags**:
+- `FLAG_ACTIVE` (1): SLA is active
+- `FLAG_ESCALATE` (2): Enable escalation
+- `FLAG_NOALERTS` (4): Suppress overdue alerts
+- `FLAG_TRANSIENT` (8): Temporary SLA
+
+---
+
+### Schedule Tables
+
+#### `schedule`
+Business hours/schedule definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Schedule flags |
+| `name` | VARCHAR(255) | NOT NULL | Schedule name |
+| `timezone` | VARCHAR(64) | | Schedule timezone |
+| `description` | TEXT | | Description |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+---
+
+#### `schedule_entry`
+Schedule time blocks.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `schedule_id` | INT(10) UNSIGNED | NOT NULL | Schedule FK |
+| `flags` | INT(10) UNSIGNED | DEFAULT 0 | Entry flags |
+| `sort` | INT(10) UNSIGNED | DEFAULT 0 | Sort order |
+| `name` | VARCHAR(255) | | Entry name |
+| `repeats` | VARCHAR(16) | NOT NULL, DEFAULT 'never' | Repeat pattern |
+| `starts_on` | DATE | | Start date |
+| `starts_at` | TIME | | Start time |
+| `ends_on` | DATE | | End date |
+| `ends_at` | TIME | | End time |
+| `stops_on` | DATE | | Repeat stop date |
+| `day` | INT(10) UNSIGNED | DEFAULT 0 | Day of week/month |
+| `week` | INT(10) UNSIGNED | DEFAULT 0 | Week number |
+| `month` | INT(10) UNSIGNED | DEFAULT 0 | Month |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `schedule_id`, `repeats`
+
+---
+
+### Queue/View Tables
+
+#### `queue`
+Custom ticket queues/saved searches.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `parent_id` | INT(11) UNSIGNED | DEFAULT 0 | Parent queue FK |
+| `columns_id` | INT(11) UNSIGNED | DEFAULT 0 | Column set FK |
+| `sort_id` | INT(11) UNSIGNED | DEFAULT 0 | Default sort FK |
+| `flags` | INT(11) UNSIGNED | DEFAULT 0 | Queue flags |
+| `staff_id` | INT(11) UNSIGNED | DEFAULT 0 | Owner staff FK (0=public) |
+| `sort` | INT(11) UNSIGNED | DEFAULT 0 | Sort order |
+| `title` | VARCHAR(60) | | Queue title |
+| `config` | TEXT | | Queue config (JSON) |
+| `filter` | VARCHAR(64) | | Quick filter |
+| `root` | VARCHAR(32) | | Root object type |
+| `path` | VARCHAR(80) | NOT NULL, DEFAULT '/' | Hierarchical path |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `staff_id`, `parent_id`
+
+---
+
+#### `queue_column`
+Available queue column definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `flags` | INT(11) UNSIGNED | DEFAULT 0 | Column flags |
+| `name` | VARCHAR(64) | NOT NULL | Column name |
+| `primary` | VARCHAR(255) | NOT NULL, DEFAULT '' | Primary field path |
+| `secondary` | VARCHAR(255) | | Secondary field path |
+| `filter` | VARCHAR(32) | | Quick filter type |
+| `truncate` | VARCHAR(16) | | Truncation mode |
+| `annotations` | TEXT | | Column annotations (JSON) |
+| `conditions` | TEXT | | Display conditions (JSON) |
+| `extra` | TEXT | | Additional config (JSON) |
+
+---
+
+#### `queue_columns`
+Staff queue column selections.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `queue_id` | INT(11) UNSIGNED | PK | Queue FK |
+| `column_id` | INT(11) UNSIGNED | PK | Column FK |
+| `staff_id` | INT(11) UNSIGNED | PK | Staff FK (0=default) |
+| `bits` | INT(11) UNSIGNED | DEFAULT 0 | Column bits |
+| `sort` | INT(11) UNSIGNED | DEFAULT 0 | Display order |
+| `heading` | VARCHAR(64) | | Custom heading |
+| `width` | INT(11) UNSIGNED | DEFAULT 100 | Column width (px) |
+
+---
+
+#### `queue_sort`
+Sort column definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `root` | VARCHAR(32) | DEFAULT '' | Root object type |
+| `name` | VARCHAR(64) | NOT NULL, DEFAULT '' | Sort name |
+| `columns` | TEXT | | Sort columns (JSON) |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+---
+
+#### `queue_sorts`
+Sort assignments to queues.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `queue_id` | INT(11) UNSIGNED | PK | Queue FK |
+| `sort_id` | INT(11) UNSIGNED | PK | Sort definition FK |
+| `bits` | INT(11) UNSIGNED | DEFAULT 0 | Sort bits |
+| `sort` | INT(11) UNSIGNED | DEFAULT 0 | Order |
+
+---
+
+#### `queue_export`
+Queue export column definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `queue_id` | INT(11) UNSIGNED | NOT NULL | Queue FK |
+| `path` | VARCHAR(255) | NOT NULL | Export field path |
+| `heading` | VARCHAR(64) | | Column heading |
+| `sort` | INT(11) UNSIGNED | DEFAULT 0 | Export order |
+
+**Indexes**: `queue_id`
+
+---
+
+#### `queue_config`
+Staff queue configurations.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `queue_id` | INT(11) UNSIGNED | PK | Queue FK |
+| `staff_id` | INT(11) UNSIGNED | PK | Staff FK |
+| `setting` | TEXT | | Settings (JSON) |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+---
+
+### API Table
+
+#### `api_key`
+API authentication keys.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `isactive` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 1 | Active status |
+| `ipaddr` | VARCHAR(64) | NOT NULL | Allowed IP address |
+| `apikey` | VARCHAR(255) | NOT NULL | API key |
+| `can_create_tickets` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 1 | Create tickets permission |
+| `can_exec_cron` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 1 | Execute cron permission |
+| `notes` | TEXT | | Admin notes |
+| `updated` | DATETIME | NOT NULL | Last update |
+| `created` | DATETIME | NOT NULL | Creation date |
+
+**Indexes**: `ipaddr`, UNIQUE(`apikey`)
+
+---
+
+### Plugin Tables
+
+#### `plugin`
+Installed plugins registry.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `name` | VARCHAR(255) | NOT NULL | Plugin name |
+| `install_path` | VARCHAR(60) | NOT NULL | Installation path |
+| `isphar` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | PHAR package |
+| `isactive` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Active status |
+| `version` | VARCHAR(64) | | Plugin version |
+| `notes` | TEXT | | Admin notes |
+| `installed` | DATETIME | NOT NULL | Installation date |
+
+**Indexes**: UNIQUE(`install_path`)
+
+---
+
+#### `plugin_instance`
+Plugin instances/configurations.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `plugin_id` | INT(11) UNSIGNED | NOT NULL | Plugin FK |
+| `flags` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Instance flags |
+| `name` | VARCHAR(128) | NOT NULL, DEFAULT '' | Instance name |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: `plugin_id`
+
+---
+
+### Internationalization Table
+
+#### `translation`
+i18n translation strings.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(11) UNSIGNED | PK, AUTO_INCREMENT | |
+| `object_hash` | VARCHAR(32) | | Source object hash |
+| `type` | ENUM('phrase','article','override') | | Translation type |
+| `flags` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Translation flags |
+| `revision` | INT(11) UNSIGNED | | Revision number |
+| `agent_id` | INT(11) UNSIGNED | NOT NULL, DEFAULT 0 | Translator ID |
+| `lang` | VARCHAR(16) | NOT NULL, DEFAULT 'en_US' | Target language |
+| `text` | MEDIUMTEXT | NOT NULL | Translated text |
+| `source_text` | MEDIUMTEXT | | Original text |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: (`type`, `lang`), `object_hash`
+
+---
+
+### Content Table
+
+#### `content`
+Static pages/information content.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INT(10) UNSIGNED | PK, AUTO_INCREMENT | |
+| `isactive` | TINYINT(1) UNSIGNED | NOT NULL, DEFAULT 0 | Active status |
+| `type` | VARCHAR(32) | NOT NULL, DEFAULT 'other' | Content type |
+| `name` | VARCHAR(255) | NOT NULL | Content name/identifier |
+| `body` | TEXT | NOT NULL | Content body |
+| `notes` | TEXT | | Admin notes |
+| `created` | DATETIME | NOT NULL | Creation date |
+| `updated` | DATETIME | NOT NULL | Last update |
+
+**Indexes**: UNIQUE(`name`)
+
+---
+
+## Object Type Codes (Polymorphism)
+
+The database uses single-character codes for polymorphic relationships:
+
+| Code | Object Type |
+|------|-------------|
+| `T` | Ticket |
+| `A` | Task |
+| `C` | Child Ticket (merged) |
+| `U` | User |
+| `O` | Organization |
+| `S` | Staff |
+| `D` | Department |
+| `E` | Team |
+| `K` | FAQ |
+| `F` | AttachmentFile |
+| `H` | ThreadEntry (generic) |
+
+---
+
+## Entity Relationship Summary
+
+### Primary Relationships
+
+```
+User ─────────────────┬── UserEmail (1:N)
+  │                   └── UserAccount (1:1)
+  └── Organization (N:1)
+
+Ticket ───────────────┬── User (N:1)
+  │                   ├── Staff (N:1, assigned)
+  │                   ├── Team (N:1)
+  │                   ├── Department (N:1)
+  │                   ├── Topic (N:1)
+  │                   ├── Status (N:1)
+  │                   ├── Priority (N:1)
+  │                   ├── SLA (N:1)
+  │                   ├── Thread (1:1)
+  │                   └── Lock (1:1)
+
+Thread ───────────────┬── ThreadEntry (1:N)
+  │                   ├── ThreadEvent (1:N)
+  │                   ├── ThreadCollaborator (1:N)
+  │                   └── ThreadReferral (1:N)
+
+Staff ────────────────┬── Department (N:1, primary)
+  │                   ├── Role (N:1, primary)
+  │                   ├── StaffDeptAccess (1:N, extended)
+  │                   └── TeamMember (1:N)
+
+Department ───────────┬── Department (N:1, parent)
+  │                   ├── Email (N:1)
+  │                   ├── SLA (N:1)
+  │                   ├── Schedule (N:1)
+  │                   └── Staff (N:1, manager)
+
+Form ─────────────────┬── FormField (1:N)
+  └── FormEntry (1:N) ─── FormEntryValues (1:N)
+```
+
+---
+
+## Migration System
+
+### Overview
+- **Location**: `include/upgrader/streams/core/`
+- **File Types**: `.patch.sql` (additions), `.cleanup.sql` (cleanup)
+- **Tracking**: `config` table with `schema_signature` key
+
+### Migration File Format
+```sql
+/**
+ * @signature <sha1_hash>
+ * @version v1.x.x
+ * @title Migration description
+ */
+
+-- Schema changes here
+ALTER TABLE ...
+
+-- Update signature
+UPDATE %TABLE_PREFIX%config
+SET value = '<new_signature>'
+WHERE key = 'schema_signature' AND namespace = 'core';
+```
+
+---
+
+## Index Strategy
+
+### Performance Indexes
+- All foreign keys have corresponding indexes
+- Composite indexes on frequently joined columns
+- Covering indexes for common query patterns
+
+### Unique Constraints
+- Natural keys (email addresses, usernames, names)
+- Composite uniqueness (topic+parent, filter rules)
+
+---
+
+## Notes
+
+### Character Sets
+- Default: `utf8`
+- Binary fields: `ascii_bin` (passwords, signatures)
+- Case-insensitive: `ascii_general_ci` (file types, session IDs)
+- Unicode collation: `utf8_unicode_ci` (user agents)
+
+### Timestamps
+- All major tables have `created` and `updated` columns
+- Some tables use `TIMESTAMP` with `ON UPDATE CURRENT_TIMESTAMP`
+
+### Soft Deletes
+- Uses `flags` field for deletion markers
+- Hard deletes available for certain statuses (deleted state)


### PR DESCRIPTION
- SCHEMA.md: Comprehensive database schema reference covering all 66 tables, column definitions, indexes, foreign keys, and relationships. Documents MySQL-specific syntax and migration system.

- FX.md: Business logic documentation covering core entities, ticket lifecycle operations, access control, SLA processing, email handling, cron jobs, API endpoints, and system invariants.