### PR TITLE
[FIX] mails will be fetched with empty bodies

### DIFF
--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -149,13 +149,18 @@ class Mail_Parse {
     }
 
     function splitBodyHeader() {
-        $match = array();
-        if (!$this->header
-                && preg_match("/^(.*?)\r?\n\r?\n./s",
-                    $this->mime_message,
-                    $match)) {
-            $this->header=$match[1];
+        $match = [];
+        if ($this->header) {
+            return;
         }
+        if (preg_match("/^(.*?)\r?\n\r?\n/s", $this->mime_message, $match)) {
+            $header = $match[1];
+        } else { // corrupt - better all as nothing
+            $header = $this->mime_message;
+        }
+
+        // remove BOOM chars - see osticket forum at: https://forum.osticket.com/d/107250-mail-fetcher-error/10
+        $this->header = preg_replace('/^\xEF\xBB\xBF/', '', $header);
     }
 
     /**
@@ -186,6 +191,9 @@ class Mail_Parse {
         $array = array();
         foreach ($headers as $hdr) {
             list($name, $val) = explode(": ", $hdr, 2);
+            // decode header value like subject, from, to, cc, bcc ...
+            if($val && is_string($val))
+                $val = Format::mimedecode($val);
             # Create list of values if header is specified more than once
             $name = strtolower($name);
             if (isset($array[$name]) && $as_array) {
@@ -343,7 +351,7 @@ class Mail_Parse {
             // Handle rfc1892 style bounces
             if (strtolower($ctype) === 'text/rfc822-headers') {
                 $body = $p->body . "\n\nIgnored";
-                $T = new Mail_mimeDecode($body, ['attachOnParseError' => false]);
+                $T = new Mail_mimeDecode($body); // Mail_mimeDecode has only one parameter
                 if ($struct = $T->decode())
                     return $struct->headers;
             }
@@ -359,15 +367,16 @@ class Mail_Parse {
         if (!$this->struct)
             return new TextThreadEntryBody('');
 
+        // "0" is a valid body
         if ($cfg && $cfg->isRichTextEnabled()) {
-            if ($html=$this->getPart($this->struct,'text/html'))
+            if (($html=trim($this->getPart($this->struct,'text/html'))) !== '')
                 $body = new HtmlThreadEntryBody($html);
-            elseif ($text=$this->getPart($this->struct,'text/plain'))
+            elseif (($text=trim($this->getPart($this->struct,'text/plain'))) !== '')
                 $body = new TextThreadEntryBody($text);
         }
-        elseif ($text=$this->getPart($this->struct,'text/plain'))
+        elseif (($text=trim($this->getPart($this->struct,'text/plain'))) !== '')
             $body = new TextThreadEntryBody($text);
-        elseif ($html=$this->getPart($this->struct,'text/html'))
+        elseif (($html=trim($this->getPart($this->struct,'text/html'))) !== '')
             $body = new TextThreadEntryBody(
                     Format::html2text(Format::safe_html($html),
                         100, false));
@@ -405,9 +414,9 @@ class Mail_Parse {
                     && (strcasecmp($struct->disposition, 'inline') !== 0))
                 return '';
             if ($ctype && strcasecmp($ctype,$ctypepart)==0) {
-                $content = $struct->body;
+                $content = (string) $struct->body;
                 //Encode to desired encoding - ONLY if charset is known??
-                if (isset($struct->ctype_parameters['charset']))
+                if ($content !== '' && isset($struct->ctype_parameters['charset']))
                     $content = Charset::transcode($content,
                         $struct->ctype_parameters['charset'], $this->charset);
 
@@ -417,7 +426,7 @@ class Mail_Parse {
 
         if ($this->tnef && !strcasecmp($ctypepart, 'text/html')
                 && ($content = $this->tnef->getBody('text/html', $this->charset)))
-            return $content;
+            return (string) $content;
 
         $data='';
         if ($struct && @$struct->parts && $recurse
@@ -667,8 +676,8 @@ class Mail_Parse {
         }
 
         //maybe we got BCC'ed??
-        if(isset($recipients['bcc'])) {
-            foreach ($recipients['bcc'] as $addr) {
+        if (($bcc = $this->getBccAddressList())) {
+            foreach ($bcc as $addr) {
                 if (($emailId=Email::getIdByEmail($addr->mailbox.'@'.$addr->host))) {
                     $info['system_emails'][] = $emailId;
                     if (!$info['emailId'])
@@ -677,10 +686,13 @@ class Mail_Parse {
             }
         }
 
-        // reply to ?
+        // reply to ? - set it only, if it's a valid mail
         if (($replyto = $this->getReplyTo())
-                && ($replyto = $replyto[0])) {
-            $info['reply-to'] = $replyto->mailbox.'@'.$replyto->host;
+                && ($replyto = $replyto[0])
+                && ($replytoAddress = $replyto->mailbox.'@'.$replyto->host)
+                && Validator::is_email($replytoAddress)
+           ) {
+            $info['reply-to'] = $replytoAddress;
             if ($replyto->personal)
                 $info['reply-to-name'] = trim($replyto->personal, " \t\n\r\0\x0B\x22");
         }

--- a/include/laminas-mail/src/Headers.php
+++ b/include/laminas-mail/src/Headers.php
@@ -88,10 +88,6 @@ class Headers implements Countable, Iterator
      */
     public static function fromString($string, $eol = self::EOL)
     {
-        // PATCH: Strip UTF-8 BOM
-        if (preg_match("/^\xEF\xBB\xBF/", $string))
-            $string = preg_replace('/^\xEF\xBB\xBF/', '', $string);
-
         $headers     = new static();
         $currentLine = '';
         $emptyLine   = 0;

--- a/include/pear/Mail/mimeDecode.php
+++ b/include/pear/Mail/mimeDecode.php
@@ -160,6 +160,9 @@ class Mail_mimeDecode extends PEAR
      */
     function __construct(&$input)
     {
+        // normalize different line breaks \r or \n or \r\n or mixed -> \r\n
+        $input = str_replace("\n", "\r\n", str_replace(["\r\n", "\r"], "\n", $input));
+        
         list($header, $body)   = $this->_splitBodyHeader($input);
 
         $this->_input          = &$input;
@@ -303,7 +306,15 @@ class Mail_mimeDecode extends PEAR
         }
 
         if (isset($content_type)) {
-            switch (strtolower($content_type['value'])) {
+            $ct = strtolower(trim($content_type['value'] ?? ''));
+            // not all multipart bodies will parsed correct
+            // for example, multipart/form-data goes to default fallback and will not parsed correct
+            // so we handle all multipart bodies the same way
+            // -> for switch, we change content type temporarly to multipart/mixed
+            if($ct && str_starts_with($ct, 'multipart/'))
+                $ct = 'multipart/mixed';
+
+            switch ($ct) {
                 case 'text/plain':
                     $encoding = isset($content_transfer_encoding) ? $content_transfer_encoding['value'] : '7bit';
                     $this->_include_bodies ? $return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding) : $body) : null;
@@ -313,7 +324,8 @@ class Mail_mimeDecode extends PEAR
                     $encoding = isset($content_transfer_encoding) ? $content_transfer_encoding['value'] : '7bit';
                     $this->_include_bodies ? $return->body = ($this->_decode_bodies ? $this->_decodeBody($body, $encoding) : $body) : null;
                     break;
-                
+
+/* no need for this cases at the moment, because all multipart/* content types changed to multipart/mixed....
                 case 'multipart/parallel':
                 case 'multipart/appledouble': // Appledouble mail
                 case 'multipart/report': // RFC1892
@@ -322,6 +334,8 @@ class Mail_mimeDecode extends PEAR
                 case 'multipart/alternative':
                 case 'multipart/related':
                 case 'multipart/relative': //#20431 - android
+                case 'multipart/form-data':
+*/
                 case 'multipart/mixed':
                 case 'application/vnd.wap.multipart.related':
                     if(!isset($content_type['other']['boundary'])){
@@ -430,7 +444,9 @@ class Mail_mimeDecode extends PEAR
         if ($input instanceof StringView)
             $check = $input->substr(0, 64<<10);
         else
-            $check = &$input;
+            $check = $input;
+
+        $match = [];
         if (preg_match("/^.*?(\r?\n\r?\n)(.)/s", $check, $match, PREG_OFFSET_CAPTURE)) {
             $headers = ($input instanceof StringView)
                 ? (string) $input->substr(0, $match[1][1]) : substr($input, 0, $match[1][1]);
@@ -440,11 +456,14 @@ class Mail_mimeDecode extends PEAR
         }
         // bug #17325 - empty bodies are allowed. - we just check that at least one line 
         // of headers exist..
-        if (count(explode("\n",$input))) {
+        // $input ends with an empty line (maybe with white spaces...)
+        if (preg_match("/\r?\n\r?\n[ \t]*\z/s", (string)$check)) {
             return array($input, '');
         }
         $this->_error = 'Could not split header and body';
-        return false;
+        // if we can't splitt $input into header and bodies, we set $input for header and body
+        // header may correct, body may contain raw email (better than empty)
+        return array($input, $input);
     }
 
     /**


### PR DESCRIPTION
This pull request will fix several issues, that may produce empty tickets.

Following changes will be done by this commit:

**class Mail_parse:**

splitBodyHeader()
- do nothing, if $this->header is already set
- get mail header and set it to $this-header
- if mail header can't get correctly, set whole mime_message to $this->header

static function splitHeaders()
- decode every decoded header line like subject, from, to, cc, bcc ...

function getOriginalMessageHeaders()
- remove second parameter by "new Mail_mimeDecode($body)"
    Mail_mimeDecode constructor supports only one parameter

function getBody()
- "0" is a valid body...

function getPart()
- ensure $struct->body is a string (can be object from instanceof StringView)
- Charset::transcode($content ...) only, if $content != ''

function getHeaderInfo()
- get bcc addresses from $this->getBccAddressList() instead of $recipients['bcc']
- set replyTo only, it it's a valid mail


**class Mail_mimeDecode**

function __construct()
- normalize line breaks ( set \r or \n or mixed to \r\n)

function _decode()
- not all multipart bodies will parsed correct
    for example, multipart/form-data goes to default fallback and will not parsed correct
    so we handle all multipart bodies the same way
    -> for switch, we change content type temporarly to multipart/mixed

function _splitBodyHeader()
this function may produce empty bodies
if $input can be splitted correctly -> return header and body
elseif body is empty, but separator line can be found -> return header and empty body
else header and body can't be splitted and separator line can't be found -> return header = body = $input
(this may shown the whole header in the ticket message, but this raw mail is corrupt. So it's better to see all instead of nothing)