### PR TITLE
Add Docker Compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+.git
+.gitignore
+.github
+.env
+.env.example
+data
+stage
+nbproject
+*.code-workspace
+.DS_Store
+._.DS_Store
+Vagrantfile
+.vagrant
+
+# Never bake a local install's secrets or state into the image.
+include/ost-config.php
+include/plugins/*.phar
+include/i18n/*.phar
+include/mpdf/tmp
+include/mpdf/ttfontdata
+
+# IIS only; the container runs Apache.
+web.config

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Copy to .env and adjust before the first `docker compose up`.
+# The database credentials below are the ones you type into the osTicket
+# installer -- use `db` as the MySQL hostname.
+
+# --- Database ---------------------------------------------------------------
+MYSQL_ROOT_PASSWORD=change-me-root
+MYSQL_DATABASE=osticket
+MYSQL_USER=osticket
+MYSQL_PASSWORD=change-me
+
+# --- Web --------------------------------------------------------------------
+HTTP_PORT=8100
+
+# --- PHP --------------------------------------------------------------------
+PHP_TIMEZONE=UTC
+PHP_MEMORY_LIMIT=256M
+PHP_MAX_EXECUTION_TIME=60
+PHP_UPLOAD_MAX_FILESIZE=20M
+PHP_POST_MAX_SIZE=24M
+
+# --- osTicket ---------------------------------------------------------------
+# Seconds between api/cron.php runs (mail fetch, SLA alerts, search index).
+OSTICKET_CRON_INTERVAL=60
+
+# Set to true and recreate the app container once the installer has finished,
+# to drop setup/ from the running container.
+OSTICKET_REMOVE_SETUP=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Container tooling must keep LF endings. On a Windows checkout with
+# core.autocrlf=true, CRLF breaks a script's shebang and leaves a trailing \r
+# on every .dockerignore pattern.
+*.sh              text eol=lf
+Dockerfile        text eol=lf
+docker-compose.yml text eol=lf
+.dockerignore     text eol=lf
+docker/**         text eol=lf
+
+# A trailing \r would end up inside compose variable values (passwords, ports).
+.env              text eol=lf
+.env.example      text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ stage
 include/mpdf/ttfontdata
 include/mpdf/tmp
 nbproject/
+
+# Docker Compose environment and mapped volumes
+.env
+data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+name: osticket
+
+services:
+  db:
+    image: mariadb:10.11
+    restart: unless-stopped
+    # osTicket creates its tables as utf8mb3 explicitly and does not cope well
+    # with STRICT_TRANS_TABLES, so the server defaults are relaxed to match.
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
+      --sql-mode=NO_ENGINE_SUBSTITUTION
+    environment:
+      MARIADB_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?set MYSQL_ROOT_PASSWORD in .env}
+      MARIADB_DATABASE: ${MYSQL_DATABASE:-osticket}
+      MARIADB_USER: ${MYSQL_USER:-osticket}
+      MARIADB_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD in .env}
+    volumes:
+      - ./data/db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  app:
+    build:
+      context: .
+      dockerfile: docker/app/Dockerfile
+    image: osticket-app:local
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PHP_TIMEZONE: ${PHP_TIMEZONE:-UTC}
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT:-256M}
+      PHP_MAX_EXECUTION_TIME: ${PHP_MAX_EXECUTION_TIME:-60}
+      PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE:-20M}
+      PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE:-24M}
+      OSTICKET_REMOVE_SETUP: ${OSTICKET_REMOVE_SETUP:-false}
+    ports:
+      - "${HTTP_PORT:-8100}:80"
+    volumes:
+      - ./data/osticket:/data
+    healthcheck:
+      test: ["CMD", "php", "-r", "exit(@file_get_contents('http://127.0.0.1/') === false ? 1 : 0);"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
+  cron:
+    image: osticket-app:local
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_started
+      db:
+        condition: service_healthy
+    environment:
+      PHP_TIMEZONE: ${PHP_TIMEZONE:-UTC}
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT:-256M}
+      OSTICKET_CRON_INTERVAL: ${OSTICKET_CRON_INTERVAL:-60}
+    volumes:
+      - ./data/osticket:/data
+    command: ["osticket-cron.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,120 @@
+osTicket with Docker Compose
+============================
+
+Runs the source in this repository as a container image (Apache + PHP 8.3),
+with a MariaDB service alongside it. The application code lives **inside** the
+image; only state — database files, `ost-config.php`, plugins, language packs
+and file-backed attachments — lives in mapped volumes under `./data/`.
+
+Layout
+------
+
+```
+docker-compose.yml           three services: db, app, cron
+.env.example                 copy to .env, then edit
+docker/app/Dockerfile        application image
+docker/app/entrypoint.sh     wires /data into the application tree on boot
+docker/app/cron.sh           runs api/cron.php on an interval
+docker/app/apache-osticket.conf
+docker/app/php-osticket.ini
+
+data/db/                     MariaDB data directory
+data/osticket/config/        ost-config.php  (symlinked to include/ost-config.php)
+data/osticket/plugins/       plugin .phar files, copied into include/plugins/ on boot
+data/osticket/i18n/          language pack .phar files, copied into include/i18n/ on boot
+data/osticket/attachments/   target for the Filesystem storage plugin
+```
+
+`data/` and `.env` are gitignored.
+
+First run
+---------
+
+```sh
+cp .env.example .env
+# edit .env -- at minimum MYSQL_ROOT_PASSWORD and MYSQL_PASSWORD
+docker compose up -d --build
+```
+
+Open <http://localhost:8100>. The container ships an `ost-config.php` with
+`OSTINSTALLED=FALSE`, so osTicket redirects to its installer. Fill it in using:
+
+| Field           | Value                            |
+| --------------- | -------------------------------- |
+| MySQL Hostname  | `db`                             |
+| MySQL Database  | `MYSQL_DATABASE` from `.env`     |
+| MySQL Username  | `MYSQL_USER` from `.env`         |
+| MySQL Password  | `MYSQL_PASSWORD` from `.env`     |
+
+The installer writes through the symlink to
+`data/osticket/config/ost-config.php`, so the install survives
+`docker compose down` and image rebuilds.
+
+After the installer finishes, drop the `setup/` directory (osTicket warns
+about it until you do):
+
+```sh
+# in .env
+OSTICKET_REMOVE_SETUP=true
+docker compose up -d --force-recreate app
+```
+
+Day-to-day
+----------
+
+```sh
+docker compose logs -f app        # Apache access/error logs go to stdout
+docker compose exec app php manage.php --help
+docker compose restart cron
+```
+
+**Rebuilding after a code change.** The source is baked into the image, so
+`docker compose up -d --build` is the update path. Nothing under `./data/` is
+touched by a rebuild.
+
+**Plugins.** Drop the `.phar` into `data/osticket/plugins/` and recreate the
+app container; it is copied into `include/plugins/` at boot and will then show
+up under Admin Panel → Manage → Plugins.
+
+**Language packs.** Same, but into `data/osticket/i18n/`.
+
+**Attachments.** osTicket stores attachments in the database by default. To put
+them on disk instead, install the Filesystem storage plugin and point it at
+`/data/attachments`, which is mapped to `data/osticket/attachments/`.
+
+**Backups.** `data/db/` plus `data/osticket/` is the complete state.
+
+```sh
+docker compose exec db mariadb-dump -u root -p"$MYSQL_ROOT_PASSWORD" \
+    --single-transaction osticket > backup.sql
+```
+
+Notes and trade-offs
+--------------------
+
+**PHP 8.3, not 8.4.** osTicket supports 8.2–8.4, but `ext-imap` is unbundled in
+8.4 and Debian no longer packages uw-imap. It is omitted here in either case:
+osTicket calls `imap_utf8()` / `imap_mime_header_decode()` only behind
+`function_exists()` guards, and mail fetching goes through the bundled
+laminas-mail. The installer's prerequisite page lists PHP IMAP under
+*recommended*, not *required*, so it will show a red mark that is safe to
+ignore. Everything actually required (PHP version, `mysqli`) plus the full
+recommended set — `gd`, `intl`, `zip`, `gettext`, `apcu`, OPcache, `ldap` — is
+installed.
+
+**MariaDB `sql-mode`.** Set to `NO_ENGINE_SUBSTITUTION` only. osTicket's schema
+relies on columns without defaults, which `STRICT_TRANS_TABLES` rejects.
+
+**Behind a reverse proxy.** The vhost maps `X-Forwarded-Proto: https` onto
+`HTTPS=on`. Also set `TRUSTED_PROXIES` in
+`data/osticket/config/ost-config.php` to your proxy's IP or CIDR, otherwise
+osTicket ignores `X-Forwarded-For` and logs the proxy as the client IP.
+
+**Ownership on Linux hosts.** The entrypoint runs `chown -R www-data /data`,
+which is a no-op on Docker Desktop bind mounts but matters on a Linux host —
+`www-data` inside the container is uid 33.
+
+**Not included.** TLS termination, an SMTP relay, and inbound mail piping
+(`api/pipe.php`). Put a reverse proxy in front for TLS; configure outbound SMTP
+and IMAP/POP fetching from within osTicket's admin panel — the `cron` service
+polls for new mail every `OSTICKET_CRON_INTERVAL` seconds.

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,68 @@
+# osTicket application image -- Apache + mod_php serving the source in this repo.
+#
+# PHP 8.3 is used rather than 8.4 because ext-imap is no longer bundled with
+# 8.4 and uw-imap is no longer packaged by Debian. osTicket only calls the
+# imap_* helpers behind function_exists() guards (include/class.format.php)
+# and fetches mail through laminas-mail, so the extension stays optional.
+FROM php:8.3-apache
+
+# Libraries needed to build (and run) the PHP extensions osTicket wants. The
+# -dev packages are deliberately kept so `docker-php-ext-install` still works
+# in images derived from this one.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libwebp-dev \
+        libicu-dev \
+        libldap2-dev \
+        libxml2-dev \
+        libzip-dev \
+        ; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap --with-libdir="lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)"; \
+    docker-php-ext-install -j"$(nproc)" \
+        gd \
+        gettext \
+        intl \
+        ldap \
+        mysqli \
+        opcache \
+        zip \
+        ; \
+    pecl install apcu; \
+    docker-php-ext-enable apcu; \
+    rm -rf /var/lib/apt/lists/*
+
+# osTicket relies on the .htaccess rewrite rules shipped in api/, pages/ and
+# scp/apps/ to route extension-less URLs.
+RUN a2enmod rewrite headers expires
+
+COPY docker/app/php-osticket.ini /usr/local/etc/php/conf.d/zz-osticket.ini
+COPY docker/app/apache-osticket.conf /etc/apache2/sites-available/000-default.conf
+
+WORKDIR /var/www/html
+
+# The whole application lives in the image; only state goes to /data. The code
+# stays root-owned and read-only to www-data -- everything osTicket needs to
+# write (ost-config.php) is symlinked out to the volume by the entrypoint.
+COPY . /var/www/html/
+
+# Pristine copies used to bootstrap an empty /data on first boot.
+RUN set -eux; \
+    rm -rf /var/www/html/docker; \
+    mkdir -p /opt/osticket-defaults /data; \
+    cp -a /var/www/html/include/plugins /opt/osticket-defaults/plugins; \
+    cp /var/www/html/include/ost-sampleconfig.php /opt/osticket-defaults/ost-config.php
+
+COPY docker/app/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/app/cron.sh /usr/local/bin/osticket-cron.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/osticket-cron.sh
+
+VOLUME ["/data"]
+EXPOSE 80
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/docker/app/apache-osticket.conf
+++ b/docker/app/apache-osticket.conf
@@ -1,0 +1,37 @@
+ServerTokens Prod
+ServerSignature Off
+
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html>
+        # FollowSymLinks is required: include/ost-config.php is a symlink into
+        # the /data volume.
+        Options -Indexes +FollowSymLinks
+        AllowOverride All
+        Require all granted
+        DirectoryIndex index.php
+    </Directory>
+
+    # Application internals. include/ ships its own "Deny from all" .htaccess;
+    # this makes the denial explicit and independent of mod_access_compat.
+    <Directory /var/www/html/include>
+        Require all denied
+    </Directory>
+
+    <DirectoryMatch "^/var/www/html/\.git">
+        Require all denied
+    </DirectoryMatch>
+
+    <FilesMatch "^(\.|composer\.|.*\.(md|txt|yaml|yml|sql|dist))$">
+        Require all denied
+    </FilesMatch>
+
+    # Trust the scheme advertised by an upstream reverse proxy so osTicket
+    # generates https:// URLs when it is terminated in front of this container.
+    # Also set TRUSTED_PROXIES in include/ost-config.php.
+    SetEnvIf X-Forwarded-Proto "^https$" HTTPS=on
+
+    ErrorLog  /dev/stderr
+    CustomLog /dev/stdout combined
+</VirtualHost>

--- a/docker/app/cron.sh
+++ b/docker/app/cron.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Periodic task runner. api/cron.php is osTicket's local cron entry point: it
+# fetches mail, fires overdue/SLA alerts and advances the search index.
+set -eu
+
+INTERVAL="${OSTICKET_CRON_INTERVAL:-60}"
+CONFIG=/var/www/html/include/ost-config.php
+
+echo "[cron] running api/cron.php every ${INTERVAL}s"
+
+while true; do
+    if grep -qi "define('OSTINSTALLED',TRUE)" "$CONFIG" 2>/dev/null; then
+        su -s /bin/sh -c "php /var/www/html/api/cron.php" www-data \
+            || echo "[cron] run failed (exit $?)"
+    else
+        echo "[cron] osTicket is not installed yet -- waiting"
+    fi
+    sleep "$INTERVAL"
+done

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Prepares the persistent /data volume and links it into the application tree,
+# then hands off to the container command (apache2-foreground or the cron loop).
+set -eu
+
+OST_ROOT=/var/www/html
+DATA_DIR=/data
+DEFAULTS=/opt/osticket-defaults
+
+log() { echo "[entrypoint] $*"; }
+
+# ---------------------------------------------------------------------------
+# Persistent layout
+# ---------------------------------------------------------------------------
+mkdir -p \
+    "$DATA_DIR/config" \
+    "$DATA_DIR/plugins" \
+    "$DATA_DIR/i18n" \
+    "$DATA_DIR/attachments"
+
+# ---------------------------------------------------------------------------
+# Configuration file
+#
+# osTicket insists on writing include/ost-config.php itself during setup, so we
+# keep the real file on the volume and symlink it into place. A config with
+# OSTINSTALLED=FALSE is exactly what bootstrap.php needs to redirect a fresh
+# container to setup/install.php.
+# ---------------------------------------------------------------------------
+CONFIG_FILE="$DATA_DIR/config/ost-config.php"
+if [ ! -f "$CONFIG_FILE" ]; then
+    log "no ost-config.php on the volume yet -- seeding the installer template"
+    cp "$DEFAULTS/ost-config.php" "$CONFIG_FILE"
+fi
+chmod 0664 "$CONFIG_FILE" 2>/dev/null || true
+ln -sfn "$CONFIG_FILE" "$OST_ROOT/include/ost-config.php"
+
+# ---------------------------------------------------------------------------
+# Plugins and language packs
+#
+# Both are discovered by globbing include/plugins/* and include/i18n/* (see
+# Plugin::getPlugins() and Internationalization::availableLanguages()). Copying
+# them in on boot -- rather than mounting over those directories -- keeps the
+# files shipped with the image intact across upgrades.
+# ---------------------------------------------------------------------------
+if [ -z "$(ls -A "$DATA_DIR/plugins" 2>/dev/null)" ]; then
+    log "seeding $DATA_DIR/plugins from image defaults"
+    cp -a "$DEFAULTS/plugins/." "$DATA_DIR/plugins/"
+fi
+
+log "installing plugins from $DATA_DIR/plugins"
+cp -a "$DATA_DIR/plugins/." "$OST_ROOT/include/plugins/"
+
+if [ -n "$(ls -A "$DATA_DIR/i18n" 2>/dev/null)" ]; then
+    log "installing language packs from $DATA_DIR/i18n"
+    cp -a "$DATA_DIR/i18n/." "$OST_ROOT/include/i18n/"
+fi
+
+# ---------------------------------------------------------------------------
+# Runtime PHP settings driven by the environment
+# ---------------------------------------------------------------------------
+cat > /usr/local/etc/php/conf.d/zzz-runtime.ini <<INI
+date.timezone = ${PHP_TIMEZONE:-UTC}
+memory_limit = ${PHP_MEMORY_LIMIT:-256M}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME:-60}
+upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE:-20M}
+post_max_size = ${PHP_POST_MAX_SIZE:-24M}
+INI
+
+# ---------------------------------------------------------------------------
+# The setup/ directory is a standing security warning once installed. Removing
+# it is per-container and reversible -- flip the flag back and recreate.
+# ---------------------------------------------------------------------------
+if [ "${OSTICKET_REMOVE_SETUP:-false}" = "true" ] && [ -d "$OST_ROOT/setup" ]; then
+    log "OSTICKET_REMOVE_SETUP=true -- removing $OST_ROOT/setup"
+    rm -rf "$OST_ROOT/setup"
+fi
+
+# /data is the only tree www-data needs to write. Best effort: this is a no-op
+# on bind mounts backed by Windows/macOS, where the mount already grants access.
+chown -R www-data:www-data "$DATA_DIR" 2>/dev/null || true
+
+log "ready -- exec: $*"
+exec "$@"

--- a/docker/app/php-osticket.ini
+++ b/docker/app/php-osticket.ini
@@ -1,0 +1,29 @@
+; Baseline PHP settings for osTicket. Runtime-tunable values (timezone, upload
+; limits, memory) are re-written by entrypoint.sh into zz-runtime.ini from the
+; container environment, so edit the .env file rather than this one.
+
+expose_php = Off
+memory_limit = 256M
+max_execution_time = 60
+max_input_vars = 5000
+
+upload_max_filesize = 20M
+post_max_size = 24M
+file_uploads = On
+
+date.timezone = UTC
+
+session.use_strict_mode = 1
+session.cookie_httponly = 1
+session.cookie_samesite = Lax
+
+opcache.enable = 1
+opcache.enable_cli = 0
+opcache.memory_consumption = 192
+opcache.interned_strings_buffer = 16
+opcache.max_accelerated_files = 20000
+opcache.validate_timestamps = 1
+opcache.revalidate_freq = 2
+
+apc.enabled = 1
+apc.enable_cli = 1


### PR DESCRIPTION
Runs osTicket as a container image (Apache + PHP 8.3) alongside MariaDB. The application code is baked into the image and stays root-owned; all state lives in bind mounts under ./data/.

- db:   MariaDB 10.11, data in ./data/db. sql-mode is relaxed to
        NO_ENGINE_SUBSTITUTION because the install schema uses columns
        without defaults, which STRICT_TRANS_TABLES rejects.
- app:  Apache vhost with AllowOverride All so the .htaccess rewrites in
        api/, pages/ and scp/apps/ keep working; include/ is denied.
- cron: loops api/cron.php for mail fetch, SLA alerts and search indexing.

The installer writes include/ost-config.php itself, so the real file is kept on the volume and symlinked into place; the seeded copy carries OSTINSTALLED=FALSE, which is what bootstrap.php needs to redirect a fresh container into setup/install.php. Plugins and language packs are copied from the volume into include/ on boot rather than mounted over those directories, so the files shipped with the image survive an upgrade.

PHP 8.3 rather than 8.4: ext-imap is unbundled in 8.4 and Debian no longer packages uw-imap. The extension is omitted entirely -- the imap_* helpers are called behind function_exists() guards and mail fetching goes through laminas-mail -- so it only shows as a missing recommendation in the installer's prerequisite list.