### PR TITLE
issue: Inline Image Upload CSRF

### DIFF
--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -386,7 +386,7 @@ $(function() {
                 'imageCaption': false,
                 'imageManagerJson': 'ajax.php/draft/images/browse',
                 'imagePosition': true,
-                'imageUploadData': {
+                'imageData': {
                     '__CSRFToken__': $("meta[name=csrf_token]").attr("content")
                 },
                 'imageResizable': true,


### PR DESCRIPTION
This addresses issue #6931 where uploading inline image on client portal fails. This is due to missing CSRF Token. During replication I noticed the key that set the CSRF Token in the upload data was `imageUploadData` but the real key is `imageData`. This simply updates the key name to address the issue. The issue only recently cropped up as we hardened the request handling.