### PR TITLE
issue: Microsoft UTF-8 BOM

### DIFF
--- a/include/laminas-mail/src/Headers.php
+++ b/include/laminas-mail/src/Headers.php
@@ -88,6 +88,10 @@ class Headers implements Countable, Iterator
      */
     public static function fromString($string, $eol = self::EOL)
     {
+        // PATCH: Strip UTF-8 BOM
+        if (preg_match("/^\xEF\xBB\xBF/", $string))
+            $string = preg_replace('/^\xEF\xBB\xBF/', '', $string);
+
         $headers     = new static();
         $currentLine = '';
         $emptyLine   = 0;


### PR DESCRIPTION
This addresses an issue where MS started adding UTF-8 BOM to beginning of some content which causes parsing issues and errors. This removes the UTF-8 BOM before using it in laminas to avoid parsing issues and errors.