### PR TITLE
issue: PGP + S/MIME Mail Parsing

### DIFF
--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -314,14 +314,6 @@ class Mail_mimeDecode extends PEAR
                     $this->_include_bodies ? $return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding) : $body) : null;
                     break;
                 
-                case 'multipart/signed': // PGP
-                    $parts = $this->_boundarySplit($body, $content_type['other']['boundary'], true);
-                    $return->parts['msg_body'] = $parts[0]; 
-                    list($part_header, $part_body) = $this->_splitBodyHeader($parts[1]);
-                    $return->parts['sig_hdr'] = $part_header;
-                    $return->parts['sig_body'] = $part_body;
-                    break;
-
                 case 'multipart/parallel':
                 case 'multipart/appledouble': // Appledouble mail
                 case 'multipart/report': // RFC1892


### PR DESCRIPTION
This addresses an issue with PGP and S/MIME mail parsing where sometimes the content is completely empty or malformed. This is due to an old PGP block that was added back to the code after a Pear upgrade. This removes the block to allow PGP and S/MIME mail to be parsed correctly.