### PR TITLE
Fix passwd1 maxlength lost on reset token flow

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -1608,7 +1608,7 @@ extends AbstractForm {
         // required for agents.
         if (isset($_SESSION['_staff']['reset-token'])) {
             unset($fields['current']);
-            $fields['passwd1']->set('configuration', array('autofocus' => true));
+            $fields['passwd1']->set('configuration', array('autofocus' => true, 'length' => '128'));
         }
         else {
             $fields['passwd1']->set('layout',


### PR DESCRIPTION
Fixes #6940

When using a password reset link, the `passwd1` field's configuration 
was being overwritten with only `autofocus`, dropping the `length` 
setting and causing the "New Password" field to have a maxlength of 30 
instead of 128, inconsistent with the "Confirm Password" field.

Fix: Preserve the `length` setting when setting `autofocus` in the 
reset-token flow of `PasswordChangeForm`.