### PR TITLE
Can only find old tickets among very many search hits  #6977

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -400,7 +400,7 @@ class MysqlSearchBackend extends SearchBackend {
                     "(SELECT COALESCE(Z3.`object_id`, Z5.`ticket_id`, Z8.`ticket_id`) as `ticket_id`, Z1.relevance FROM (SELECT Z1.`object_id`, Z1.`object_type`, {} AS `relevance` FROM `:_search` Z1 WHERE {} ORDER BY relevance DESC) Z1 LEFT JOIN `:thread_entry` Z2 ON (Z1.`object_type` = 'H' AND Z1.`object_id` = Z2.`id`) LEFT JOIN `:thread` Z3 ON (Z2.`thread_id` = Z3.`id` AND (Z3.`object_type` = 'T' OR Z3.`object_type` = 'C')) LEFT JOIN `:ticket` Z5 ON (Z1.`object_type` = 'T' AND Z1.`object_id` = Z5.`ticket_id`) LEFT JOIN `:user` Z6 ON (Z6.`id` = Z1.`object_id` and Z1.`object_type` = 'U') LEFT JOIN `:organization` Z7 ON (Z7.`id` = Z1.`object_id` AND Z7.`id` = Z6.`org_id` AND Z1.`object_type` = 'O') LEFT JOIN `:ticket` Z8 ON (Z8.`user_id` = Z6.`id`)) Z1"),
                 ),
             ));
-            $criteria->extra(array('order_by' => array(array(new SqlCode('Z1.relevance', 'DESC')))));
+            $criteria->extra(array('order_by' => array(array(new SqlCode('Z1.relevance DESC')))));
 
             $criteria->filter(array('ticket_id'=>new SqlCode('Z1.`ticket_id`')));
             break;


### PR DESCRIPTION
Fix for "Can only find old tickets among very many search hits"
 #6977

When calling the SqlCode constructor with two arguments, see code changes: 

In previous versions, the SQLCode constructor did not even have a 2nd parameter (but PHP gives a shit when calling with two arguments):

https://github.com/osTicket/osTicket/blob/2570d69892775fff5df40a7540e507131a0975ad/include/class.orm.php#L1054-L1057

This means the 'DESC' part of the constructor call did get ignored.

So as far as I understand, the quick search does up to now search for the 500 *most irrelevant* hits, doesn't it? See. #6977 .


It seems to have gotten worse, in current versions, there is a 2nd constructor parameter, but with different meaning:

https://github.com/osTicket/osTicket/blob/8d38b0619649a50ee7cbbf37085f5d297fdc6f36/include/class.orm.php#L1037-L1040


By the way, typing PHP would have brought this bug to daylight: the string 'DESC' argment type string would've collided with parameter $level type int.