### PR TITLE
issue: Empty Dept Error On Topic Update

### DIFF
--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -146,6 +146,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info, true);
                     &nbsp;<span class="error">*&nbsp;<?php echo $warn; ?></span>
                 <?php } ?>
                 <i class="help-tip icon-question-sign" href="#department"></i>
+                <div class="error"><?php echo $errors['dept_id']; ?></div>
             </td>
         </tr>
         <tr class="border">


### PR DESCRIPTION
This addresses an issue where when updating a Help Topic and having a disabled Department set for example, the system will return a generic error stating to address the errors below; but none are shown. This is due to a missing error div that displays the Department errors. This simply adds the div so Department errors are visible.