### PR TITLE
Stop duplicate flags__hasbit keys from dropping filter conditions

### DIFF
--- a/include/class.queue.php
+++ b/include/class.queue.php
@@ -1439,8 +1439,8 @@ class CustomQueue extends VerySimpleModel {
                         ->when(array('sort' => 0), 999)
                         ->otherwise(new SqlField('sort'))))
             ->filter(Q::any(array(
-                'flags__hasbit' => self::FLAG_PUBLIC,
-                'flags__hasbit' => static::FLAG_QUEUE,
+                new Q(array('flags__hasbit' => self::FLAG_PUBLIC)),
+                new Q(array('flags__hasbit' => static::FLAG_QUEUE)),
                 'staff_id' => $staff->getId(),
             )))
             ->exclude(['flags__hasbit' => self::FLAG_DISABLED])

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1506,8 +1506,8 @@ class MergedField extends FormField {
         $query->annotate(array(
                 'merged' => new SqlExpr(new Q(array(
                     Q::any(array(
-                        'flags__hasbit' => Ticket::FLAG_SEPARATE_THREADS,
-                        'flags__hasbit' => Ticket::FLAG_COMBINE_THREADS,
+                        new Q(array('flags__hasbit' => Ticket::FLAG_SEPARATE_THREADS)),
+                        new Q(array('flags__hasbit' => Ticket::FLAG_COMBINE_THREADS)),
                 )))
             ))));
 

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -412,7 +412,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
     function getMissingRequiredFields() {
 
         return $this->getDynamicFields(array(
-                    'answers__field__flags__hasbit' => DynamicFormField::FLAG_ENABLED,
+                    new Q(array('answers__field__flags__hasbit' => DynamicFormField::FLAG_ENABLED)),
                     'answers__field__flags__hasbit' => DynamicFormField::FLAG_CLOSE_REQUIRED,
                     'answers__value__isnull' => true,
                     ));

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1219,7 +1219,7 @@ implements RestrictedAccess, Threadable, Searchable {
           return $disabled;
 
         $criteria = array(
-                    'answers__field__flags__hasbit' => DynamicFormField::FLAG_ENABLED,
+                    new Q(array('answers__field__flags__hasbit' => DynamicFormField::FLAG_ENABLED)),
                     'answers__field__flags__hasbit' => DynamicFormField::FLAG_CLOSE_REQUIRED,
                     'answers__value__isnull' => true,
                     );


### PR DESCRIPTION
Four filter arrays list `flags__hasbit` twice under the same key, so PHP keeps the last pair and the first condition never reaches the query.

In `class.queue.php` the `Q::any` that decides which queues an agent sees loses the `FLAG_PUBLIC` alternative, leaving public queues out of that clause. In `class.search.php` the merged annotation loses `FLAG_SEPARATE_THREADS`. In `class.task.php` and `class.ticket.php` the arrays are ANDed rather than ORed, and there the surviving key is `FLAG_CLOSE_REQUIRED`, so `getMissingRequiredFields` stops restricting itself to enabled fields and a disabled close-required field counts as missing.

I used the shape your own code already uses for this, a `Q` object sitting at a numeric slot next to string keys, as in `class.staff.php` where `Q::all(array('status__state__in' => [...], $in_dept))` and `Q::all(new Q(array(...)))` appear a few lines apart. `filter()` wraps each argument in a `Q` and the compiler handles a nested one, so the two conditions end up as separate criteria instead of overwriting each other.

I have not run your test suite, so the part worth checking is whether restoring the dropped half changes any query you rely on being wide. The `class.ticket.php` and `class.task.php` pair is the one where results shrink rather than grow.
