### PR TITLE
API keys: support CIDR source authorization

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -101,16 +101,62 @@ class API {
         return ($key && $ip && self::getIdByKey($key, $ip));
     }
 
+    static function parseNetworks($networks) {
+        return array_filter(array_map('trim', explode(',', (string) $networks)), 'strlen');
+    }
+
+    static function isValidNetwork($network) {
+        if (Validator::is_ip($network))
+            return true;
+
+        if (strpos($network, '/') === false)
+            return false;
+
+        list($address, $prefix) = explode('/', $network, 2);
+        $address = trim($address);
+        $prefix = trim($prefix);
+
+        if ($prefix === '' || !is_numeric($prefix))
+            return false;
+
+        return Validator::is_ip($address) && Validator::check_ip($address, $address.'/'.$prefix);
+    }
+
+    static function isValidSource($source) {
+        $networks = self::parseNetworks($source);
+        if (!$networks)
+            return false;
+
+        foreach ($networks as $network) {
+            if (!self::isValidNetwork($network))
+                return false;
+        }
+
+        return true;
+    }
+
+    static function isSourceAuthorized($ip, $source) {
+        if (!Validator::is_ip($ip))
+            return false;
+
+        foreach (self::parseNetworks($source) as $network) {
+            if (Validator::check_ip($ip, $network))
+                return true;
+        }
+
+        return false;
+    }
+
     static function getIdByKey($key, $ip='') {
 
-        $sql='SELECT id FROM '.API_KEY_TABLE.' WHERE apikey='.db_input($key);
-        if($ip)
-            $sql.=' AND ipaddr='.db_input($ip);
+        $sql='SELECT id, ipaddr FROM '.API_KEY_TABLE.' WHERE apikey='.db_input($key);
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            list($id, $source) = db_fetch_row($res);
+            if (!$ip || self::isSourceAuthorized($ip, $source))
+                return $id;
+        }
 
