### PR TITLE
Fix login loop caused by expired database session clearing CSRF token

### DIFF
--- a/login.php
+++ b/login.php
@@ -46,6 +46,10 @@ if ($_POST) {
 }
 
 if ($_POST && isset($_POST['luser'])) {
+    // Clear any stale user-space session token so an expired token from a
+    // previous session does not cause isValid() to return false right after
+    // successful authentication.
+    unset($_SESSION[':token']['client']);
     if (!$_POST['luser'])
         $errors['err'] = __('Valid username or email address is required');
     elseif (Validator::is_userid(trim($_POST['luser']), $errors['err'], false)
@@ -141,6 +145,18 @@ elseif ($user = UserAuthenticationBackend::processSignOn($errors, false)) {
         Http::redirect($_SESSION['_client']['auth']['dest']
                 ?: 'tickets.php');
     }
+}
+
+// Always rotate the CSRF token when rendering the login form so that a
+// reloaded page (e.g. after session expiry) always carries a valid token.
+if (!$_POST) {
+    // If the session has no CSRF data it is either brand-new or was cleared
+    // by the expired-session handler in DatabaseSessionStorageBackend.
+    // Force a new session ID so the replacement session starts unexpired
+    // and can persist the rotated token across the GET→POST cycle.
+    if (empty($_SESSION['csrf']))
+        session_regenerate_id(true);
+    $ost->getCSRF()->rotate();
 }
 
 if (!$nav) {

--- a/scp/login.php
+++ b/scp/login.php
@@ -66,6 +66,10 @@ if ($_POST) {
 
 }
 if ($_POST && isset($_POST['userid'])) {
+    // Clear any stale user-space session token so an expired token from a
+    // previous session does not cause isValid() to return false right after
+    // successful authentication.
+    unset($_SESSION[':token']['staff']);
     // Lookup support backends for this staff
     $username = trim($_POST['userid']);
     if (Validator::is_userid($username, $errors['err'], false)
@@ -130,6 +134,18 @@ elseif (!$thisstaff || !($thisstaff->getId() || $thisstaff->isValid())) {
 }
 elseif ($thisstaff && $thisstaff->isValid()) {
     Http::redirect($dest);
+}
+
+// Always rotate the CSRF token when rendering the login form so that a
+// reloaded page (e.g. after session expiry) always carries a valid token.
+if (!$_POST) {
+    // If the session has no CSRF data it is either brand-new or was cleared
+    // by the expired-session handler in DatabaseSessionStorageBackend.
+    // Force a new session ID so the replacement session starts unexpired
+    // and can persist the rotated token across the GET→POST cycle.
+    if (empty($_SESSION['csrf']))
+        session_regenerate_id(true);
+    $ost->getCSRF()->rotate();
 }
 
 define("OSTSCPINC",TRUE); //Make includes happy!


### PR DESCRIPTION
When the DatabaseSessionStorageBackend finds a session row with session_expire in the past it resets session_data to '' on every read, but writes do not refresh session_expire. This creates a cycle where any token written during a GET (CSRF, user-space) is gone by the time the POST arrives, causing the CSRF check to fail and the user to be looped back to the login page indefinitely — even with valid credentials.

Two fixes applied to both scp/login.php and login.php:

1. On GET: call session_regenerate_id(true) when $_SESSION['csrf'] is empty. This gives the browser a fresh session row whose expiry is not in the past, so the rotated CSRF token persists to the POST.

2. On POST: unset $_SESSION[':token']['staff|client'] before calling the authentication backend. setSessionToken() binds $this->token to $_SESSION[':token'][class] by reference and reuses whatever is already there; a stale expired token from a prior session causes isValid() to return false immediately after a successful authenticate(), sending the user back to login.php despite correct credentials.

The root cause in class.ostsession.php (DatabaseSessionRecord:: lookupRecord resetting session_data for expired rows without refreshing session_expire on write) remains; these login-page guards make the login flow resilient to that condition without patching the session backend.