### PR TITLE
Fix session timeout unit mismatch causing auth loop.

### DIFF
--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -216,7 +216,7 @@ class ClientSession extends EndUser {
         // XXX: Change the key to user-id
         $this->session = new UserSession($user->getUserId());
         $this->setSessionToken();
-        $this->maxidletime = $cfg->getClientTimeout();
+        $this->maxidletime = $cfg->getClientTimeout()*60;
     }
 
     function getSessionUser() {
@@ -237,7 +237,7 @@ class StaffSession extends Staff {
             $staff->class = 'staff';
             $staff->session = new UserSession($staff->getId());
             $staff->setSessionToken();
-            $staff->maxidletime = $cfg->getStaffTimeout();
+            $staff->maxidletime = $cfg->getStaffTimeout()*60;
             $staff->checkip = $cfg->enableStaffIPBinding();
         }
         return $staff;


### PR DESCRIPTION
StaffSession and ClientSession populate maxidletime from config values expressed in minutes, but UserSession::isValidSession() compares it against (time() - expire) in seconds. 

```
        // is it expired??
        if ($maxidletime && ((time()-$expire) > $maxidletime))
            return false;
```

This unit mismatch leads to repeated re-authentication loops (notably in scp/login.php), until either user clear session data (cookies) from its browser or the condition that leads to this bug change, often through additional waiting time for the condition to lift.

Normalized maxidletime to seconds before comparison to ensure correct session expiration behavior.