### PR TITLE
Do not translate months and weeks when not needed (porting of the fix for days to months)

### DIFF
--- a/include/class.schedule.php
+++ b/include/class.schedule.php
@@ -1061,24 +1061,21 @@ class ScheduleEntry extends VerySimpleModel {
     }
 
     static function getWeeks() {
-        static $translated = false;
-        if (!$translated) {
-            foreach (static::$weeks as $k=>$v)
-                static::$weeks[$k] = __($v);
-        }
-
-        return static::$weeks;
+       return self::$weeks;
     }
 
     static function getMonths() {
-        static $translated = false;
-        if (!$translated) {
-            foreach (static::$months as $k=>$v)
-                static::$months[$k] = __($v);
-        }
-
-        return static::$months;
+        return self::$months;
     }
+
+    static function getTranslatedMonths() {
+        static $translated = null;
+        if (!isset($translated))
+            $translated = array_map(function ($d) { return __($d); }, static::getMonths());
+
+        return $translated;
+    }
+
     static function create($ht=false) {
         $inst = new static($ht);
         $inst->set('created', new SqlFunction('NOW'));
@@ -1255,7 +1252,7 @@ extends AbstractForm {
                     'default' => 0,
                     'layout' => new GridFluidCell(4),
                     'label' => __('In'),
-                    'choices' => ScheduleEntry::getMonths(),
+                    'choices' => ScheduleEntry::getTranslatedMonths(),
                     'validator-error' => __('Selection required'),
                     'configuration'=>array('prompt'=>__('Month')),
                     'visibility' => new VisibilityConstraint(


### PR DESCRIPTION
While deploying osTicket, I noticed that sometimes I am encountering an issue almost identical to the one mentioned here: https://forum.osticket.com/d/107258-uncaught-datemalformedstringexception-in-openphp/10

The code is the last stable 1.18.4, and I double checked that the PHP code was updated, as suggested in the post.

While looking at the commit that was supposed to fix the issue, I noticed that it does fix that only for days, but not for months: https://github.com/osTicket/osTicket/commit/f2facda3e64be2404316048eb31d89309fb64292

This pull request applies the same solutions also for months and weeks.