### PR TITLE
Fix inflated Knowledgebase FAQ category counts (#5559)

### DIFF
--- a/include/client/faq-category.inc.php
+++ b/include/client/faq-category.inc.php
@@ -16,7 +16,9 @@ if (($subs=$category->getSubCategories(array('public' => true)))) {
                 <a href="faq.php?cid=%d">%s (%d)</a></div>',
                 $c->getId(),
                 $c->getLocalName(),
-                $c->getNumFAQs()
+                // getSubCategories(public) annotates a published-filtered faq_count;
+                // getNumFAQs() counts ALL faqs incl. internal/unpublished ones.
+                $c->faq_count
                 );
     }
     echo '</div>';

--- a/include/client/kb-categories.inc.php
+++ b/include/client/kb-categories.inc.php
@@ -11,18 +11,24 @@
                     ))
         )))
         //->annotate(array('faq_count'=>SqlAggregate::COUNT('faqs__ispublished')));
+        // The query joins both `faqs` (direct) and `children__faqs` (sub-category)
+        // FAQs. Counting plain rows here multiplies the two one-to-many joins into
+        // a cartesian product, inflating both counts (bug #5559). Count DISTINCT FAQ
+        // ids instead so the duplicated rows collapse.
         ->annotate(array('faq_count' => SqlAggregate::COUNT(
                         SqlCase::N()
                         ->when(array(
-                                'faqs__ispublished__gt'=> FAQ::VISIBILITY_PRIVATE), 1)
-                        ->otherwise(null)
-        )))
+                                'faqs__ispublished__gt'=> FAQ::VISIBILITY_PRIVATE),
+                                new SqlField('faqs__faq_id'))
+                        ->otherwise(null),
+                        true)))
         ->annotate(array('children_faq_count' => SqlAggregate::COUNT(
                         SqlCase::N()
                         ->when(array(
-                                'children__faqs__ispublished__gt'=> FAQ::VISIBILITY_PRIVATE), 1)
-                        ->otherwise(null)
-        )));
+                                'children__faqs__ispublished__gt'=> FAQ::VISIBILITY_PRIVATE),
+                                new SqlField('children__faqs__faq_id'))
+                        ->otherwise(null),
+                        true)));
 
        // ->filter(array('faq_count__gt' => 0));
     if ($categories->exists(true)) { ?>


### PR DESCRIPTION
Fixes #5559

## Summary

On the client Knowledgebase landing page (`/kb/index.php`), the FAQ count next to a category that has **sub-categories** is grossly inflated — e.g. a category whose tree really contains 26 FAQs is displayed as **(345)**. #5559 describes the symptom as "moving a FAQ into a sub-category doubles the parent count." Leaf categories (no sub-categories) are unaffected, which is why it often goes unnoticed until a category tree is built out.

## Root cause

`include/client/kb-categories.inc.php` builds **one** query that annotates **two** `COUNT()` aggregates over **two different one-to-many joins** — `faqs` (direct) and `children__faqs` (sub-category) — without `DISTINCT`:

```php
->annotate(array('faq_count' => SqlAggregate::COUNT(
    SqlCase::N()->when(array('faqs__ispublished__gt'=>FAQ::VISIBILITY_PRIVATE), 1)->otherwise(null))))
->annotate(array('children_faq_count' => SqlAggregate::COUNT(
    SqlCase::N()->when(array('children__faqs__ispublished__gt'=>FAQ::VISIBILITY_PRIVATE), 1)->otherwise(null))));
```

Both joins in the same query produce a **cartesian product**: each direct-FAQ row is repeated once per sub-category-FAQ row and vice-versa, so each `COUNT(… THEN 1)` is multiplied. For a category with 15 direct FAQs and 11 FAQs across its sub-categories the counts become `15×12 + 11×15 = 345` instead of `15 + 11 = 26`.

```sql
SELECT A1.*,
  COUNT(CASE WHEN A2.ispublished > 0 THEN 1 END) AS faq_count,          -- multiplied
  COUNT(CASE WHEN A4.ispublished > 0 THEN 1 END) AS children_faq_count  -- multiplied
FROM ost_faq_category A1
LEFT JOIN ost_faq          A2 ON (A1.category_id = A2.category_id)   -- direct FAQs
LEFT JOIN ost_faq_category A3 ON (A1.category_id = A3.category_pid)  -- children
LEFT JOIN ost_faq          A4 ON (A3.category_id = A4.category_id)   -- children's FAQs
GROUP BY A1.category_id
```

osTicket already uses the correct idiom for counting across multiple joins — `COUNT(field__id, true)` (i.e. `COUNT(DISTINCT …)`) — in `include/ajax.tickets.php` when counting tasks, collaborators and entries for a ticket. This query simply omitted the `DISTINCT`.

## Fix

Count **distinct** FAQ primary keys, keeping the published filter, so the duplicated cartesian rows collapse — producing `COUNT(DISTINCT CASE WHEN faq.ispublished > 0 THEN faq.faq_id END)`. (`SqlField` referencing the column inside the `CASE` is required because `SqlAggregate`'s automatic distinct-PK resolution only applies to bare field expressions.)

**Also included** (same "wrong count" family): `include/client/faq-category.inc.php` rendered sub-category counts with `Category::getNumFAQs()`, which counts **all** FAQs including internal/unpublished ones — so a category page could show `(7)` while only 6 FAQs are visible. Switched to the published-filtered `$c->faq_count` annotation from `getSubCategories(['public' => true])`.

## Testing

Seeded a KB with a **CAN** category holding 15 published direct FAQs plus sub-categories **CANS** (6 public + 1 internal) and **EDS files** (5 public) — correct total 15 + 6 + 5 = **26**:

| Category (with sub-categories) | Before | After | Actual visible |
|---|---|---|---|
| CAN | **345** | **26** | 26 |
| General | 20 | 7 | 7 |
| Product Features | 50 | 14 | 14 |
| Release Notes (leaf) | 4 | 4 | 4 |

The category page (`faq.php?cid=…`) sub-counts now exclude the internal FAQ (CANS shows **6**, not 7). No schema change, no data migration — purely a query-correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
