### PR TITLE
mailfetch: defer message archive/delete to prevent mid-loop renumbering

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -126,22 +126,11 @@ class Fetcher {
             $messages = range(1, min($max, $messageCount));
         }
 
-        // Process in DESCENDING sequence order. Some servers remove a
-        // message from the folder as soon as it is marked \Deleted (Gmail
-        // drops it from the label-folder immediately, regardless of its
-        // Auto-Expunge setting), renumbering every message above it
-        // mid-loop - the removeMessage() override in class.mail.php only
-        // protects against client-side expunge. In ascending order the loop
-        // then fetches or flags the wrong messages ("the single id was not
-        // found in response") and can move a message out of the fetch folder
-        // without ever processing it. Counting down, a removal only ever
-        // shifts sequence numbers the loop is already done with.
-        rsort($messages);
-
         $defaults = [
             'emailId' => $this->getEmailId()
         ];
         $msgs = $errors = 0;
+        $processed = [];
         // TODO: Use message UIDs instead of ids
         foreach ($messages as $i) {
             try {
@@ -149,11 +138,15 @@ class Fetcher {
                 if (($result=$this->processMessage($i, $defaults))) {
                     // Mark the message as "Seen" (IMAP only)
                     $this->mbox->markAsSeen($i);
-                    // Attempt to move the message if archive folder is set or
-                    if ($archiveFolder)
-                        $this->mbox->moveMessage($i, $archiveFolder);
-                    elseif ($deleteFetched)  // else delete if deletion is desired
-                        $this->mbox->removeMessage($i);
+                    // Defer the move/delete to the second pass below: some
+                    // servers (e.g. Gmail) remove the message from the
+                    // folder immediately - regardless of client-side
+                    // expunge - renumbering every message above it
+                    // mid-loop, which makes the loop fetch or flag the
+                    // wrong messages ("the single id was not found in
+                    // response") and can move a message out of the Fetch
+                    // Folder without ever processing it.
+                    $processed[] = $i;
                     $msgs++;
                     $errors = 0; // We are only interested in consecutive errors.
                 } else {
@@ -166,6 +159,27 @@ class Fetcher {
                     $errors++;
                 // log the exception as a debug message
                 $this->logDebug($t->getMessage());
+            }
+        }
+
+        // Second pass: archive or delete the processed messages in
+        // DESCENDING sequence order, so a server-side removal only ever
+        // renumbers messages this pass is already done with. A message
+        // that fails to move here is refetched on the next run, recognized
+        // by its Message-ID and moved again - never ticketed twice.
+        if ($archiveFolder || $deleteFetched) {
+            rsort($processed);
+            foreach ($processed as $i) {
+                try {
+                    // Attempt to move the message if archive folder is set or
+                    if ($archiveFolder)
+                        $this->mbox->moveMessage($i, $archiveFolder);
+                    else  // else delete if deletion is desired
+                        $this->mbox->removeMessage($i);
+                } catch (\Throwable $t) {
+                    // log the exception as a debug message
+                    $this->logDebug($t->getMessage());
+                }
             }
         }
 

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -126,6 +126,18 @@ class Fetcher {
             $messages = range(1, min($max, $messageCount));
         }
 
+        // Process in DESCENDING sequence order. Some servers remove a
+        // message from the folder as soon as it is marked \Deleted (Gmail
+        // drops it from the label-folder immediately, regardless of its
+        // Auto-Expunge setting), renumbering every message above it
+        // mid-loop - the removeMessage() override in class.mail.php only
+        // protects against client-side expunge. In ascending order the loop
+        // then fetches or flags the wrong messages ("the single id was not
+        // found in response") and can move a message out of the fetch folder
+        // without ever processing it. Counting down, a removal only ever
+        // shifts sequence numbers the loop is already done with.
+        rsort($messages);
+
         $defaults = [
             'emailId' => $this->getEmailId()
         ];


### PR DESCRIPTION
### Summary

`Fetcher::processEmails()` iterates message **sequence numbers in ascending order** while archiving/deleting each message as it goes. Some servers remove a message from the folder the moment it is marked `\Deleted` — notably Gmail, which drops it from the label-folder immediately **regardless of its Auto-Expunge setting** — renumbering all messages above the current one *mid-loop*. The existing `removeMessage()` override in `class.mail.php` (which defers the expunge to the end of the fetch session precisely to protect sequence numbers) only guards against *client-side* expunge, so this server-side renumbering slips past it.

### Symptoms

- Repeated `RuntimeException: the single id was not found in response` from `laminas-mail` (logged as Mail Fetcher debug messages) whenever more than one message is in the fetch folder.
- Worse: `markAsSeen()` / `moveMessage()` can hit a *different* message than the one just processed — a message is moved out of the fetch folder **without ever being ticketed**. The mail is silently lost unless something outside osTicket notices.

### Fix

Messages are still processed in **ascending order** (oldest first, so same-batch messages of one thread keep their chronological order), but the archive/delete is **deferred to a second pass** that runs after the processing loop, in **descending** sequence order:

- While the processing loop runs, nothing is removed from the folder, so mid-loop renumbering cannot occur at all — every `getRawEmail()`/`markAsSeen()` hits the message it means to.
- In the deferred pass, a server-side removal only ever shifts sequence numbers the pass has already handled, so the move/delete targets stay valid at any queue depth, for any server behaviour.
- A message that is processed but fails to move stays in the fetch folder, is re-fetched on the next run, recognized by its Message-ID and moved then — never ticketed twice.

Servers that keep `\Deleted` messages in place until the final expunge are unaffected: the same message set is processed, and deletions are still expunged once at the end of the run.

This sidesteps the renumbering problem entirely until the existing `// TODO: Use message UIDs instead of ids` is tackled, which would be the fuller fix.

*History: the first version of this PR processed messages in descending order (`rsort($messages)`), which fixes the renumbering but tickets same-batch messages newest-first — see review feedback below. The current two-pass version preserves oldest-first processing.*

### Verification

On a production 1.18.1 install fetching from Gmail via OAuth2 (cron every 2 minutes):

- before: 130+ single-id exceptions per day, 10–17 mails/day moved out of the fetch folder unprocessed (recovered only by an external reconciliation job re-applying the label)
- after (descending variant, in production 2026-07-31 → 2026-08-13): zero exceptions and zero lost mails, including a provoked burst of 4 messages processed cleanly in a single run — the exact scenario that previously failed every time.
- the two-pass variant is deployed on the same install since 2026-08-13; burst-test results including the same-thread ordering check will follow in the comments.
