### PR TITLE
Fix CSRF bypass via GET-based _method override in dispatcher

### DIFF
--- a/include/class.dispatcher.php
+++ b/include/class.dispatcher.php
@@ -28,10 +28,13 @@ class Dispatcher {
 
     function resolve($url, $args=null) {
         if ($this->file) { $this->lazy_load(); }
-        # Support HTTP method emulation with the _method GET argument
-        if (isset($_GET['_method'])) {
-            $_SERVER['REQUEST_METHOD'] = strtoupper($_GET['_method']);
-            unset($_GET['_method']);
+        # Support HTTP method emulation with the _method POST argument.
+        # Only accept from POST body (not GET query string) so that the
+        # CSRF token check — which runs before the dispatcher — already
+        # covers the request.
+        if (isset($_POST['_method'])) {
+            $_SERVER['REQUEST_METHOD'] = strtoupper($_POST['_method']);
+            unset($_POST['_method']);
         }
         // Decode URL for accurate matching
         $url = urldecode($url);


### PR DESCRIPTION
## Summary

The dispatcher accepted HTTP method overrides from `$_GET['_method']`, which could be triggered via `<img>` tags without CSRF token validation. Since the CSRF check runs before the dispatcher and only validates POST requests, an attacker could embed a hidden image in a ticket to perform state-changing DELETE/POST actions when a staff agent views the ticket.

This changes the override to only read from `$_POST['_method']`, which is already covered by the CSRF token check. The pjax frontend already sends `_method` as a POST form field, so existing functionality is preserved.

## Attack Scenario

1. Attacker submits a guest ticket containing `<img src="/scp/ajax.php/note/1?_method=DELETE" />`
2. Staff agent opens the ticket
3. Browser fires a GET request — CSRF check is skipped (not a POST)
4. Dispatcher sees `$_GET['_method']=DELETE`, overrides the method
5. `deleteNote` handler executes with the agent's session — note is deleted

## Fix

Change `$_GET['_method']` to `$_POST['_method']` in `include/class.dispatcher.php`. GET-based triggers (img tags, links) cannot set POST body data, so the bypass is closed. Legitimate pjax form submissions already send `_method` as a POST field and are covered by CSRF validation.