### PR TITLE
core: log ClientCreateRequest::attemptAutoRegister() failures

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -132,7 +132,7 @@ class ClientCreateRequest {
     }
 
     function attemptAutoRegister() {
-        global $cfg;
+        global $cfg, $ost;
 
         if (!$cfg || $cfg->isClientRegistrationMode(['disabled']))
             return false;
@@ -156,6 +156,16 @@ class ClientCreateRequest {
                 && ($cl = new ClientSession(new EndUser($U)))
                 && ($bk->login($cl, $bk)))
             return $cl;
+
+        if ($ost) {
+            $errors = $this_form->errors();
+            $ost->logWarning('Client Auto-Registration Failed',
+                sprintf('Unable to auto-register user "%s" via %s backend. %s',
+                    $this->getUsername(), $bk->getBkId(),
+                    $errors ? 'Form errors: '.json_encode($errors)
+                        : 'Account creation, confirmation, or session login failed.'),
+                false);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`ClientCreateRequest::attemptAutoRegister()` (used by external auth backends, e.g. OAuth2, to auto-register end users on first SSO login) chains six conditions with `&&` and silently returns `null` if any step fails — form validation, `User::fromVars()`, `ClientAccount::createForUser()`, `confirm()`, or `login()`. None of these failure paths are logged anywhere.

This PR adds a single `$ost->logWarning()` call on the fallthrough path, including form validation errors when available. No behavior change — return values are unaffected.

## Reproduction (currently silent)

1. Enable client self-registration and an external auth backend that calls `attemptAutoRegister()` (e.g. the OAuth2 plugin).
2. Create a pre-existing `ost_user`/`ost_user_email` record for an email address (a "ghost" record, e.g. left over from a deleted ticket or partial signup) that collides with what the IdP returns for a new SSO user.
3. Have that user sign in via SSO for the first time. `ClientAccount::createForUser()` (or a later step in the chain) fails due to the collision.
4. The user is silently denied/bounced with no ticket created and no record in System Logs of why — there's nothing for an admin to act on.

## Test plan

- [ ] Trigger the collision scenario above; confirm a `logWarning` entry now appears in System Logs identifying the username/backend and the form errors if present.
- [ ] Confirm successful auto-registration is unaffected (no new log entries, same return value).