-        if(($res=db_query($sql)) && db_num_rows($res))
-            list($id) = db_fetch_row($res);
-
-        return $id;
+        return null;
     }
 
     static function lookupByKey($key, $ip='') {
@@ -123,8 +169,11 @@ class API {
 
     static function save($id, $vars, &$errors) {
 
-        if(!$id && (!$vars['ipaddr'] || !Validator::is_ip($vars['ipaddr'])))
-            $errors['ipaddr'] = __('Valid IP is required');
+        if (!$id) {
+            $vars['ipaddr'] = trim($vars['ipaddr']);
+            if (!$vars['ipaddr'] || !self::isValidSource($vars['ipaddr']))
+                $errors['ipaddr'] = __('Valid IP or CIDR is required');
+        }
 
         if($errors) return false;
 
@@ -198,18 +247,18 @@ class ApiController extends Controller {
         // see getApiKey method.
         if (!($key=$this->getKey()))
             return $this->exerr(401, __('Valid API key required'));
-        elseif (!$key->isActive() || $key->getIPAddr() != $this->getRemoteAddr())
+        elseif (!$key->isActive() || !API::isSourceAuthorized($this->getRemoteAddr(), $key->getIPAddr()))
             return $this->exerr(401, __('API key not found/active or source IP not authorized'));
 
         return $key;
     }
 
     function getKey() {
-        // Lookup record using sent API Key && IP Addr
+        // Lookup record using sent API key. Source authorization is
+        // validated separately in requireApiKey().
         if (!$this->key
-                && ($key=$this->getApiKey())
-                && ($ip=$this->getRemoteAddr()))
-            $this->key = API::lookupByKey($key, $ip);
+                && ($key=$this->getApiKey()))
+            $this->key = API::lookupByKey($key);
 
         return $this->key;
     }

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -101,11 +101,8 @@ class API {
         return ($key && $ip && self::getIdByKey($key, $ip));
     }
 
-    static function parseNetworks($networks) {
-        return array_filter(array_map('trim', explode(',', (string) $networks)), 'strlen');
-    }
-
     static function isValidNetwork($network) {
+        $network = trim((string) $network);
         if (Validator::is_ip($network))
             return true;
 
@@ -116,35 +113,34 @@ class API {
         $address = trim($address);
         $prefix = trim($prefix);
 
-        if ($prefix === '' || !is_numeric($prefix))
+        if ($prefix === '' || !ctype_digit($prefix))
             return false;
 
-        return Validator::is_ip($address) && Validator::check_ip($address, $address.'/'.$prefix);
+        if (!Validator::is_ip($address))
+            return false;
+
+        $max = strpos($address, ':') !== false ? 128 : 32;
+        $prefix = (int) $prefix;
+        return ($prefix >= 0 && $prefix <= $max);
     }
 
     static function isValidSource($source) {
-        $networks = self::parseNetworks($source);
-        if (!$networks)
+        $source = trim((string) $source);
+        if (!$source || strpos($source, ',') !== false)
             return false;
 
-        foreach ($networks as $network) {
-            if (!self::isValidNetwork($network))
-                return false;
-        }
-
-        return true;
+        return self::isValidNetwork($source);
     }
 
     static function isSourceAuthorized($ip, $source) {
         if (!Validator::is_ip($ip))
             return false;
 
-        foreach (self::parseNetworks($source) as $network) {
-            if (Validator::check_ip($ip, $network))
-                return true;
-        }
+        $source = trim((string) $source);
+        if (!$source || strpos($source, ',') !== false)
+            return false;
 
-        return false;
+        return Validator::check_ip($ip, $source);
     }
 
     static function getIdByKey($key, $ip='') {
@@ -254,11 +250,11 @@ class ApiController extends Controller {
     }
 
     function getKey() {
-        // Lookup record using sent API key. Source authorization is
-        // validated separately in requireApiKey().
+        // Lookup record using sent API key and source IP.
         if (!$this->key
-                && ($key=$this->getApiKey()))
-            $this->key = API::lookupByKey($key);
+                && ($key=$this->getApiKey())
+                && ($ip=$this->getRemoteAddr()))
+            $this->key = API::lookupByKey($key, $ip);
 
         return $this->key;
     }

--- a/include/i18n/en_US/help/tips/manage.api_keys.yaml
+++ b/include/i18n/en_US/help/tips/manage.api_keys.yaml
@@ -28,5 +28,5 @@ api_key:
 ip_addr:
     title: IP Address
     content: >
-        Client's network IP address. Each unique client IP address will
-        require separate API keys
+        Client source IP or CIDR range (for example: 10.0.8.0/24). Use a
+        CIDR range to authorize a subnet with a single API key.

--- a/include/i18n/en_US/help/tips/manage.api_keys.yaml
+++ b/include/i18n/en_US/help/tips/manage.api_keys.yaml
@@ -28,5 +28,5 @@ api_key:
 ip_addr:
     title: IP Address
     content: >
-        Client source IP or CIDR range (for example: 10.0.8.0/24). Use a
-        CIDR range to authorize a subnet with a single API key.
+        Client source IP or CIDR subnet (for example: 10.0.8.0/24). One
+        IP/CIDR entry is allowed per API key.


### PR DESCRIPTION
## Summary
Add CIDR-aware source authorization for API keys while preserving strict security semantics.

This allows a single API key to authorize a subnet like `10.0.8.0/24` (instead of only one exact IP), which is useful for VPN and dynamic client IP pools.

## Problem
Current API key authorization compares the source IP as an exact string match, so subnet-based clients (VPNs, load-balanced egress, NAT pools) require many separate keys.

## What Changed
### 1) CIDR/IP validation for API key source
- Added source validation helpers in `include/class.api.php`:
  - `API::isValidNetwork()`
  - `API::isValidSource()`
  - `API::isSourceAuthorized()`
- `save()` now accepts either:
  - a single IP (`x.x.x.x` or IPv6)
  - a single CIDR subnet (`x.x.x.x/n` or IPv6 CIDR)
- Multi-entry/comma-separated values are intentionally rejected for now.

### 2) CIDR-aware authorization
- `requireApiKey()` now authorizes using `Validator::check_ip()` through `API::isSourceAuthorized()`.

### 3) Defense-in-depth preserved
- `getKey()` still looks up by **API key + source IP** (not key-only), preserving current security posture if `getKey()` is reused elsewhere.

### 4) Help text updated
- Updated `include/i18n/en_US/help/tips/manage.api_keys.yaml` to document single IP/CIDR usage.

## Security / Behavior Notes
- Existing single-IP API keys remain backward compatible.
- Invalid CIDR prefixes are rejected with explicit bounds:
  - IPv4: `0..32`
  - IPv6: `0..128`
- Comma-separated ranges are rejected to avoid ambiguity and schema/migration changes (`ipaddr` remains single-entry semantics).

## Testing
### Static
- `php -l include/class.api.php`

### Functional (manual)
1. Set API key source to an allowed CIDR containing caller IP.
2. `POST /api/http.php/tasks/cron` with `X-API-Key` returns `200 Completed`.
3. Set source to a non-matching CIDR.
4. Same request returns `401`.

## Files
- `include/class.api.php`
- `include/i18n/en_US/help/tips/manage.api_keys.yaml`
